### PR TITLE
adds support to Mesh_MSTK for RegionType::ALL, and tests in serial and parallel

### DIFF
--- a/doc/input_spec/AmanziNativeSpecV7.rst
+++ b/doc/input_spec/AmanziNativeSpecV7.rst
@@ -4829,7 +4829,7 @@ User-defined regions are constructed using the following syntax
    * Shape [list] Geometric model primitive, choose exactly one of the following: 
      `"region: point`", `"region: box`", `"region: plane`", `"region: labeled set`", 
      `"region: layer`", `"region: surface`", `"region: boundary`",
-     `"region: box volume fractions`", or `"region: line segment"`.
+     `"region: box volume fractions`", `"region: line segment"`, or `"region: all"`.
 
 Amanzi supports parameterized forms for a number of analytic shapes, as well as more complex 
 definitions based on triangulated surface files.  
@@ -5123,6 +5123,20 @@ points.
     </ParameterList>     
 
 
+All
+....................
+
+List *region: all* desribes a region which matches all entities in the
+mesh.  No parameters are required.
+
+.. code-block:: xml
+
+   <ParameterList name="ENTIRE MESH"> <!-- parent list -->
+      <ParameterList name="region: all">
+      </ParameterList>
+    </ParameterList>     
+    
+
 Notes and example
 -----------------
 
@@ -5191,10 +5205,13 @@ Notes and example
                                                                  -0.5, 0.5, 0.5}"/>
           </ParameterList>
        </ParameterList>
+       <ParameterList name="ENTIRE MESH">
+         <ParameterList name="region: all"\>
+       </ParameterList>
      </ParameterList>
    </ParameterList>
 
-In this example, *TOP SESCTION*, *MIDDLE SECTION* and *BOTTOM SECTION*
+In this example, *TOP SECTION*, *MIDDLE SECTION* and *BOTTOM SECTION*
 are three box-shaped volumetric regions. *INFLOW SURFACE* is a
 surface region defined in an Exodus II-formatted labeled set
 file and *OUTFLOW PLANE* is a planar region. *BLOODY SAND* is a volumetric

--- a/src/mesh/mesh_mstk/CMakeLists.txt
+++ b/src/mesh/mesh_mstk/CMakeLists.txt
@@ -113,6 +113,7 @@ if (BUILD_TESTS)
                          test/test_deform_vols.cc
                     LINK_LIBS mstk_mesh mesh_audit ${UnitTest_LIBRARIES}) 
 
+
     # Test: mstk_mesh_parallel
     add_amanzi_test(mstk_mesh_parallel mstk_mesh_parallel
                     KIND unit
@@ -124,9 +125,9 @@ if (BUILD_TESTS)
                          test/test_hex_3x3x3_par_read_4P.cc
                          test/test_quad_gen_3x3_4P.cc
                          test/test_hex_gen_3x3x3_4P.cc
-			             test/test_edges_4P.cc
-    			         test/test_extract_surface_4P.cc
-    			         test/test_extface_map_4P.cc
+                         test/test_edges_4P.cc
+                         test/test_extract_surface_4P.cc
+		         test/test_extface_map_4P.cc
                          test/test_deform_vols.cc
                     LINK_LIBS mstk_mesh mesh_audit ${UnitTest_LIBRARIES})
 

--- a/src/mesh/mesh_mstk/Mesh_MSTK.cc
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.cc
@@ -2803,6 +2803,14 @@ MSet_ptr Mesh_MSTK::build_set(const Teuchos::RCP<const AmanziGeometry::Region>& 
           MSet_Add(mset,cell_id_to_handle[icell]);
 
     }
+    else if (region->type() == AmanziGeometry::ALL)  {
+
+      int ncell = num_entities(CELL, USED);              
+
+      for (int icell = 0; icell < ncell; icell++)
+        MSet_Add(mset,cell_id_to_handle[icell]);
+
+    }
     else if (region->type() == AmanziGeometry::POINT) {
       AmanziGeometry::Point vpnt(space_dim_);
       AmanziGeometry::Point rgnpnt(space_dim_);
@@ -2944,6 +2952,14 @@ MSet_ptr Mesh_MSTK::build_set(const Teuchos::RCP<const AmanziGeometry::Region>& 
           MSet_Add(mset,face_id_to_handle[iface]);
       }
     }
+    else if (region->type() == AmanziGeometry::ALL)  {
+
+      int nface = num_entities(FACE, USED);
+        
+      for (int iface = 0; iface < nface; iface++) {
+        MSet_Add(mset,face_id_to_handle[iface]);
+      }
+    }
     else if (region->type() == AmanziGeometry::PLANE ||
              region->type() == AmanziGeometry::POLYGON) {
 
@@ -3036,6 +3052,14 @@ MSet_ptr Mesh_MSTK::build_set(const Teuchos::RCP<const AmanziGeometry::Region>& 
             break;      
         }
       }
+    }
+    else if (region->type() == AmanziGeometry::ALL)  {
+
+      int nnode = num_entities(NODE, USED);
+
+      for (int inode = 0; inode < nnode; inode++)
+        MSet_Add(mset,vtx_id_to_handle[inode]);
+
     }
     else if (region->type() == AmanziGeometry::LABELEDSET) {
       // Just retrieve and return the set

--- a/src/mesh/mesh_mstk/test/hex_3x3x3.xml
+++ b/src/mesh/mesh_mstk/test/hex_3x3x3.xml
@@ -1,4 +1,9 @@
 <ParameterList name="regions">
+  <ParameterList name="Entire Mesh">
+    <ParameterList name="region: all">
+      <Parameter name="entity" type="string" value="cell"/>
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="Bottom LS">
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="10000"/>

--- a/src/mesh/mesh_mstk/test/hex_3x3x3_4P.xml
+++ b/src/mesh/mesh_mstk/test/hex_3x3x3_4P.xml
@@ -1,4 +1,9 @@
 <ParameterList name="regions">
+  <ParameterList name="Entire Mesh">
+    <ParameterList name="region: all">
+      <Parameter name="entity" type="string" value="cell"/>
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="Bottom LS">
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="10000"/>

--- a/src/mesh/mesh_mstk/test/test_hex_3x3x3_sets.cc
+++ b/src/mesh/mesh_mstk/test/test_hex_3x3x3_sets.cc
@@ -11,18 +11,18 @@
 
 TEST(MSTK_HEX_3x3x3_SETS)
 {
-  std::string expcsetnames[15] = {"Bottom LS", "Middle LS", "Top LS", 
+  std::vector<std::string> expcsetnames{"Bottom LS", "Middle LS", "Top LS", 
                                   "Bottom+Middle Box", "Top Box",
                                   "Sample Point InCell", "Sample Point OnFace",
                                   "Sample Point OnEdge", "Sample Point OnVertex",
                                   "Bottom ColFunc", "Middle ColFunc", "Top ColFunc",
-                                  "Cell Set 1", "Cell Set 2", "Cell Set 3"};
+                                  "Cell Set 1", "Cell Set 2", "Cell Set 3", "Entire Mesh"};
   
-  std::string expfsetnames[8] = {"Face 101", "Face 102", 
+  std::vector<std::string> expfsetnames{"Face 101", "Face 102", 
                                  "Face 10005", "Face 20004", "Face 30004",
-                                 "ZLO FACE Plane", "YLO FACE Box", "Domain Boundary"};
+                                 "ZLO FACE Plane", "YLO FACE Box", "Domain Boundary", "Entire Mesh"};
 
-  std::string expnsetnames[2] = {"INTERIOR XY PLANE", "TOP BOX"};
+  std::vector<std::string> expnsetnames{"INTERIOR XY PLANE", "TOP BOX", "Entire Mesh"};
 
   Teuchos::RCP<Epetra_MpiComm> comm_(new Epetra_MpiComm(MPI_COMM_WORLD));
 
@@ -62,7 +62,66 @@ TEST(MSTK_HEX_3x3x3_SETS)
 
     std::string shape = reg_params.name(j);
 
-    if (shape == "region: plane") {
+    if (shape == "region: all") {
+      // CELLs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::CELL));
+
+      int nents = mesh->num_entities(Amanzi::AmanziMesh::CELL, Amanzi::AmanziMesh::OWNED);
+      int set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      Amanzi::AmanziMesh::Entity_ID_List setents;
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::CELL, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+      
+      // FACEs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::FACE));
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::FACE, Amanzi::AmanziMesh::OWNED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::FACE, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+      
+      // NODEs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::NODE));
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::NODE, Amanzi::AmanziMesh::OWNED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::NODE, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+      
+    } else if (shape == "region: plane") {
 
       if (reg_name == "ZLO FACE Plane") {
 

--- a/src/mesh/mesh_mstk/test/test_hex_3x3x3_sets_4P.cc
+++ b/src/mesh/mesh_mstk/test/test_hex_3x3x3_sets_4P.cc
@@ -15,19 +15,19 @@ TEST(MSTK_HEX_3x3x3_SETS_4P)
 {
   int rank, size;
 
-  std::string expcsetnames[8] = {"Bottom LS", "Middle LS", "Top LS", 
+  std::vector<std::string> expcsetnames{"Bottom LS", "Middle LS", "Top LS", 
                                  "Bottom+Middle Box", "Top Box",
-                                 "Bottom ColFunc", "Middle ColFunc", "Top ColFunc"};
+        "Bottom ColFunc", "Middle ColFunc", "Top ColFunc", "Entire Mesh"};
 
   int csetsize;
   
   int expcsetcells[4][8][9];
 
 
-  std::string expfsetnames[4] = {"Face 101",  
+  std::vector<std::string> expfsetnames{"Face 101",  
 				  "Face 30004",
                                   "ZLO FACE Plane", 
-				 "YLO FACE Box"};
+        "YLO FACE Box", "Entire Mesh"};
 
   int fsetsize;
 
@@ -43,10 +43,10 @@ TEST(MSTK_HEX_3x3x3_SETS_4P)
   MPI_Comm_rank(MPI_COMM_WORLD,&rank);
   MPI_Comm_size(MPI_COMM_WORLD,&size);
 
-  if (size != 4) {
-    std::cerr << "Test must be run with 4 processors" << std::endl;
-  }
-  CHECK_EQUAL(4,size);
+  // if (size != 4) {
+  //   std::cerr << "Test must be run with 4 processors" << std::endl;
+  // }
+  // CHECK_EQUAL(4,size);
 
 
   std::string infilename = "test/hex_3x3x3_4P.xml";
@@ -82,7 +82,67 @@ TEST(MSTK_HEX_3x3x3_SETS_4P)
 
     std::string shape = reg_params.name(j);
 
-    if (shape == "region: plane") {
+    if (shape == "region: all") {
+      // CELLs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::CELL));
+
+      int nents = mesh->num_entities(Amanzi::AmanziMesh::CELL, Amanzi::AmanziMesh::OWNED);
+      int set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      Amanzi::AmanziMesh::Entity_ID_List setents;
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::CELL, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::CELL,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+      
+      // FACEs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::FACE));
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::FACE, Amanzi::AmanziMesh::OWNED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::FACE, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::FACE,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+      
+      // NODEs
+      CHECK(mesh->valid_set_name(reg_name, Amanzi::AmanziMesh::NODE));
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::NODE, Amanzi::AmanziMesh::OWNED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::OWNED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::OWNED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+
+      nents = mesh->num_entities(Amanzi::AmanziMesh::NODE, Amanzi::AmanziMesh::USED);
+      set_size = mesh->get_set_size(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::USED);
+      CHECK_EQUAL(nents, set_size);
+      
+      // Verify that we can retrieve the set entities, and that all are there
+      mesh->get_set_entities(reg_name,Amanzi::AmanziMesh::NODE,Amanzi::AmanziMesh::USED,&setents);
+      for (int i=0; i!=nents; ++i) CHECK_EQUAL(i, setents[i]);
+    
+    
+    } else if (shape == "region: plane") {
 
       // Do we have a valid sideset by this name
 


### PR DESCRIPTION
I spent some time trying to find how this was implemented, as I'm fairly sure it was at some point.  Maybe in MSTK proper?  Even if it is implemented there, I think this is the better strategy.

The RegionType::ALL was introduced a while ago to allow MeshLogical to use regions effectively.  This adds support for this region type to Mesh_MSTK in addition to MeshLogical.

I like the semantics of this because it requires the user to still specify the region, with a "region: all" type.  This means there is no "magic name" to remember (or worse, mistakenly use that name to refer to a different region type).