### PR TITLE
Upgraded Trilinos.

### DIFF
--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -117,6 +117,7 @@
 #                - update OpenMPI to 3.1.1
 #   0.95.6       - added new package nanoflann 1.3.0
 #   0.95.7       - update MSTK to 3.1.0
+#   0.95.8       - update Trilinos to 12.14.1
 
 include(CMakeParseArguments)
 
@@ -169,7 +170,7 @@ endmacro(amanzi_tpl_version_write)
 #
 set(AMANZI_TPLS_VERSION_MAJOR 0)
 set(AMANZI_TPLS_VERSION_MINOR 95)
-set(AMANZI_TPLS_VERSION_PATCH 7)
+set(AMANZI_TPLS_VERSION_PATCH 8)
 set(AMANZI_TPLS_VERSION ${AMANZI_TPLS_VERSION_MAJOR}.${AMANZI_TPLS_VERSION_MINOR}.${AMANZI_TPLS_VERSION_PATCH})
 # Not sure how to create a meaningful hash key for the collection
 
@@ -431,13 +432,14 @@ set(PETSc_MD5_SUM        ce207f60800e19cfb55a2d7a879ca42c)
 # TPL: Trilinos
 #
 set(Trilinos_VERSION_MAJOR 12)
-set(Trilinos_VERSION_MINOR 12)
+set(Trilinos_VERSION_MINOR 14)
 set(Trilinos_VERSION_PATCH 1)
 set(Trilinos_VERSION ${Trilinos_VERSION_MAJOR}-${Trilinos_VERSION_MINOR}-${Trilinos_VERSION_PATCH})
 set(Trilinos_URL_STRING     "https://github.com/trilinos/Trilinos/archive")
 set(Trilinos_ARCHIVE_FILE   trilinos-release-${Trilinos_VERSION}.tar.gz)
 set(Trilinos_SAVEAS_FILE    ${Trilinos_ARCHIVE_FILE})
-set(Trilinos_MD5_SUM        ecd4606fa332212433c98bf950a69cc7)
+#set(Trilinos_MD5_SUM        ecd4606fa332212433c98bf950a69cc7)
+set(Trilinos_MD5_SUM        de912cca43c2ca3b74aa08528ac39dbd)
 
 #
 # TPL: SEACAS

--- a/config/SuperBuild/include/Build_Trilinos.cmake
+++ b/config/SuperBuild/include/Build_Trilinos.cmake
@@ -180,7 +180,8 @@ set(Trilinos_CMAKE_ARGS
 # Trilinos patches
 set(ENABLE_Trilinos_Patch ON)
 if (ENABLE_Trilinos_Patch)
-  set(Trilinos_patch_file trilinos-ifpack-hypre.patch trilinos-duplicate-parameters.patch)
+  #set(Trilinos_patch_file trilinos-ifpack-hypre.patch trilinos-duplicate-parameters.patch)
+  set(Trilinos_patch_file trilinos-duplicate-parameters.patch)
   configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/trilinos-patch-step.sh.in
                  ${Trilinos_prefix_dir}/trilinos-patch-step.sh
                  @ONLY)


### PR DESCRIPTION
Upgraded to version 12.14.1. Tests passed. A few compiler warnings from KokkosBlas related to C-wrapper for the function with return type std::complex<double>. We do not use complex numbers yet.