### PR TITLE
Added Peaceman model to converter

### DIFF
--- a/doc/input_spec/AmanziNativeSpecV7.rst
+++ b/doc/input_spec/AmanziNativeSpecV7.rst
@@ -1654,30 +1654,22 @@ Again, constant functions can be replaced by any of the available functions.
   For the other options, it is measured in [kg/s]. 
   When the source function is defined over a few regions, Q is distributed over their union.
   Option `"volume fraction`" can be used when the region geometric
-  model support volume fractions. Option `"simple well`" provides
-  capability to model source term by Peaceman model. The well flux is
-  defined as q_w = WI(p - p_w), where WI is the well index and p_w is
-  the well pressure and q_w [kg/s] is the well flux. The pressure in
-  a well is assumed to be hydrostatic.
+  model support volume fractions. Option `"simple well`" implements the Peaceman model. 
+  The well flux is defined as `q_w = WI (p - p_w)` [kg/s], where `WI` is the well index 
+  and `p_w` is the well pressure. The pressure in a well is assumed to be hydrostatic.
 
 * `"use volume fractions`" instructs the code to use all available volume fractions. 
   Note that the region geometric model supports volume fractions only for a few regions.
 
 * `"submodel`" [string] refines definition of the source. Available options are `"rate`",
-  `"integrated source`" and `"bhp"`. The first option defines the source in a natural way as the rate 
-  of change `q`. The second option defines the indefinite integral `Q` of the rate 
-  of change, i.e. the source term is calculated as `q =
-  dQ/dt`. Default is `"rate`". In the case of `"simple well`"
-  distribution method two submodel options are available: `"rate`" and
-  `"bhp`" (bottom hole pressure)
-
-* In the case of a `"simple well`" model and `"bhp`" submodel the
-  following parameters has to be defined: `"depth"`, `"well radius`"
-  and `"bhp`" pressure. In the case of  `"simple well`" model and
-  `"rate`" submodel only rate function has to be defined. `"integrated
-  source`" is not supported for `"simple well`".
-
-
+  `"integrated source`" and `"bhp"` (bottom hole pressure). The first option defines the source 
+  in a natural way as the rate of change `q`. The second option defines the indefinite
+  integral `Q` of the rate of change, i.e. the source term is calculated as `q = dQ/dt`. 
+  For most distributions methods, two submodles are available: `"rate`" and `"integrated source`".
+  For distribution method `"simple well`", two submodels are available: `"rate`" and
+  `"bhp`". Submodel `"bhp`" requires `"depth"`, `"well radius`" and 
+  `"bhp`" function. Submodel `"rate`" requires only rate function.
+  Default is `"rate`". 
 
 .. code-block:: xml
 
@@ -1705,7 +1697,7 @@ Again, constant functions can be replaced by any of the available functions.
        </ParameterList>
 
        <ParameterList name="SRC 2">
-         <Parameter name="regions" type="Array(string)" value="{WellCenter}"/>
+         <Parameter name="regions" type="Array(string)" value="{WELL_NORTH}"/>
            <Parameter name="spatial distribution method" type="string" value="simple well"/>    
            <ParameterList name="well">
              <Parameter name="submodel" type="string" value="bhp"/>
@@ -1721,7 +1713,7 @@ Again, constant functions can be replaced by any of the available functions.
        </ParameterList>
 
        <ParameterList name="SRC 3">
-         <Parameter name="regions" type="Array(string)" value="{WellCenter2}"/>
+         <Parameter name="regions" type="Array(string)" value="{WELL_SOUTH}"/>
            <Parameter name="spatial distribution method" type="string" value="simple well"/>
            <ParameterList name="well">
              <Parameter name="submodel" type="string" value="rate"/>

--- a/src/common/interface_platform/InputConverterU_Transport.cc
+++ b/src/common/interface_platform/InputConverterU_Transport.cc
@@ -836,7 +836,7 @@ void InputConverterU::TranslateTransportSourcesGroup_(
 
 
 /* ******************************************************************
-* Create list of transport sources.
+* Setup flag for volume fractions.
 ****************************************************************** */
 bool InputConverterU::WeightVolumeSubmodel_(const std::vector<std::string>& regions)
 {

--- a/src/common/interface_platform/test/converter_u_test3.xml
+++ b/src/common/interface_platform/test/converter_u_test3.xml
@@ -260,6 +260,17 @@
     </boundary_condition>
   </boundary_conditions>
 
+  <sources>
+    <source name="Pumping Well">
+      <assigned_regions>Well</assigned_regions>
+      <liquid_phase name="water">
+        <liquid_component name="water">
+          <peaceman_well function="constant" radius="0.1" depth="25.0" start="0.0" value="110000.0 Pa"/>
+        </liquid_component>
+      </liquid_phase>
+    </source>
+  </sources>
+
   <output>
     <vis>
       <base_filename>plot</base_filename>

--- a/src/common/interface_platform/test/converter_u_validate3.xml
+++ b/src/common/interface_platform/test/converter_u_validate3.xml
@@ -397,6 +397,23 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
+        <ParameterList name="source terms">
+          <ParameterList name="Pumping Well">
+            <Parameter name="regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="spatial distribution method" type="string" value="simple well"/>
+            <Parameter name="use volume fractions" type="bool" value="false"/>
+            <ParameterList name="well">
+              <Parameter name="submodel" type="string" value="bhp"/>
+              <Parameter name="well radius" type="double" value="0.1"/>
+              <Parameter name="depth" type="double" value="25.0"/>
+              <ParameterList name="bhp">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.1e+05"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="physical models and assumptions">
           <Parameter name="water content model" type="string" value="constant density"/>
         </ParameterList>
@@ -529,6 +546,23 @@
               <Parameter name="spatial distribution method" type="string" value="none"/>
               <Parameter name="use area fractions" type="bool" value="false"/>
               <Parameter name="rainfall" type="bool" value="false"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="source terms">
+          <ParameterList name="Pumping Well">
+            <Parameter name="regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="spatial distribution method" type="string" value="simple well"/>
+            <Parameter name="use volume fractions" type="bool" value="false"/>
+            <ParameterList name="well">
+              <Parameter name="submodel" type="string" value="bhp"/>
+              <Parameter name="well radius" type="double" value="0.1"/>
+              <Parameter name="depth" type="double" value="25.0"/>
+              <ParameterList name="bhp">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.1e+05"/>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -725,7 +759,7 @@
 
   <ParameterList name="analysis">
     <Parameter name="used boundary condition regions" type="Array(string)" value="{Bottom Surface, Crib, Recharge_Boundary_WestOfCrib, Recharge_Boundary_EastOfCrib, Bottom Surface, Crib, Recharge_Boundary_WestOfCrib, Recharge_Boundary_EastOfCrib, Bottom Surface, Crib, Recharge_Boundary_WestOfCrib, Recharge_Boundary_EastOfCrib}"/>
-    <Parameter name="used source regions" type="Array(string)" value="{}"/>
+    <Parameter name="used source regions" type="Array(string)" value="{Well, Well, Well}"/>
     <Parameter name="used observation regions" type="Array(string)" value="{}"/>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>

--- a/src/pks/PK_DomainFunctionSimpleWell.hh
+++ b/src/pks/PK_DomainFunctionSimpleWell.hh
@@ -7,7 +7,6 @@
   provided in the top-level COPYRIGHT file.
 
   Author: Daniil Svyatsky (dasvyat@lanl.gov)
-
 */
 
 #ifndef AMANZI_PK_DOMAIN_FUNCTION_SIMPLEWELL_HH_
@@ -30,11 +29,11 @@ class PK_DomainFunctionSimpleWell : public FunctionBase,
                                     public Functions::UniqueMeshFunction {
  public:
   PK_DomainFunctionSimpleWell(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh) :
-      UniqueMeshFunction(mesh){};
+      UniqueMeshFunction(mesh) {};
 
   PK_DomainFunctionSimpleWell(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           const Teuchos::ParameterList& plist) :
-      UniqueMeshFunction(mesh){};
+      UniqueMeshFunction(mesh) {};
 
   ~PK_DomainFunctionSimpleWell() {};
 
@@ -97,7 +96,7 @@ void PK_DomainFunctionSimpleWell<FunctionBase>::Init(const Teuchos::ParameterLis
     Exceptions::amanzi_throw(m);
   }
 
-  if (submodel_ == "bhp"){
+  if (submodel_ == "bhp") {
     depth_ = well_list.get<double>("depth");
     double* gravity_data;
     int dim = (*mesh_).space_dimension();
@@ -120,7 +119,7 @@ void PK_DomainFunctionSimpleWell<FunctionBase>::Init(const Teuchos::ParameterLis
 template <class FunctionBase>
 void PK_DomainFunctionSimpleWell<FunctionBase>::Compute(double t0, double t1)
 {
-   // create the input tuple (time + space)
+  // create the input tuple (time + space)
   int dim = (*mesh_).space_dimension();
   std::vector<double> args(1 + dim);
 
@@ -173,7 +172,7 @@ void PK_DomainFunctionSimpleWell<FunctionBase>::Compute(double t0, double t1)
 
         double bhp;
         for (int i = 0; i < nfun; ++i){
-          bhp = (*(*uspec)->first->second)(args)[i] + rho_*g*(depth_ - xc[dim-1]);          
+          bhp = (*(*uspec)->first->second)(args)[i] + rho_ * g * (depth_ - xc[dim-1]);
           val_vec[i] = bhp * wi[0][*c] / mesh_->cell_volume(*c);
         }
         value_[*c] = val_vec;

--- a/src/pks/flow/Flow_PK.cc
+++ b/src/pks/flow/Flow_PK.cc
@@ -70,14 +70,14 @@ void Flow_PK::Setup(const Teuchos::Ptr<State>& S)
   }
 
   // Wells
-  if (!S->HasField("well_index")){
+  if (!S->HasField("well_index")) {
     if (fp_list_->isSublist("source terms")) {
       Teuchos::ParameterList& src_list = fp_list_->sublist("source terms");
       for (auto it = src_list.begin(); it != src_list.end(); ++it) {
         std::string name = it->first;
         if (src_list.isSublist(name)) {
           Teuchos::ParameterList& spec = src_list.sublist(name);
-          if (IsWellIndexRequire(spec)){
+          if (IsWellIndexRequire(spec)) {
             S->RequireField("well_index", passwd_)->SetMesh(mesh_)->SetGhosted(true)
                 ->SetComponent("cell", AmanziMesh::CELL, 1);
             peaceman_model_ = true;
@@ -230,7 +230,7 @@ void Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
   // Process main one-line options (not sublists)
   atm_pressure_ = *S_->GetScalarData("atmospheric_pressure");
 
-  // Create the BC objects
+  // Create BC objects
   // -- memory
   op_bc_ = Teuchos::rcp(new Operators::BCs(mesh_, AmanziMesh::FACE, Operators::DOF_Type::SCALAR));
 
@@ -306,7 +306,9 @@ void Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
 
   VV_ValidateBCs();
 
-  if (S_->HasField("well_index")){
+  // Create source objects
+  // -- evaluate the well index
+  if (S_->HasField("well_index")) {
     if (!S_->GetField("well_index", passwd_)->initialized()) {
       S_->GetFieldData("well_index", passwd_)->PutScalar(0.0);
 
@@ -324,10 +326,10 @@ void Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
     S_->GetField("well_index", passwd_)->set_initialized();
   }
 
-  // Create the source object if any
+  // -- wells
   srcs.clear();
   if (plist.isSublist("source terms")) {
-    PK_DomainFunctionFactory<PK_DomainFunction > factory(mesh_, S_);
+    PK_DomainFunctionFactory<PK_DomainFunction> factory(mesh_, S_);
     PKUtils_CalculatePermeabilityFactorInWell(S_.ptr(), Kxy);
 
     Teuchos::ParameterList& src_list = plist.sublist("source terms");
@@ -343,7 +345,7 @@ void Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
 
 
 /* ******************************************************************
-* TBW
+* Compute well index
 ****************************************************************** */
 void Flow_PK::ComputeWellIndex(Teuchos::ParameterList& spec)
 {
@@ -367,7 +369,7 @@ void Flow_PK::ComputeWellIndex(Teuchos::ParameterList& spec)
       mesh_->cell_get_faces(c, &faces);
       xmin = ymin = zmin = 1e+23;
       xmax = ymax = zmax = 1e-23;
-      for (int j = 0; j < faces.size(); j++){
+      for (int j = 0; j < faces.size(); j++) {
         int f = faces[j];
         const AmanziGeometry::Point& xf = mesh_->face_centroid(f);
         xmax = std::max(xmax, xf[0]);
@@ -387,7 +389,7 @@ void Flow_PK::ComputeWellIndex(Teuchos::ParameterList& spec)
       kx = perm[0][c];
       ky = perm[1][c];
 
-      r0 = 0.28 * sqrt(dy*dy *sqrt(kx/ky) + dx*dx*sqrt(ky/kx));
+      r0 = 0.28 * sqrt(dy*dy * sqrt(kx/ky) + dx*dx * sqrt(ky/kx));
       r0 = r0 / (std::pow(kx/ky, 0.25) + std::pow(ky/kx, 0.25));
                       
       // r0 = 0.28 * sqrt(sqrt(kx/ky)*dx + sqrt(ky/kx)*dy);
@@ -400,7 +402,7 @@ void Flow_PK::ComputeWellIndex(Teuchos::ParameterList& spec)
 
 
 /* ******************************************************************
-* TBW
+* Analyze spec for well signature
 ****************************************************************** */
 bool Flow_PK::IsWellIndexRequire(Teuchos::ParameterList& spec)
 {

--- a/src/pks/flow/test/flow_darcy_1well_peaceman_3D.xml
+++ b/src/pks/flow/test/flow_darcy_1well_peaceman_3D.xml
@@ -54,27 +54,27 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-          <!-- <ParameterList name="SRC 1"> -->
-          <!--   <Parameter name="regions" type="Array(string)" value="{WellCenter}"/> -->
-          <!--   <Parameter name="spatial distribution method" type="string" value="simple well"/> -->
-          <!--   <ParameterList name="well"> -->
-          <!--     <Parameter name="submodel" type="string" value="rate"/> -->
-          <!--     <ParameterList name="rate"> -->
-          <!--       <ParameterList name="function-constant"> -->
-          <!--         <Parameter name="value" type="double" value="100.0"/> -->
-          <!--       </ParameterList> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
-          <!-- <ParameterList name="SRC 2"> -->
-          <!--   <Parameter name="regions" type="Array(string)" value="{WellCenter}"/> -->
-          <!--   <Parameter name="spatial distribution method" type="string" value="volume"/> -->
-          <!--   <ParameterList name="well"> -->
-          <!--     <ParameterList name="function-constant"> -->
-          <!--       <Parameter name="value" type="double" value="100"/> -->
-          <!--     </ParameterList> -->
-          <!--   </ParameterList> -->
-          <!-- </ParameterList> -->
+          <!--ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{WellCenter}"/>
+            <Parameter name="spatial distribution method" type="string" value="simple well"/> 
+            <ParameterList name="well">
+              <Parameter name="submodel" type="string" value="rate"/>
+              <ParameterList name="rate">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="100.0"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList-->
+          <!--ParameterList name="SRC 2">
+            <Parameter name="regions" type="Array(string)" value="{WellCenter}"/>
+            <Parameter name="spatial distribution method" type="string" value="volume"/>
+            <ParameterList name="well">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="100"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList-->
         </ParameterList>
 
         <ParameterList name="boundary conditions">
@@ -93,19 +93,19 @@
             <ParameterList name="BC 1">
               <Parameter name="regions" type="Array(string)" value="{Right side, Left side, Back side, Front side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-              <!-- <ParameterList name="static head"> -->
-              <!--   <ParameterList name="function-static-head"> -->
-              <!--     <Parameter name="p0" type="double" value="0.0"/> -->
-              <!--     <Parameter name="density" type="double" value="1.0"/> -->
-              <!--     <Parameter name="gravity" type="double" value="1.0"/> -->
-              <!--     <Parameter name="space dimension" type="int" value="3"/> -->
-              <!--     <ParameterList name="water table elevation"> -->
-              <!--       <ParameterList name="function-constant"> -->
-              <!--         <Parameter name="value" type="double" value="-5.0"/> -->
-              <!--       </ParameterList> -->
-              <!--     </ParameterList> -->
-              <!--   </ParameterList> -->
-              <!-- </ParameterList> -->
+              <!--ParameterList name="static head"> 
+                <ParameterList name="function-static-head">
+                  <Parameter name="p0" type="double" value="0.0"/>
+                  <Parameter name="density" type="double" value="1.0"/>
+                  <Parameter name="gravity" type="double" value="1.0"/> -->
+                  <Parameter name="space dimension" type="int" value="3"/>
+                  <ParameterList name="water table elevation"> 
+                    <ParameterList name="function-constant"> 
+                      <Parameter name="value" type="double" value="-5.0"/>
+                    </ParameterList> 
+                  </ParameterList>
+                </ParameterList> 
+              </ParameterList-->
               <ParameterList name="boundary pressure">
                 <ParameterList name="function-additive">
                   
@@ -116,21 +116,16 @@
                       <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, -2.5}"/>
                     </ParameterList>
                   </ParameterList>
-                  <!-- <ParameterList name="function1"> -->
-                  <!--   <ParameterList name="function-constant"> -->
-                  <!--     <Parameter name="value" type="double" value="10.0"/> -->
-                  <!--   </ParameterList> -->
-                  <!-- </ParameterList> -->
 
                   <ParameterList name="function2">
                     <ParameterList name="function-multiplicative">
 
                       <ParameterList name="function1">
                         <ParameterList name="function-constant">
-                          <!-- <Parameter name="value" type="double" value="-1.59154943091895"/> -->
                           <Parameter name="value" type="double" value="-0.318309886183791"/>
-                          <!-- <Parameter name="value" type="double" value="-6.36619772367581"/> -->
-                          <!-- <Parameter name="value" type="double" value="-7.957747155"/> -->
+                          <!--Parameter name="value" type="double" value="-1.59154943091895"/-->
+                          <!--Parameter name="value" type="double" value="-6.36619772367581"/-->
+                          <!--Parameter name="value" type="double" value="-7.957747155"/-->
                         </ParameterList>
                       </ParameterList>
                       
@@ -166,10 +161,6 @@
                   </ParameterList>
                 
                 </ParameterList>
-                <!-- <ParameterList name="function-distance"> -->
-                <!--   <Parameter name="x0" type="Array(double)" value="{0., 0., -5.0}"/> -->
-                <!--   <Parameter name="metric" type="Array(double)" value="{1.0, 1.0, 0.0}"/> -->
-                <!-- </ParameterList>  -->
               </ParameterList>
               
             </ParameterList>

--- a/src/pks/flow/test/flow_darcy_well.cc
+++ b/src/pks/flow/test/flow_darcy_well.cc
@@ -177,7 +177,7 @@ void Run_3D_DarcyWell(std::string controller) {
 
   Epetra_MpiComm comm(MPI_COMM_WORLD);
   int MyPID = comm.MyPID();
-  if (MyPID == 0) std::cout << "Test: 3D Darcy flow, two wells" << std::endl;
+  if (MyPID == 0) std::cout << "\nTest: 3D Darcy flow, two wells" << std::endl;
 
   // read parameter list
   std::string xmlFileName = controller;
@@ -263,13 +263,13 @@ void Run_3D_DarcyWell(std::string controller) {
 }
 
 
-// TEST(FLOW_3D_DARCY_WELL) {
-//    Run_3D_DarcyWell("test/flow_darcy_well_3D.xml");
-// }
+TEST(FLOW_3D_DARCY_WELL) {
+  Run_3D_DarcyWell("test/flow_darcy_well_3D.xml");
+}
 
 
+/* **************************************************************** */
 TEST(FLOW_3D_DARCY_PEACEMAN_WELL) {
-  // Run_3D_DarcyWell("test/flow_darcy_well_peaceman_3D.xml");
   using namespace Teuchos;
   using namespace Amanzi;
   using namespace Amanzi::AmanziMesh;
@@ -278,7 +278,7 @@ TEST(FLOW_3D_DARCY_PEACEMAN_WELL) {
 
   Epetra_MpiComm comm(MPI_COMM_WORLD);
   int MyPID = comm.MyPID();
-  if (MyPID == 0) std::cout << "Test: 3D Darcy flow, one well" << std::endl;
+  if (MyPID == 0) std::cout << "\nTest: 3D Darcy flow, one well" << std::endl;
 
   // read parameter list
   std::string xmlFileName = "test/flow_darcy_1well_peaceman_3D.xml";
@@ -373,7 +373,7 @@ TEST(FLOW_3D_DARCY_PEACEMAN_WELL) {
     p_ex = pw + gravity[2]*(xc[2] + depth);
     if (r > 1e-3) {
       p_ex = p_ex + Q/(2*M_PI*k*h)*(log(r) - log(rw));
-    }else{
+    } else {
       p_ex = p[0][c];
     }
 
@@ -394,8 +394,8 @@ TEST(FLOW_3D_DARCY_PEACEMAN_WELL) {
 
   err = sqrt(err);
   sol = sqrt(sol);
-  err = err/sol;
-  std::cout<<"Error: "<<err<<"\n";
+  err /= sol;
+  std::cout << "Error: " << err << "\n";
 
   CHECK(err < 0.02);
 
@@ -405,7 +405,7 @@ TEST(FLOW_3D_DARCY_PEACEMAN_WELL) {
     GMV::write_cell_data(p, 0, "pressure");
     GMV::write_cell_data(p_exact, 0, "exact");
     GMV::write_cell_data(err_p, 0, "error");
-    if (S->HasField("well_index")){
+    if (S->HasField("well_index")) {
       const Epetra_MultiVector& wi = *S->GetFieldData("well_index")->ViewComponent("cell");
       GMV::write_cell_data(wi, 0, "well_index");
     }


### PR DESCRIPTION
This adds Peaceman model to spec 2.3. The model is converted to flow source "simple well" with submodel "bhp" (bottom hole pressure). Spec 2.3 introduces new  element <peaceman_well/> under liquid components of sources with standard attributes "function", "start" [s], "end" [s], "value" [Pa], and two new attributes "radius" [m] and "depth" [m]. Spec example can be also found in XML file converter_u_test3.xml 