### PR TITLE
better enables "systems" in Hypre BoomerAMG

### DIFF
--- a/src/data_structures/SuperMap.cc
+++ b/src/data_structures/SuperMap.cc
@@ -129,13 +129,13 @@ SuperMap::GhostIndices(const std::string& compname, int dofnum) const {
 }
 
 
-std::pair<int, Teuchos::RCP<std::vector<int>>>
+std::pair<int, Teuchos::RCP<std::vector<int> > >
 SuperMap::BlockIndices() const {
   auto block_indices = Teuchos::rcp(new std::vector<int>(Map()->NumMyElements()));
   int block_id = 0;
   for (const auto& comp : *this) {
     int ndofs = NumDofs(comp);
-    for (int d = 0; d!=ndofs; ++d) {
+    for (int d=0; d!=ndofs; ++d) {
       const auto& inds = Indices(comp, d);
       for (int i=0; i!=inds.size(); ++i) (*block_indices)[inds[i]] = block_id;
       block_id++;

--- a/src/data_structures/SuperMap.cc
+++ b/src/data_structures/SuperMap.cc
@@ -129,6 +129,22 @@ SuperMap::GhostIndices(const std::string& compname, int dofnum) const {
 }
 
 
+std::pair<int, Teuchos::RCP<std::vector<int>>>
+SuperMap::BlockIndices() const {
+  auto block_indices = Teuchos::rcp(new std::vector<int>(Map()->NumMyElements()));
+  int block_id = 0;
+  for (const auto& comp : *this) {
+    int ndofs = NumDofs(comp);
+    for (int d = 0; d!=ndofs; ++d) {
+      const auto& inds = Indices(comp, d);
+      for (int i=0; i!=inds.size(); ++i) (*block_indices)[inds[i]] = block_id;
+      block_id++;
+    }
+  }
+  return std::make_pair(block_id, block_indices);
+}
+
+
 const std::vector<int>&
 SuperMap::CreateIndices_(const std::string& compname, int dofnum, bool ghosted) const {
   if (ghosted) {

--- a/src/data_structures/SuperMap.hh
+++ b/src/data_structures/SuperMap.hh
@@ -67,7 +67,7 @@ class SuperMap {
   // where each dof and component have a unique integer value.  The returned
   // int is the number of unique values, equal to
   // sum(NumDofs(comp) for comp in components), in this array.
-  std::pair<int, Teuchos::RCP<std::vector<int>>> BlockIndices() const;
+  std::pair<int, Teuchos::RCP<std::vector<int> > > BlockIndices() const;
   
   // iterate over compnames
   typedef std::vector<std::string>::const_iterator name_iterator;

--- a/src/data_structures/SuperMap.hh
+++ b/src/data_structures/SuperMap.hh
@@ -63,6 +63,19 @@ class SuperMap {
   const std::vector<int>& Indices(const std::string& compname, int dofnum) const;
   const std::vector<int>& GhostIndices(const std::string& compname, int dofnum) const;
 
+  // block indices.  This is an array of integers, length Map().MyLength(),
+  // where each dof and component have a unique integer value.  The returned
+  // int is the number of unique values, equal to
+  // sum(NumDofs(comp) for comp in components), in this array.
+  std::pair<int, Teuchos::RCP<std::vector<int>>> BlockIndices() const;
+  
+  // iterate over compnames
+  typedef std::vector<std::string>::const_iterator name_iterator;
+  name_iterator begin() const { return compnames_.begin(); }
+  name_iterator end() const { return compnames_.end(); }
+  unsigned int size() const { return compnames_.size(); }
+
+  
   // // block accessors
   // void BlockIndices(const std::string& compname, int element_lid, std::vector<int>* indices) const {
   //   int ndofs = NumDofs(compname);

--- a/src/operators/Operator.cc
+++ b/src/operators/Operator.cc
@@ -413,7 +413,7 @@ void Operator::InitializePreconditioner(Teuchos::ParameterList& plist)
     // NOTE: Hypre frees this
     auto block_ids = smap_->BlockIndices();
 
-    plist.sublist("boomer amg parameters").set("number of functions", block_ids.first);
+    plist.sublist("boomer amg parameters").set("number of unique block indices", block_ids.first);
 
     // Note, this passes a raw pointer through a ParameterList.  I was surprised
     // this worked too, but ParameterList is a boost::any at heart... --etc

--- a/src/operators/Operator.hh
+++ b/src/operators/Operator.hh
@@ -220,6 +220,8 @@ class Operator {
 
   void InitPreconditioner(const std::string& prec_name, const Teuchos::ParameterList& plist);
   void InitPreconditioner(Teuchos::ParameterList& plist);
+  void InitializePreconditioner(Teuchos::ParameterList& plist);
+  void UpdatePreconditioner();
 
   void CreateCheckPoint();
   void RestoreCheckPoint();

--- a/src/operators/PDE_DiffusionMFD.cc
+++ b/src/operators/PDE_DiffusionMFD.cc
@@ -1488,6 +1488,7 @@ int PDE_DiffusionMFD::UpdateConsistentFaces(CompositeVector& u)
     consistent_face_op_ = Teuchos::rcp(new Operator_ConsistentFace(cface_cvs, plist_.sublist("consistent faces")));
     consistent_face_op_->OpPushBack(local_op_);
     consistent_face_op_->SymbolicAssembleMatrix();
+    consistent_face_op_->InitializePreconditioner(plist_.sublist("consistent faces").sublist("preconditioner"));
   }
 
   // calculate the rhs, given by y_f - Afc * x_c
@@ -1514,7 +1515,7 @@ int PDE_DiffusionMFD::UpdateConsistentFaces(CompositeVector& u)
 
   // x_f = Aff^-1 * ...
   consistent_face_op_->AssembleMatrix();
-  consistent_face_op_->InitPreconditioner(plist_.sublist("consistent faces").sublist("preconditioner"));
+  consistent_face_op_->UpdatePreconditioner();
 
   int ierr = 0;
   if (plist_.sublist("consistent faces").isSublist("linear solver")) {

--- a/src/operators/TreeOperator.hh
+++ b/src/operators/TreeOperator.hh
@@ -69,6 +69,9 @@ class TreeOperator {
   void InitPreconditioner(Teuchos::ParameterList& plist);
   void InitBlockDiagonalPreconditioner();
 
+  void InitializePreconditioner(Teuchos::ParameterList& plist);
+  void UpdatePreconditioner();
+
   // access
   Teuchos::RCP<Epetra_CrsMatrix> A() { return A_; } 
   Teuchos::RCP<const Epetra_CrsMatrix> A() const { return A_; } 

--- a/src/solvers/PreconditionerBoomerAMG.cc
+++ b/src/solvers/PreconditionerBoomerAMG.cc
@@ -154,10 +154,6 @@ void PreconditionerBoomerAMG::Init(const std::string& name, const Teuchos::Param
         }
       }
     }
-
-  } else {
-    Errors::Message msg("Hypre (BoomerAMG) expects number of functions!");
-    Exceptions::amanzi_throw(msg);
   }
 
 #else
@@ -193,7 +189,6 @@ void PreconditionerBoomerAMG::Update(const Teuchos::RCP<Epetra_RowMatrix>& A)
     // IfpHypre_::Compute() gets called (for every call but the last) and when
     // IfpHypre_ gets destroyed (for the last call).
     int* indices = new int[block_indices_->size()];
-    //    memcpy(indices, &(*block_indices_)[0], sizeof(int)*block_indices_->size());
     for (int i=0; i!=block_indices_->size(); ++i) {
       indices[i] = (*block_indices_)[i];
     }

--- a/src/solvers/PreconditionerBoomerAMG.cc
+++ b/src/solvers/PreconditionerBoomerAMG.cc
@@ -86,7 +86,7 @@ void PreconditionerBoomerAMG::Init(const std::string& name, const Teuchos::Param
     //
     // Block indices is an array of ints, indicating what unknowns are
     // coarsened as a system.  For now just put in a placeholder.
-    block_indices_ = plist_.get<Teuchos::RCP<std::vector<int>>>("block indices");
+    block_indices_ = plist_.get<Teuchos::RCP<std::vector<int> > >("block indices");
     block_index_function_index_ = funcs_.size();
     funcs_.push_back(Teuchos::null);
   }

--- a/src/solvers/PreconditionerBoomerAMG.hh
+++ b/src/solvers/PreconditionerBoomerAMG.hh
@@ -32,11 +32,15 @@ Internal parameters for Boomer AMG include
 
 * `"max multigrid levels`" ``[int]`` optionally defined the maximum number of multigrid levels.
 
-* `"number of functions`" ``[int]`` **1**  Any value > 1 tells Boomer AMG to use the `"systems 
-  of PDEs`" code.  Note that, to use this approach, unknowns must be ordered with 
-  DoF fastest varying (i.e. not the native Epetra_MultiVector order).  By default, it
-  uses the `"unknown`" approach in which each equation is coarsened and
-  interpolated independently.  **Getting this correct is very helpful!**
+* `"use block indices`" ``[bool]`` **false** If true, uses the `"systems of
+    PDEs`" code with blocks given by the SuperMap, or one per DoF per entity
+    type.
+
+* `"number of functions`" ``[int]`` **1** Any value > 1 tells Boomer AMG to
+  use the `"systems of PDEs`" code with strided block type.  Note that, to use
+  this approach, unknowns must be ordered with DoF fastest varying (i.e. not
+  the native Epetra_MultiVector order).  By default, it uses the `"unknown`"
+  approach in which each equation is coarsened and interpolated independently.
   
 * `"nodal strength of connection norm`" ``[int]`` tells AMG to coarsen such
     that each variable has the same coarse grid - sometimes this is more
@@ -84,7 +88,8 @@ namespace AmanziPreconditioners {
 
 class PreconditionerBoomerAMG : public Preconditioner {
  public:
-  PreconditionerBoomerAMG() {};
+  PreconditionerBoomerAMG() :
+    num_blocks_(0) {};
   ~PreconditionerBoomerAMG() {};
 
   void Init(const std::string& name, const Teuchos::ParameterList& list);

--- a/src/solvers/PreconditionerBoomerAMG.hh
+++ b/src/solvers/PreconditionerBoomerAMG.hh
@@ -103,7 +103,7 @@ class PreconditionerBoomerAMG : public Preconditioner {
  private:
   Teuchos::ParameterList plist_;
   std::vector<Teuchos::RCP<FunctionParameter> > funcs_;
-  Teuchos::RCP<std::vector<int>> block_indices_;
+  Teuchos::RCP<std::vector<int> > block_indices_;
   int num_blocks_;
   int block_index_function_index_;
   

--- a/src/solvers/PreconditionerBoomerAMG.hh
+++ b/src/solvers/PreconditionerBoomerAMG.hh
@@ -98,6 +98,9 @@ class PreconditionerBoomerAMG : public Preconditioner {
  private:
   Teuchos::ParameterList plist_;
   std::vector<Teuchos::RCP<FunctionParameter> > funcs_;
+  Teuchos::RCP<std::vector<int>> block_indices_;
+  int num_blocks_;
+  int block_index_function_index_;
   
   int returned_code_;
   Teuchos::RCP<Ifpack_Hypre> IfpHypre_;

--- a/src/solvers/PreconditionerBoomerAMG.hh
+++ b/src/solvers/PreconditionerBoomerAMG.hh
@@ -89,7 +89,9 @@ namespace AmanziPreconditioners {
 class PreconditionerBoomerAMG : public Preconditioner {
  public:
   PreconditionerBoomerAMG() :
-    num_blocks_(0) {};
+      num_blocks_(0),
+      block_indices_(Teuchos::null),
+      IfpHypre_(Teuchos::null) {}
   ~PreconditionerBoomerAMG() {};
 
   void Init(const std::string& name, const Teuchos::ParameterList& list);


### PR DESCRIPTION
Hypre has a "systems" of equations approach in which, through a variety of flags, one can specify to coarsen the operator not as a single set of unknowns, but independently or collectively as block systems of equations.  This is critical in cases where scaling between the systems is not perfect or nondimensional.  Previously we allowed this through the "number of functions" option in PreconditionerBoomerAMG -- this specified a fixed, strided block operator structure where, for instance, if there were 2 "functions", then structure was assumed to be "1,2,1,2,1,2..." for each unknown.  

Unfortunately, while straightforward, this approach did not allow splitting face and cell unknowns for independent coarsening.  This pull request automates the generation of a "block index" array, which can be passed to Hypre to specify which block each unknown belongs to for coarsening.  

This array of ints can be provided by SuperMap, and is currently set up to provide a unique index for each component and each degree of freedom in the SuperMap.  For hybrid form discretizations, this means faces and cells can be coarsened independently.  For, e.g., coupled flow + energy problems, this means 4 unique block ids (face + cell x flow + energy).  

Additionally, to avoid repeating some work, the Operator InitPreconditioner() was extended to include an InitializePreconditioner() and an UpdatePreconditioner().  The InitializePreconditioner() would then typically be called once (for each SymbolicAssembleMatrix() call) while the UpdatePreconditioner() should be called each time the Matrix entries are changed (after each AssembleMatrix() call).  This is different from the previous interface where InitPreconditioner() needed to be called every time the matrix entries changed.

Note the InitPreconditioner() still exists, and does not generate block IDs.  So this pull request does not change answers.  However, this should be deprecated, and PKs can swap to the Initialize() / Update() model instead, as this is always not less efficient.  When they do so, they will also get the updates to how BoomerAMG is used.  Additionally, other Preconditioner* implementations could take better advantage of this splitting to be more efficient.

Note that I have tried this face + cell split coarsening on 4 ATS meshes (1 quasi-2D hillslope + 3x 3D triangular prisms at a variety of scales and DEM nastiness).  In these experiments, I solved problems of coupled surface/subsurface water, and saw improved convergence rates on all DEM-based meshes, and not reduced convergence rates on simpler meshes.  I believe it is justified making this the default for all problems using BoomerAMG.  If people want to do some testing, I could amend this pull request to add an option enabling this method.