### PR TITLE
refactors how nonlinear solvers work

### DIFF
--- a/src/solvers/LinearOperatorNKA.hh
+++ b/src/solvers/LinearOperatorNKA.hh
@@ -265,8 +265,7 @@ LinearOperatorNKA<Matrix, Vector, VectorSpace>::Init(
 
   // NKA
   nka_ = Teuchos::rcp(
-    new NKA_Base<Vector, VectorSpace>(nka_dim_, nka_tol_, m_->getDomainMap()));
-  nka_->Init(plist);
+      new NKA_Base<Vector, VectorSpace>(nka_dim_, nka_tol_, m_->getDomainMap(), vo_));
 
   initialized_ = true;
 }

--- a/src/solvers/NKA_Base.hh
+++ b/src/solvers/NKA_Base.hh
@@ -74,13 +74,8 @@ namespace AmanziSolvers {
 template <class Vector, class VectorSpace>
 class NKA_Base {
  public:
-  NKA_Base(int mvec, double vtol, const Teuchos::RCP<const VectorSpace>& map);
-
-  void Init(Teuchos::ParameterList& plist)
-  {
-    vo_ = Teuchos::rcp(new VerboseObject("NKA_Base", plist));
-  }
-
+  NKA_Base(int mvec, double vtol, const Teuchos::RCP<const VectorSpace>& map,
+           const Teuchos::RCP<VerboseObject>& vo=Teuchos::null);
 
   void Relax();
   void Restart();
@@ -113,10 +108,21 @@ class NKA_Base {
  * Allocate memory
  ***************************************************************** */
 template <class Vector, class VectorSpace>
-NKA_Base<Vector, VectorSpace>::NKA_Base(
-  int mvec, double vtol, const Teuchos::RCP<const VectorSpace>& map)
-  : subspace_(false), pending_(false), mvec_(std::max(mvec, 1)), vtol_(vtol)
+NKA_Base<Vector, VectorSpace>::NKA_Base(int mvec,
+        double vtol,
+        const Teuchos::RCP<const VectorSpace>& map,
+        const Teuchos::RCP<VerboseObject>& vo)
+  : subspace_(false),
+    pending_(false),
+    mvec_(std::max(mvec, 1)),
+    vtol_(vtol),
+    vo_(vo)    
 {
+  if (vo_ == Teuchos::null) {
+    Teuchos::ParameterList plist;
+    vo_ = Teuchos::rcp(new VerboseObject("NKA_Base", plist));
+  }
+  
   v_.resize(mvec_ + 1);
   w_.resize(mvec_ + 1);
 

--- a/src/solvers/Solver.hh
+++ b/src/solvers/Solver.hh
@@ -9,10 +9,10 @@
       Konstantin Lipnikov (lipnikov@lanl.gov)
 */
 
-//! <MISSING_ONELINE_DOCSTRING>
+//! Interface for a Nonlinear Solver
 
-#ifndef AMANZI_SOLVER_BASE_
-#define AMANZI_SOLVER_BASE_
+#ifndef AMANZI_SOLVER_
+#define AMANZI_SOLVER_
 
 #include "Teuchos_RCP.hpp"
 
@@ -30,20 +30,45 @@ class Solver {
   virtual void Init(const Teuchos::RCP<SolverFnBase<Vector>>& fn,
                     const Teuchos::RCP<const VectorSpace>& map) = 0;
 
+  // Returns 0 if success, 1 if failure.
   virtual int Solve(const Teuchos::RCP<Vector>& u) = 0;
 
   // mutators
   virtual void set_tolerance(double tol) = 0;
-  virtual void set_pc_lag(double pc_lag) = 0;
-  virtual void set_db(const Teuchos::RCP<ResidualDebugger>& db) {}
+  virtual void set_pc_lag(int pc_lag) = 0;
+  virtual void set_db(const Teuchos::RCP<ResidualDebugger>& db) = 0;
 
-  // access
-  virtual double tolerance() = 0;
-  virtual double residual() = 0;
-  virtual int num_itrs() = 0;
-  virtual int returned_code() = 0;
-  virtual int pc_calls() = 0;
-  virtual int pc_updates() = 0;
+  // accessors
+
+  // Note, what the error is is dependent upon the MonitorType and the
+  // MonitorNorm
+  virtual double error() const = 0;
+
+  // Tolerance to compare to error.
+  virtual double tolerance() const = 0;
+
+  // The L2 norm of the residual
+  virtual double residual() const = 0;
+
+  // Number of nonlinear iterations
+  virtual int num_iterations() const = 0;
+
+  // See SolverDefs.hh MonitorStatus definition, but positive values indicate
+  // number of iterations convergence was achieved in while negative numbers
+  // indicate an error.
+  virtual int returned_code() const = 0;
+
+  // Number of preconditioner ApplyInverse calls (this solve)
+  virtual int pc_calls() const = 0;
+
+  // Number of times predonditioner was updated (this solve)
+  virtual int pc_updates() const = 0;
+
+  // Number of times nonlinear residual function was called (this solve)
+  virtual int function_calls() const = 0;
+
+  // name of the method (for logging)
+  virtual std::string name() const = 0;
 };
 
 } // namespace AmanziSolvers

--- a/src/solvers/SolverDefault.hh
+++ b/src/solvers/SolverDefault.hh
@@ -1,0 +1,421 @@
+/*
+  Copyright 2010-201x held jointly by participating institutions.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors:
+      Ethan Coon (coonet@ornl.gov)
+      Konstantin Lipnikov (lipnikov@lanl.gov)
+*/
+
+//! A framework for nonlinear solvers that use the same basic structure.
+
+/*!
+
+The majority of nonlinear solvers use a common structure to implement their
+solve process.  This reduces that to a few common callbacks, making it easier
+to share common implementation here.
+
+Implementations must implement the CalculateUpdate_() method, and may
+re-implement the Restart_() and Init() methods.
+
+ * `"monitor`" ``[string]`` **monitor l2 update** Defines what is meant by "error."  One of:
+        - `"monitor l2 update`" The L2 norm of the correction, du.
+        - `"monitor linf update`" The Linf norm of the correction, du
+        - `"monitor update`" The functional's ErrorNorm() of the correction, du.
+        - `"monitor l2 residual`" The L2 norm of the functional's residual.
+        - `"monitor linf residual`" The Linf norm of the functional's residual.
+        - `"monitor residual`" The functional's ErrorNorm() of the functional's residual.
+      Hereafter this quantity is called the error; all tolerances, etc, are with respect to this.
+
+ * `"nonlinear tolerance`" ``[double]`` **1.e-6** Solve is successful when the
+       error is less than this tolerance.
+
+ * `"limit iterations`" ``[int]`` **50** Max number of iterations before solver fails.
+
+ * `"max divergent iterations`" ``[int]`` **3** Max number of iterations where
+        the error increases before failure.
+
+ * `"diverged tolerance`" ``[double]`` **1.e10** Max error allowed without failure.
+
+ * `"max error growth factor`" ``[double]`` **1.e5** Max ratio of error to
+        previous iteration's error allowed without failure.
+
+ * `"max iterations before stagnation`" ``[int]`` **8** Number of iterations
+        after which the error must have decreased from the initial error
+        without failing.
+ 
+ * `"modify correction`" ``[bool]`` **false** Call the PK's ModifyCorrection() method.
+
+ * `"preconditioner lag iterations`" ``[int]`` **0** Number of iterations to
+        lag before updating the preconditioner.
+
+*/
+
+#ifndef AMANZI_SOLVER_DEFAULT_
+#define AMANZI_SOLVER_DEFAULT_
+
+#include "Teuchos_RCP.hpp"
+
+#include "ResidualDebugger.hh"
+#include "Solver.hh"
+#include "SolverFnBase.hh"
+
+namespace Amanzi {
+namespace AmanziSolvers {
+
+template <class Vector, class VectorSpace>
+class SolverDefault : public Solver<Vector,VectorSpace> {
+ public:
+  SolverDefault(Teuchos::ParameterList& plist);
+  
+  virtual void Init(const Teuchos::RCP<SolverFnBase<Vector>>& fn,
+                    const Teuchos::RCP<const VectorSpace>& map) override
+  { fn_ = fn; }
+
+  // Returns 0 if success, 1 if failure.
+  virtual int Solve(const Teuchos::RCP<Vector>& u) override;
+  
+  // mutators
+  virtual void set_tolerance(double tol) override { tolerance_ = tol; }
+  virtual void set_pc_lag(int pc_lag) override { pc_lag_ = pc_lag; }
+  virtual void set_db(const Teuchos::RCP<ResidualDebugger>& db) override
+  { db_ = db; }
+
+  // accessors
+  // Note, what the error is is dependent upon the MonitorType and the
+  // MonitorNorm
+  virtual double error() const override { return error_; }
+
+  // Tolerance to compare to error.
+  virtual double tolerance() const override { return tolerance_; }
+
+  // The L2 norm of the residual
+  virtual double residual() const override { return residual_; }
+
+  // Number of nonlinear iterations
+  virtual int num_iterations() const override { return num_itrs_; }
+
+  // See SolverDefs.hh MonitorStatus definition, but positive values indicate
+  // number of iterations convergence was achieved in while negative numbers
+  // indicate an error.
+  virtual int returned_code() const override {
+    if (status_ == MonitorStatus::CONVERGED) return num_iterations();
+    else return (int) status_;
+  }
+
+  // Number of preconditioner ApplyInverse calls (this solve)
+  virtual int pc_calls() const override { return pc_calls_; }
+
+  // Number of times predonditioner was updated (this solve)
+  virtual int pc_updates() const override { return pc_updates_; }
+
+  // Number of times nonlinear residual function was called (this solve)
+  virtual int function_calls() const override { return function_calls_; }
+
+
+ protected:
+  virtual void Restart_() {}
+
+  // Do any modifications specific to the method.
+  //
+  // This may be, for instance, apply an accelerator, doing line search, etc,
+  // or it may simply call the PK's ModifyCorrection() (it probably, at the
+  // least, should do this).
+  //
+  // NOTE: It is up to the method to ensure that, after this call, if status is
+  // CONTINUE, that du is valid, not diverging, and good to directly apply.
+  //
+  // NOTE: du is taken by non-const reference -- the pointer MAY be reseated.
+  virtual std::pair<MonitorStatus,double> ModifyCorrection_(Teuchos::RCP<Vector>& r,
+          const Teuchos::RCP<Vector>& u, Teuchos::RCP<Vector>& du) = 0;
+  virtual MonitorStatus MonitorError_(double error, double previous_error,
+          double l2_error, double l2_error_initial, int& divergence_count);
+  
+ protected:
+  // public interface
+  double tolerance_;
+  double residual_;
+  double error_;
+  int num_itrs_;
+  int returned_code_;
+  int pc_calls_;
+  int pc_updates_;
+  int function_calls_;
+
+  // functional 
+  Teuchos::RCP<SolverFnBase<Vector>> fn_;
+
+  // convergence control
+  Monitor monitor_type_;
+  MonitorStatus status_;
+  MonitorNorm norm_type_;
+  bool modify_correction_;
+  int pc_lag_;
+
+  // reasons to crash
+  double diverged_tol_;
+  double max_error_growth_factor_;
+  int max_divergence_count_;
+  int max_itrs_stagnation_;
+  int max_itrs_;
+
+  // debugging and verbose object
+  Teuchos::RCP<ResidualDebugger> db_;
+  Teuchos::RCP<VerboseObject> vo_;
+};
+
+
+// Implementation
+template <class Vector, class VectorSpace>
+SolverDefault<Vector,VectorSpace>::SolverDefault(Teuchos::ParameterList& plist)
+    : function_calls_(0),
+      pc_calls_(0),
+      pc_updates_(0),
+      pc_lag_(0),
+      residual_(-1.0)
+{
+  // control parameters
+  modify_correction_ = plist.get<bool>("modify correction", false);
+  pc_lag_ = plist.get<int>("preconditioner lag iterations", 0);
+
+  // converged/diverged control parameters
+  tolerance_ = plist.get<double>("nonlinear tolerance", 1.e-6);
+  max_itrs_ = plist.get<int>("limit iterations", 50);
+  max_divergence_count_ = plist.get<int>("max divergent iterations", 3);
+  diverged_tol_ = plist.get<double>("diverged tolerance", 1.0e10);
+  max_error_growth_factor_ = plist.get<double>("max error growth factor", 1.0e5);
+  max_itrs_stagnation_ = plist.get<int>("max iterations before stagnation", 8);
+
+  // what do we monitor and how do we monitor it?
+  std::string monitor_name = plist.get<std::string>("monitor", "monitor l2 update");
+  if (monitor_name == "monitor residual") {
+    monitor_type_ = Monitor::RESIDUAL;
+    norm_type_ = MonitorNorm::ENORM;
+  } else if (monitor_name == "monitor l2 residual") {
+    monitor_type_ = Monitor::RESIDUAL;
+    norm_type_ = MonitorNorm::L2;
+  } else if (monitor_name == "monitor linf residual") {
+    monitor_type_ = Monitor::RESIDUAL;
+    norm_type_ = MonitorNorm::LINF;
+  // } else if (monitor_name == "monitor preconditioned residual") {
+  //   monitor_type_ = SOLVER_MONITOR_PCED_RESIDUAL;
+  //   norm_type_ = MonitorNorm::ENORM;
+  // } else if (monitor_name == "monitor preconditioned l2 residual") {
+  //   monitor_type_ = SOLVER_MONITOR_PCED_RESIDUAL;
+  //   norm_type_ = MonitorNorm::L2;
+  // } else if (monitor_name == "monitor preconditioned linf residual") {
+  //   monitor_type_ = SOLVER_MONITOR_PCED_RESIDUAL;
+  //   norm_type_ = MonitorNorm::LINF;
+  } else if (monitor_name == "monitor update") {
+    monitor_type_ = Monitor::UPDATE;  // default value
+    norm_type_ = MonitorNorm::ENORM;
+  } else if (monitor_name == "monitor l2 update") {
+    monitor_type_ = Monitor::UPDATE;  // default value
+    norm_type_ = MonitorNorm::L2;
+  } else if (monitor_name == "monitor linf update") {
+    monitor_type_ = Monitor::UPDATE;  // default value
+    norm_type_ = MonitorNorm::LINF;
+  } else {
+    Errors::Message m;
+    m << "SolverNKA: Invalid monitor \"" << monitor_name << "\"";
+    Exceptions::amanzi_throw(m);
+  }
+}
+
+
+template <class Vector, class VectorSpace>
+int
+SolverDefault<Vector,VectorSpace>::Solve(const Teuchos::RCP<Vector>& u)
+{
+  Teuchos::OSTab tab = vo_->getOSTab();
+
+  // reinitialize
+  num_itrs_ = 0;
+  pc_updates_ = 0;
+  pc_calls_ = 0;
+  function_calls_ = 0;
+  residual_ = -1.0;
+  status_ = MonitorStatus::CONTINUE;
+  Restart_();
+
+  // generate work space
+  auto r = Teuchos::rcp(new Vector(u->getMap()));
+  auto du = Teuchos::rcp(new Vector(u->getMap()));
+
+  // variables to monitor the progress of the nonlinear solver
+  error_ = std::numeric_limits<double>::max();
+  residual_ = std::numeric_limits<double>::max();
+
+  double previous_error(std::numeric_limits<double>::max());
+  double l2_error(std::numeric_limits<double>::max());
+  double l2_error_initial(std::numeric_limits<double>::max());
+  double du_norm(std::numeric_limits<double>::max());
+  double previous_du_norm(std::numeric_limits<double>::max());
+  double du_norm_initial(std::numeric_limits<double>::max());
+  double r_norm_initial(std::numeric_limits<double>::max());
+
+  int divergence_count(0);
+  int db_write_iter = 0;
+
+  // start the iteration loop
+  do {
+    // Check for too many nonlinear iterations.
+    if (num_itrs_ >= max_itrs_) {
+      if (vo_->os_OK(Teuchos::VERB_MEDIUM))
+        *vo_->os() << "Solve reached maximum of iterations (" << num_itrs_
+                   << ")  error=" << error_ << " terminating..." << std::endl;
+      status_ = MonitorStatus::MAX_ITERATIONS;
+      return 1;
+    }
+
+    // Evaluate the nonlinear function.
+    function_calls_++;
+    fn_->Residual(u, r);
+    residual_ = r->norm2();
+    db_->WriteVector<Vector>(db_write_iter++, *r, u.ptr(), du.ptr());
+
+    // If monitoring the residual, check for convergence.
+    if (monitor_type_ == Monitor::RESIDUAL) {
+      previous_error = error_;
+      l2_error = residual_;
+
+      if (norm_type_ == MonitorNorm::LINF)
+        error_ = r->normInf();
+      else if (norm_type_ == MonitorNorm::L2)
+        error_ = residual_;
+      else if (norm_type_ == MonitorNorm::ENORM)
+        error_ = fn_->ErrorNorm(u, r);
+
+      // We attempt to catch non-convergence early.
+      // Stagnation based on L2 norm.
+      if (num_itrs_ == 0) {
+        l2_error_initial = l2_error;
+      }
+
+      // Check for convergence
+      status_ = MonitorError_(error_, previous_error, l2_error, l2_error_initial, divergence_count);
+      if (status_ == MonitorStatus::CONVERGED) return 0;
+      else if (status_ != MonitorStatus::CONTINUE) return 1;
+    }
+
+    // Update the preconditioner if necessary.
+    if (num_itrs_ % (pc_lag_ + 1) == 0) {
+      pc_updates_++;
+      fn_->UpdatePreconditioner(u);
+    }
+
+    // Apply the preconditioner to the nonlinear residual.
+    pc_calls_++;
+    int prec_error = fn_->ApplyPreconditioner(r, du);
+    if (prec_error) {
+      status_ = MonitorStatus::LINEAR_SOLVER_ERROR;
+      return 1;
+    }
+
+    // Check for a method-specific direction.
+    //
+    // NOTE: It is up to the method to ensure that, after this call, if status
+    // is CONTINUE, that du is valid, not diverging, and good to directly
+    // apply.
+    previous_du_norm = du_norm;
+    std::tie(status_, du_norm) = ModifyCorrection_(r, u, du);
+    if (status_ == MonitorStatus::CONVERGED) return 0;
+    else if (status_ != MonitorStatus::CONTINUE) return 1;
+
+    // Keep track of diverging iterations
+    if (du_norm < 0) {
+      // ModifyCorrection did not take the norm for us.
+      du_norm = du->norm2();
+    }
+
+    // Next solution iterate and error estimate: u  = u - du
+    u->update(-1.0, *du, 1.0);
+    fn_->ChangedSolution();
+
+    // Increment iteration counter.
+    num_itrs_++;
+
+    // If monitoring the update, check for convergence.
+    if (monitor_type_ == Monitor::UPDATE) {
+      previous_error = error_;
+      l2_error = du_norm;
+
+      if (norm_type_ == MonitorNorm::LINF)
+        error_ = du->normInf();
+      else if (norm_type_ == MonitorNorm::L2)
+        error_ = du_norm;
+      else if (norm_type_ == MonitorNorm::ENORM)
+        error_ = fn_->ErrorNorm(u, du);
+
+      // We attempt to catch non-convergence early.
+      // Stagnation based on L2 norm.
+      if (num_itrs_ == 1) {
+        l2_error_initial = l2_error;
+      }
+
+      // Check for convergence
+      status_ = MonitorError_(error_, previous_error, l2_error, l2_error_initial, divergence_count);
+      if (status_ == MonitorStatus::CONVERGED) return 0;
+      else if (status_ != MonitorStatus::CONTINUE) return 1;
+    }
+  } while(true); // continue do loop
+}
+
+
+template <class Vector, class VectorSpace>
+MonitorStatus
+SolverDefault<Vector,VectorSpace>::MonitorError_(double error,
+        double previous_error, double l2_error, double l2_error_initial, int& divergence_count)
+{
+  if (vo_->os_OK(Teuchos::VERB_HIGH))
+    *vo_->os() << num_itrs_ << ": error=" << error << "  L2-error=" << l2_error << std::endl;
+
+  if (error < tolerance_) {
+    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
+      *vo_->os() << "Solver converged: " << num_itrs_
+                 << " itrs, error=" << error << std::endl;
+    return MonitorStatus::CONVERGED;
+
+  } else if (num_itrs_ > max_itrs_stagnation_ && l2_error > l2_error_initial) {
+    if (vo_->os_OK(Teuchos::VERB_MEDIUM)) 
+      *vo_->os() << "Solver stagnating, L2-error=" << l2_error
+                 << " > " << l2_error_initial << " (initial L2-error)" << std::endl;
+    return MonitorStatus::STAGNATING;
+
+  } else if (error > diverged_tol_) {
+    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
+      *vo_->os() << "Solve failed, error " << error << " > " << diverged_tol_
+                 << " (diverged)" << std::endl;
+    return MonitorStatus::DIVERGED;
+
+  } else if ((num_itrs_ > 1) &&
+             (error > max_error_growth_factor_ * previous_error)) {
+    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
+      *vo_->os() << "Solver threatens to diverge, error " << error << " > "
+                 << previous_error << " (previous error)" << std::endl;
+    return MonitorStatus::DIVERGED;
+
+  } else if (error >= previous_error) {
+    divergence_count++;
+
+    // If it does not recover quickly, abort.
+    if (divergence_count >= max_divergence_count_) {
+      if (vo_->os_OK(Teuchos::VERB_MEDIUM))
+        *vo_->os() << "Solver is diverging repeatedly, terminating..." << std::endl;
+      return MonitorStatus::DIVERGING;
+    }
+
+  } else {
+    divergence_count = 0;
+  }
+
+  return MonitorStatus::CONTINUE;
+}
+
+
+} // namespace AmanziSolvers
+} // namespace Amanzi
+
+#endif

--- a/src/solvers/SolverDefs.hh
+++ b/src/solvers/SolverDefs.hh
@@ -17,35 +17,30 @@
 namespace Amanzi {
 namespace AmanziSolvers {
 
-enum ConvergenceMonitor {
-  SOLVER_MONITOR_UPDATE = 0,
-  SOLVER_MONITOR_PCED_RESIDUAL = 1,
-  SOLVER_MONITOR_RESIDUAL = 2
+enum class Monitor {
+  UPDATE = 0,
+  RESIDUAL = 1,
+  //  PRECONDITIONED_RESIDUAL = 2 // NOTE: Never used...  
 };
 
-enum BacktrackMonitor {
-  BT_MONITOR_ENORM, // accept decrease in the ENORM
-  BT_MONITOR_L2,    // accept decrease in the Linf of the ConvergenceMonitor
-                    // (residual)
-  BT_MONITOR_EITHER // accept decrease in either of the above
+enum class MonitorNorm {
+  LINF = 1, // accept decrease in L_INF norm
+  L2 = 3,    // accept decrease in L2 norm
+  ENORM = 5  // accept decrease in PK's ErrorNorm()
 };
 
-const int SOLVER_CONTINUE = 1;
-const int SOLVER_CONVERGED = 0;
-
-const int SOLVER_MAX_ITERATIONS = -1;
-const int SOLVER_OVERFLOW = -2;
-const int SOLVER_STAGNATING = -3;
-const int SOLVER_DIVERGING = -4;
-const int SOLVER_INADMISSIBLE_SOLUTION = -5;
-const int SOLVER_INTERNAL_EXCEPTION = -6;
-const int SOLVER_BAD_SEARCH_DIRECTION = -7;
-const int SOLVER_LINEAR_SOLVER_ERROR = -8;
-
-const double BACKTRACKING_GOOD_REDUCTION = 0.5;
-const int BACKTRACKING_USED = 1;
-const int BACKTRACKING_MAX_ITERATIONS = 4;
-const int BACKTRACKING_ROUNDOFF_PROBLEM = 8;
+enum class MonitorStatus {
+  CONTINUE = 1,
+  CONVERGED = 0,
+  MAX_ITERATIONS = -1,
+  DIVERGED = -2,
+  STAGNATING = -3,
+  DIVERGING = -4,
+  INADMISSIBLE_SOLUTION = -5,
+  INTERNAL_EXCEPTION = -6,
+  BAD_SEARCH_DIRECTION = -7,
+  LINEAR_SOLVER_ERROR = -8
+};
 
 } // namespace AmanziSolvers
 } // namespace Amanzi

--- a/src/solvers/SolverNKA.hh
+++ b/src/solvers/SolverNKA.hh
@@ -12,10 +12,29 @@
 
 /*!
 
-  Uses an accelerated nonlinear solver that is similar to a multidimensional
-  secant method.
+Uses an accelerated nonlinear solver that is similar to a multidimensional
+secant method.
 
- */
+ * `"max nka vectors`" ``[int]`` **10** Number of vectors used to span the
+      secant space of previously explored directions.
+
+ * `"nka vector tolerance`" ``[double]`` **0.05** Tolerance on when the dot
+      product of two vectors suggests they are parallel.
+
+ * `"nka lag iterations`" ``[int]`` **0** Number of iterations to wait to begin
+        the NKA accelerator.  Note that no theoretical NKA work has been done
+        with globalization, though experience suggests that it is robust to
+        globalized corrections as long as the actual correction taken is given
+        to the NKA algorithm.  Lagging NKA may be useful if the first few
+        Jacobian corrections are always expected to be heavily modified via
+        globalization.
+
+
+ [1] N.N.Carlson and K.Miller, "Design and application of a gradient-
+      weighted moving finite element code I: in one dimension", SIAM J.
+      Sci. Comput;, 19 (1998), pp. 728-765.  See section 9.
+        
+*/
 
 #ifndef AMANZI_NKA_SOLVER_
 #define AMANZI_NKA_SOLVER_
@@ -23,26 +42,31 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 
-#include "VerboseObject.hh"
-#include "ResidualDebugger.hh"
-
-#include "Solver.hh"
-#include "SolverFnBase.hh"
 #include "SolverDefs.hh"
+#include "SolverDefault.hh"
 #include "NKA_Base.hh"
 
 namespace Amanzi {
 namespace AmanziSolvers {
 
 template <class Vector, class VectorSpace>
-class SolverNKA : public Solver<Vector, VectorSpace> {
+class SolverNKA : public SolverDefault<Vector, VectorSpace> {
  public:
-  SolverNKA(Teuchos::ParameterList& plist) : plist_(plist) {};
+  SolverNKA(Teuchos::ParameterList& plist)
+      : SolverDefault<Vector,VectorSpace>(plist) {
+    nka_dim_ = plist.get<int>("max nka vectors", 10);
+    nka_dim_ = std::min<int>(nka_dim_, this->max_itrs_ - 1);
+    nka_tol_ = plist.get<double>("nka vector tolerance", 0.05);
+    nka_lag_ = plist.get<int>("nka lag iterations", 0);
+
+    // update the verbose options
+    this->vo_ = Teuchos::rcp(new VerboseObject(name(), plist));
+  }
 
   SolverNKA(Teuchos::ParameterList& plist,
             const Teuchos::RCP<SolverFnBase<Vector>>& fn,
             const VectorSpace& map)
-    : plist_(plist)
+      : SolverNKA(plist)
   {
     Init(fn, map);
   }
@@ -50,61 +74,23 @@ class SolverNKA : public Solver<Vector, VectorSpace> {
   virtual void Init(const Teuchos::RCP<SolverFnBase<Vector>>& fn,
             const Teuchos::RCP<const VectorSpace>& map) override;
 
-  virtual int Solve(const Teuchos::RCP<Vector>& u) override
-  {
-    returned_code_ = NKA_(u);
-    return (returned_code_ >= 0) ? 0 : 1;
-  }
+  virtual std::string name() const override { return "Solver::NKA"; }
 
-  // mutators
+ protected:  
   //
-  // These may be legacy?  Is there an adaptive reason for these to need
-  // setters and not come from the plist?
-  void set_tolerance(double tol) override { tol_ = tol; }
-  void set_pc_lag(double pc_lag) override { pc_lag_ = pc_lag; }
-  virtual void set_db(const Teuchos::RCP<ResidualDebugger>& db) override
-  {
-    db_ = db;
-  }
+  // NKA's ModifyCorrection() calls the acceleration on the correction.
+  virtual std::pair<MonitorStatus,double> ModifyCorrection_(Teuchos::RCP<Vector>& r,
+          const Teuchos::RCP<Vector>& u, Teuchos::RCP<Vector>& du) override;
 
-  // access
-  double tolerance() override { return tol_; }
-  double residual() override { return residual_; }
-  int num_itrs() override { return num_itrs_; }
-  int pc_calls() override { return pc_calls_; }
-  int pc_updates() override { return pc_updates_; }
-  int returned_code() override { return returned_code_; }
-
- private:
-  void Init_();
-  int NKA_(const Teuchos::RCP<Vector>& u);
-  int NKA_ErrorControl_(double error, double previous_error, double l2_error);
-
+  virtual void Restart_() override { nka_->Restart(); }
+  
  protected:
-  Teuchos::ParameterList plist_;
-  Teuchos::RCP<SolverFnBase<Vector>> fn_;
   Teuchos::RCP<NKA_Base<Vector, VectorSpace>> nka_;
-
-  Teuchos::RCP<VerboseObject> vo_;
-  Teuchos::RCP<ResidualDebugger> db_;
+  Teuchos::RCP<Vector> du_tmp_;
 
   double nka_tol_;
   int nka_dim_;
-
- private:
-  double tol_, overflow_tol_, overflow_l2_tol_, overflow_pc_tol_,
-    overflow_r_tol_;
-
-  int max_itrs_, num_itrs_, returned_code_;
-  int fun_calls_, pc_calls_;
-  int pc_lag_, pc_updates_;
-  int nka_lag_space_, nka_lag_iterations_;
-  int max_error_growth_factor_, max_du_growth_factor_;
-  int max_divergence_count_;
-
-  bool modify_correction_;
-  double residual_; // defined by convergence criterion
-  ConvergenceMonitor monitor_;
+  int nka_lag_;
 };
 
 
@@ -117,332 +103,58 @@ SolverNKA<Vector, VectorSpace>::Init(
   const Teuchos::RCP<SolverFnBase<Vector>>& fn,
   const Teuchos::RCP<const VectorSpace>& map)
 {
-  fn_ = fn;
-  Init_();
+  SolverDefault<Vector,VectorSpace>::Init(fn, map);
 
   // Allocate the NKA space
-  nka_ =
-    Teuchos::rcp(new NKA_Base<Vector, VectorSpace>(nka_dim_, nka_tol_, map));
-  nka_->Init(plist_);
+  nka_ = Teuchos::rcp(new NKA_Base<Vector, VectorSpace>(nka_dim_, nka_tol_, map));
+  du_tmp_ = Teuchos::rcp(new Vector(map));
 }
 
 
 /* ******************************************************************
- * Initialization of the NKA solver.
+ * NKA's ModifyCorrection() calls the acceleration on the correction.
  ****************************************************************** */
 template <class Vector, class VectorSpace>
-void
-SolverNKA<Vector, VectorSpace>::Init_()
+std::pair<MonitorStatus,double>
+SolverNKA<Vector, VectorSpace>::ModifyCorrection_(Teuchos::RCP<Vector>& r,
+        const Teuchos::RCP<Vector>& u,
+        Teuchos::RCP<Vector>& du)
 {
-  tol_ = plist_.get<double>("nonlinear tolerance", 1.e-6);
+  // Calculate the accelerated correction.
+  if (this->num_itrs_ > nka_lag_) {
+    // Calculate the NKA correction
+    nka_->Correction(*du, *du_tmp_, du_tmp_.ptr());
 
-  overflow_tol_ = plist_.get<double>("diverged tolerance", 1.0e10);
-  overflow_l2_tol_ = plist_.get<double>("diverged l2 tolerance", 1.0e10);
-  overflow_pc_tol_ = plist_.get<double>("diverged pc tolerance", 1.0e10);
-  overflow_r_tol_ = plist_.get<double>("diverged residual tolerance", 1.0e10);
-
-  max_itrs_ = plist_.get<int>("limit iterations", 50);
-  
-  max_du_growth_factor_ = plist_.get<double>("max du growth factor", 1.0e5);
-  max_error_growth_factor_ =
-    plist_.get<double>("max error growth factor", 1.0e5);
-  max_divergence_count_ = plist_.get<int>("max divergent iterations", 3);
-
-  nka_lag_iterations_ = plist_.get<int>("lag iterations", 0);
-  modify_correction_ = plist_.get<bool>("modify correction", false);
-
-  std::string monitor_name =
-    plist_.get<std::string>("monitor", "monitor update");
-  if (monitor_name == "monitor residual") {
-    monitor_ = SOLVER_MONITOR_RESIDUAL;
-  } else if (monitor_name == "monitor preconditioned residual") {
-    monitor_ = SOLVER_MONITOR_PCED_RESIDUAL;
-  } else if (monitor_name == "monitor update") {
-    monitor_ = SOLVER_MONITOR_UPDATE; // default value
-  } else {
-    Errors::Message m;
-    m << "SolverNKA: Invalid monitor \"" << monitor_name << "\"";
-    Exceptions::amanzi_throw(m);
-  }
-
-  nka_dim_ = plist_.get<int>("max nka vectors", 10);
-  nka_dim_ = std::min<int>(nka_dim_, max_itrs_ - 1);
-  nka_tol_ = plist_.get<double>("nka vector tolerance", 0.05);
-
-  fun_calls_ = 0;
-  pc_calls_ = 0;
-  pc_updates_ = 0;
-  pc_lag_ = 0;
-  nka_lag_space_ = 0;
-
-  residual_ = -1.0;
-
-  // update the verbose options
-  vo_ = Teuchos::rcp(new VerboseObject("Solver::NKA", plist_));
-}
-
-
-/* ******************************************************************
- * The body of NKA solver
- ****************************************************************** */
-template <class Vector, class VectorSpace>
-int
-SolverNKA<Vector, VectorSpace>::NKA_(const Teuchos::RCP<Vector>& u)
-{
-  Teuchos::OSTab tab = vo_->getOSTab();
-
-  // restart the nonlinear solver (flush its history)
-  nka_->Restart();
-
-  // initialize the iteration and pc counters
-  num_itrs_ = 0;
-  pc_calls_ = 0;
-  pc_updates_ = 0;
-
-  // create storage
-  auto r = Teuchos::rcp(new Vector(u->getMap()));
-  auto du = Teuchos::rcp(new Vector(u->getMap()));
-  auto du_tmp = Teuchos::rcp(new Vector(u->getMap()));
-
-  // variables to monitor the progress of the nonlinear solver
-  double error(0.0), previous_error(0.0), l2_error(0.0);
-  double l2_error_initial(0.0);
-  double du_norm(0.0), previous_du_norm(0.0), du_tmp_norm_initial,
-    r_norm_initial;
-  int divergence_count(0);
-  int prec_error;
-  int db_write_iter = 0;
-
-  double u_norm(0.);
-  if (monitor_ == SOLVER_MONITOR_RESIDUAL) u_norm = u->norm2();
-
-  do {
-    // Check for too many nonlinear iterations.
-    if (num_itrs_ >= max_itrs_) {
-      if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-        *vo_->os() << "Solve reached maximum of iterations (" << num_itrs_
-                   << ")  error=" << error << " terminating..." << std::endl;
-      return SOLVER_MAX_ITERATIONS;
-    }
-
-    // Evaluate the nonlinear function.
-    fun_calls_++;
-    fn_->Residual(u, r);
-    db_->WriteVector<Vector>(db_write_iter++, *r, u.ptr(), du.ptr());
-
-    // Make sure that residual does not cause numerical overflow.
-    double r_norm = r->norm2();
-
-    if (num_itrs_ == 0) {
-      r_norm_initial = r_norm;
-    } else {
-      if (r_norm > overflow_r_tol_ * r_norm_initial) {
-        if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-          *vo_->os() << "teminating due to L2-norm overflow: ||r||=" << r_norm
-                     << " ||r0||=" << r_norm_initial << std::endl;
-        return SOLVER_OVERFLOW;
-      }
-    }
-
-    // If monitoring the residual, check for convergence.
-    if (monitor_ == SOLVER_MONITOR_RESIDUAL) {
-      previous_error = error;
-      l2_error = r->norm2();
-      residual_ = l2_error;
-      error = l2_error / u_norm;
-
-      // We attempt to catch non-convergence early.
-      if (num_itrs_ == 1) {
-        l2_error_initial = l2_error;
-      } else if (num_itrs_ > 8) {
-        if (l2_error > l2_error_initial) {
-          if (vo_->getVerbLevel() >= Teuchos::VERB_MEDIUM)
-            *vo_->os() << "Solver stagnating, L2-error=" << l2_error << " > "
-                       << l2_error_initial << " (initial L2-error)"
-                       << std::endl;
-          return SOLVER_STAGNATING;
-        }
-      }
-
-      int ierr = NKA_ErrorControl_(error, previous_error, l2_error);
-      if (ierr == SOLVER_CONVERGED) return num_itrs_;
-      if (ierr != SOLVER_CONTINUE) return ierr;
-    }
-
-    // Update the preconditioner if necessary.
-    if (num_itrs_ % (pc_lag_ + 1) == 0) {
-      pc_updates_++;
-      fn_->UpdatePreconditioner(u);
-    }
-
-    // Apply the preconditioner to the nonlinear residual.
-    pc_calls_++;
-    prec_error = fn_->ApplyPreconditioner(r, du_tmp);
-
-    // Make sure that preconditioner does not cause numerical overflow.
-    double du_tmp_norm = du_tmp->normInf();
-
-    if (num_itrs_ == 0) {
-      du_tmp_norm_initial = du_tmp_norm;
-    } else {
-      if (du_tmp_norm > overflow_pc_tol_ * du_tmp_norm_initial) {
-        if (vo_->getVerbLevel() >= Teuchos::VERB_MEDIUM)
-          *vo_->os()
-            << "terminating due to preconditioner overflow: ||du_tmp||="
-            << du_tmp_norm << " ||du_tmp0||=" << du_tmp_norm_initial
-            << std::endl;
-        return SOLVER_OVERFLOW;
-      }
-    }
-
-    // Calculate the accelerated correction.
-    if (num_itrs_ < nka_lag_space_) {
-      // Lag the NKA space, just use the PC'd update.
-      du->assign(*du_tmp);
-    } else {
-      if (num_itrs_ < nka_lag_iterations_) {
-        // Lag NKA's iteration, but update the space with this Jacobian info.
-        nka_->Correction(*du_tmp, *du, du.ptr());
-        du->assign(*du_tmp);
-      } else {
-        // Take the standard NKA correction.
-        nka_->Correction(*du_tmp, *du, du.ptr());
-      }
-    }
-
-    // Hack the correction
-    if (modify_correction_) {
-      bool hacked = fn_->ModifyCorrection(r, u, du);
+    // Call the PK's modify
+    if (this->modify_correction_) {
+      bool hacked = this->fn_->ModifyCorrection(r, u, du_tmp_);
       if (hacked) {
         // If we had to hack things, it't not unlikely that the Jacobian
-        // information is crap. Take the hacked correction, and restart
-        // NKA to start building a new Jacobian space.
+        // information is not representative of the local space. Take the hacked
+        // correction, and restart NKA to start building a new Jacobian space.
         nka_->Restart();
       }
     }
 
-    // Make sure that we do not diverge and cause numerical overflow.
-    previous_du_norm = du_norm;
-    du_norm = du->normInf();
+    // Check the admissibility of the NKA iterate
+    if (this->fn_->IsAdmissible(du_tmp_)) {
+      du->assign(*du_tmp_); // NOTE: should be able to remove this if we are
+                          // careful about RCPs and use swap instead? --etc
+      return std::make_pair(MonitorStatus::CONTINUE, (double) -1.0);
 
-    if (num_itrs_ == 0) {
-      double u_norm2, du_norm2;
-      u_norm2 = u->norm2();
-      du_norm2 = du->norm2();
-      if (u_norm2 > 0 && du_norm2 > overflow_l2_tol_ * u_norm2) {
-        if (vo_->getVerbLevel() >= Teuchos::VERB_MEDIUM)
-          *vo_->os() << "terminating due to L2-norm overflow ||du||="
-                     << du_norm2 << ", ||u||=" << u_norm2 << std::endl;
-        return SOLVER_OVERFLOW;
-      }
-    }
-
-    if ((num_itrs_ > 0) &&
-        (du_norm > max_du_growth_factor_ * previous_du_norm)) {
-      if (vo_->os_OK(Teuchos::VERB_HIGH))
-        *vo_->os() << "overflow: ||du||=" << du_norm
-                   << ", ||du_prev||=" << previous_du_norm << std::endl
-                   << "trying to restart NKA..." << std::endl;
-
-      // Try to recover by restarting NKA.
-      nka_->Restart();
-
-      // This is the first invocation of nka_correction with an empty
-      // nka space, so we call it withoug du_last, since there isn't one
-      nka_->Correction(*du_tmp, *du);
-
-      // Re-check du. If it fails again, give up.
-      du_norm = du->normInf();
-
-      if (du_norm > max_du_growth_factor_ * previous_du_norm) {
-        if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-          *vo_->os() << "terminating due to overflow ||du||=" << du_norm
-                     << ", ||du_prev||=" << previous_du_norm << std::endl;
-        return SOLVER_OVERFLOW;
-      }
-    }
-
-    // Keep track of diverging iterations
-    if (num_itrs_ > 0 && du_norm >= previous_du_norm) {
-      divergence_count++;
-
-      // If it does not recover quickly, abort.
-      if (divergence_count == max_divergence_count_) {
-        if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-          *vo_->os() << "Solver is diverging repeatedly, terminating..."
-                     << std::endl;
-        return SOLVER_DIVERGING;
-      }
     } else {
-      divergence_count = 0;
+      // Yuck.  Restart NKA
+      nka_->Restart();
     }
-
-    // Next solution iterate and error estimate: u  = u - du
-    u->update(-1.0, *du, 1.0);
-    fn_->ChangedSolution();
-
-    // Increment iteration counter.
-    num_itrs_++;
-
-    // Monitor the PC'd residual.
-    if (monitor_ == SOLVER_MONITOR_PCED_RESIDUAL) {
-      previous_error = error;
-      // error = fn_->ErrorNorm(u, du_tmp);
-      l2_error = du_tmp->norm2();
-      error = residual_ = l2_error;
-
-      int ierr = NKA_ErrorControl_(error, previous_error, l2_error);
-      if (ierr == SOLVER_CONVERGED) return num_itrs_;
-      if (ierr != SOLVER_CONTINUE) return ierr;
-    }
-
-    // Monitor the NKA'd PC'd residual.
-    if (monitor_ == SOLVER_MONITOR_UPDATE) {
-      previous_error = error;
-      error = fn_->ErrorNorm(u, du);
-      residual_ = error;
-      l2_error = du->norm2();
-
-      int ierr = NKA_ErrorControl_(error, previous_error, l2_error);
-      if (ierr == SOLVER_CONVERGED) return num_itrs_;
-      if (ierr != SOLVER_CONTINUE) return ierr;
-    }
-
-  } while (true);
-}
-
-
-/* ******************************************************************
- * Internal convergence control.
- ****************************************************************** */
-template <class Vector, class VectorSpace>
-int
-SolverNKA<Vector, VectorSpace>::NKA_ErrorControl_(double error,
-                                                  double previous_error,
-                                                  double l2_error)
-{
-  if (vo_->os_OK(Teuchos::VERB_HIGH))
-    *vo_->os() << num_itrs_ << ": error=" << error << "  L2-error=" << l2_error
-               << std::endl;
-
-  if (error < tol_) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solver converged: " << num_itrs_
-                 << " itrs, error=" << error << std::endl;
-    return SOLVER_CONVERGED;
-  } else if (error > overflow_tol_) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solve failed, error " << error << " > " << overflow_tol_
-                 << " (overflow)" << std::endl;
-    return SOLVER_OVERFLOW;
-  } else if ((num_itrs_ > 1) &&
-             (error > max_error_growth_factor_ * previous_error)) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solver threatens to overflow, error " << error << " > "
-                 << previous_error << " (previous error)" << std::endl;
-    return SOLVER_OVERFLOW;
   }
-  return SOLVER_CONTINUE;
+
+  // Either we aren't using the NKA iteration due to lag, or because it was
+  // bad.  Try the direct preconditioned correction.
+  if (this->modify_correction_) {
+    bool hacked = this->fn_->ModifyCorrection(r, u, du);
+  }
+  if (this->fn_->IsAdmissible(du)) return std::make_pair(MonitorStatus::CONTINUE, (double) -1.0);
+  else return std::make_pair(MonitorStatus::INADMISSIBLE_SOLUTION, (double) -1.0);
 }
 
 } // namespace AmanziSolvers

--- a/src/solvers/SolverNewton.hh
+++ b/src/solvers/SolverNewton.hh
@@ -27,332 +27,54 @@
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 
-#include "VerboseObject.hh"
-
-#include "Solver.hh"
-#include "SolverFnBase.hh"
 #include "SolverDefs.hh"
+#include "SolverDefault.hh"
 
 namespace Amanzi {
 namespace AmanziSolvers {
 
 template <class Vector, class VectorSpace>
-class SolverNewton : public Solver<Vector, VectorSpace> {
+class SolverNewton : public SolverDefault<Vector, VectorSpace> {
  public:
-  SolverNewton(Teuchos::ParameterList& plist) : plist_(plist) {};
+  SolverNewton(Teuchos::ParameterList& plist)
+      : SolverDefault<Vector,VectorSpace>(plist)
+  {
+    // update the verbose options
+    this->vo_ = Teuchos::rcp(new VerboseObject(name(), plist));
+  }
 
   SolverNewton(Teuchos::ParameterList& plist,
                const Teuchos::RCP<SolverFnBase<Vector>>& fn,
                const VectorSpace& map)
-    : plist_(plist)
+      : SolverNewton(plist)
   {
     Init(fn, map);
   }
 
-  virtual void
-  Init(const Teuchos::RCP<SolverFnBase<Vector>>& fn,
-       const Teuchos::RCP<const VectorSpace>& map) override;
+  virtual std::string name() const override { return "Solver::Newton"; }
 
-  virtual int Solve(const Teuchos::RCP<Vector>& u) override
-  {
-    returned_code_ = Newton_(u);
-    return (returned_code_ >= 0) ? 0 : 1;
-  }
-
-  // mutators
+ protected:
   //
-  // These may be legacy?  Is there an adaptive reason for these to need
-  // setters and not come from the plist?
-  void set_tolerance(double tol) { tol_ = tol; }
-  void set_pc_lag(double pc_lag){}; // Newton does not need it
+  // Newton's ModifyCorrection() does basically nothing other than check that
+  // the correction supplied by the predictor is admissible.
+  virtual std::pair<MonitorStatus,double> ModifyCorrection_(Teuchos::RCP<Vector>& r,
+          const Teuchos::RCP<Vector>& u, Teuchos::RCP<Vector>& du) override;
 
-  // access
-  double tolerance() { return tol_; }
-  double residual() { return residual_; }
-  int num_itrs() { return num_itrs_; }
-  int pc_calls() { return pc_calls_; }
-  int pc_updates() { return pc_calls_; }
-  int returned_code() { return returned_code_; }
-
- private:
-  void Init_();
-
- protected:
-  int Newton_(const Teuchos::RCP<Vector>& u);
-  int Newton_ErrorControl_(double error, double previous_error, double l2_error,
-                           double previous_du_norm, double du_norm);
-
- protected:
-  Teuchos::ParameterList plist_;
-  Teuchos::RCP<SolverFnBase<Vector>> fn_;
-
-  Teuchos::RCP<VerboseObject> vo_;
-
- private:
-  double tol_, overflow_tol_;
-
-  int max_itrs_, num_itrs_, returned_code_;
-  int fun_calls_, pc_calls_;
-  int max_error_growth_factor_, max_du_growth_factor_;
-  int max_divergence_count_, stagnation_itr_check_;
-
-  bool modify_correction_;
-  double residual_;
-  ConvergenceMonitor monitor_;
+  
 };
 
-
-/* ******************************************************************
- * Public Init method.
- ****************************************************************** */
 template <class Vector, class VectorSpace>
-void
-SolverNewton<Vector, VectorSpace>::Init(
-  const Teuchos::RCP<SolverFnBase<Vector>>& fn,
-  const Teuchos::RCP<const VectorSpace>& map)
+std::pair<MonitorStatus,double>
+SolverNewton<Vector,VectorSpace>::ModifyCorrection_(Teuchos::RCP<Vector>& r,
+        const Teuchos::RCP<Vector>& u, Teuchos::RCP<Vector>& du)
 {
-  fn_ = fn;
-  Init_();
-}
-
-
-/* ******************************************************************
- * Initialization of the Newton solver
- ****************************************************************** */
-template <class Vector, class VectorSpace>
-void
-SolverNewton<Vector, VectorSpace>::Init_()
-{
-  tol_ = plist_.get<double>("nonlinear tolerance", 1.0e-6);
-
-  overflow_tol_ = plist_.get<double>("diverged tolerance", 1.0e10);
-
-  max_itrs_ = plist_.get<int>("limit iterations", 50);
-
-  max_du_growth_factor_ = plist_.get<double>("max du growth factor", 1.0e5);
-  max_error_growth_factor_ =
-    plist_.get<double>("max error growth factor", 1.0e5);
-  max_divergence_count_ = plist_.get<int>("max divergent iterations", 3);
-
-  stagnation_itr_check_ = plist_.get<int>("stagnation iteration check", 8);
-  modify_correction_ = plist_.get<bool>("modify correction", true);
-
-  std::string monitor_name =
-    plist_.get<std::string>("monitor", "monitor update");
-  if (monitor_name == "monitor update") {
-    monitor_ = SOLVER_MONITOR_UPDATE; // default value
-  } else if (monitor_name == "monitor residual") {
-    monitor_ = SOLVER_MONITOR_RESIDUAL;
-  } else {
-    Errors::Message m;
-    m << "SolverNewton: Invalid monitor \"" << monitor_name << "\"";
-    Exceptions::amanzi_throw(m);
+  // Hack the correction
+  if (this->modify_correction_) {
+    bool hacked = this->fn_->ModifyCorrection(r, u, du);
   }
 
-  fun_calls_ = 0;
-  pc_calls_ = 0;
-
-  residual_ = -1.0;
-
-  // update the verbose options
-  vo_ = Teuchos::rcp(new VerboseObject("Solver::Newton", plist_));
-}
-
-
-/* ******************************************************************
- * Base Newton solver
- ****************************************************************** */
-template <class Vector, class VectorSpace>
-int
-SolverNewton<Vector, VectorSpace>::Newton_(const Teuchos::RCP<Vector>& u)
-{
-  Teuchos::OSTab tab = vo_->getOSTab();
-
-  // initialize the iteration and pc counters
-  num_itrs_ = 0;
-  pc_calls_ = 0;
-
-  // create storage
-  auto r = Teuchos::rcp(new Vector(u->getMap()));
-  auto du = Teuchos::rcp(new Vector(u->getMap()));
-
-  // variables to monitor the progress of the nonlinear solver
-  double error(0.0), previous_error(0.0), l2_error(0.0);
-  double l2_error_initial(0.0), u_norm(0.);
-  double res_l2(0.0), res_inf(0.0);
-  double du_l2(0.0), du_inf(0.0);
-  double du_norm(1.0), previous_du_norm(1.0);
-  int divergence_count(0);
-
-  do {
-    // Check for too many nonlinear iterations.
-    if (num_itrs_ > max_itrs_) {
-      if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-        *vo_->os() << "Solve reached maximum of iterations " << num_itrs_
-                   << "  error=" << error << std::endl;
-      return SOLVER_MAX_ITERATIONS;
-    }
-
-    // Evaluate the nonlinear function.
-    if (vo_->os_OK(Teuchos::VERB_EXTREME))
-      *vo_->os() << "Calling residual function" << std::endl;
-    fun_calls_++;
-    fn_->Residual(u, r);
-
-    // If monitoring the residual, check for convergence.
-    if (monitor_ == SOLVER_MONITOR_RESIDUAL) {
-      if (vo_->os_OK(Teuchos::VERB_EXTREME))
-        *vo_->os() << "Monitoring residual" << std::endl;
-      previous_error = error;
-      error = fn_->ErrorNorm(u, r);
-      residual_ = error;
-
-      l2_error = r->norm2();
-      u_norm = u->norm2();
-      if (vo_->os_OK(Teuchos::VERB_HIGH))
-        *vo_->os() << "||u||=" << u_norm << " ||r||=" << l2_error
-                   << " error=" << error << std::endl;
-
-      // attempt to catch non-convergence early
-      if (num_itrs_ == 0) {
-        l2_error_initial = l2_error;
-      } else if (num_itrs_ > stagnation_itr_check_) {
-        if (l2_error > l2_error_initial) {
-          if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-            *vo_->os() << "Solver stagnating, L2-error=" << l2_error << " > "
-                       << l2_error_initial << " (initial L2-error)"
-                       << std::endl;
-          return SOLVER_STAGNATING;
-        }
-      }
-
-      int ierr = Newton_ErrorControl_(
-        error, previous_error, l2_error, previous_du_norm, du_norm);
-      if (ierr == SOLVER_CONVERGED) return num_itrs_;
-      if (ierr != SOLVER_CONTINUE) return ierr;
-    }
-
-    // Update the preconditioner.
-    if (vo_->os_OK(Teuchos::VERB_EXTREME))
-      *vo_->os() << "Updating preconditioner" << std::endl;
-    pc_calls_++;
-    fn_->UpdatePreconditioner(u);
-
-    // Apply the preconditioner to the nonlinear residual.
-    pc_calls_++;
-    res_l2 = r->norm2();
-    res_inf = r->normInf();
-
-    if (vo_->os_OK(Teuchos::VERB_EXTREME))
-      *vo_->os() << "Applying preconditioner" << std::endl;
-    int pc_error = fn_->ApplyPreconditioner(r, du);
-    if (pc_error < 0) return SOLVER_LINEAR_SOLVER_ERROR;
-
-    du_l2 = du->norm2();
-    du_inf = du->normInf();
-
-    // Hack the correction
-    if (modify_correction_) {
-      if (vo_->os_OK(Teuchos::VERB_EXTREME))
-        *vo_->os() << "Modifying correction" << std::endl;
-      bool hacked = fn_->ModifyCorrection(r, u, du);
-    }
-
-    // Make sure that we do not diverge and cause numerical overflow.
-    previous_du_norm = du_norm;
-    du_norm = du->normInf();
-
-    if ((num_itrs_ > 0) &&
-        (du_norm > max_du_growth_factor_ * previous_du_norm)) {
-      if (vo_->os_OK(Teuchos::VERB_HIGH))
-        *vo_->os() << "Solver threatens to overflow: "
-                   << "  ||du||=" << du_norm
-                   << ", ||du_prev||=" << previous_du_norm << std::endl;
-
-      // If it fails again, give up.
-      if ((num_itrs_ > 0) &&
-          (du_norm > max_du_growth_factor_ * previous_du_norm)) {
-        if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-          *vo_->os() << "Solver threatens to overflow: FAIL." << std::endl
-                     << "||du||=" << du_norm
-                     << ", ||du_prev||=" << previous_du_norm << std::endl;
-        return SOLVER_OVERFLOW;
-      }
-    }
-
-    // Keep track of diverging iterations
-    if (num_itrs_ > 0 && du_norm >= previous_du_norm) {
-      // The solver is threatening to diverge.
-      divergence_count++;
-
-      // If it does not recover quickly, abort.
-      if (divergence_count == max_divergence_count_) {
-        if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-          *vo_->os() << "Solver is diverging repeatedly, FAIL." << std::endl;
-        return SOLVER_DIVERGING;
-      }
-    } else {
-      divergence_count = 0;
-    }
-
-    // Next solution iterate and error estimate: u  = u - du
-    u->update(-1.0, *du, 1.0);
-    fn_->ChangedSolution();
-
-    // Increment iteration counter.
-    num_itrs_++;
-
-    // If we monitor the update...
-    if (monitor_ == SOLVER_MONITOR_UPDATE) {
-      if (vo_->os_OK(Teuchos::VERB_EXTREME))
-        *vo_->os() << "Monitoring Update" << std::endl;
-      previous_error = error;
-      error = fn_->ErrorNorm(u, du);
-      residual_ = error;
-      l2_error = du->norm2();
-
-      int ierr = Newton_ErrorControl_(
-        error, previous_error, l2_error, previous_du_norm, du_norm);
-      if (ierr == SOLVER_CONVERGED) return num_itrs_;
-      if (ierr != SOLVER_CONTINUE) return ierr;
-    }
-  } while (true);
-}
-
-
-/* ******************************************************************
- * Internal error control
- ****************************************************************** */
-template <class Vector, class VectorSpace>
-int
-SolverNewton<Vector, VectorSpace>::Newton_ErrorControl_(double error,
-                                                        double previous_error,
-                                                        double l2_error,
-                                                        double previous_du_norm,
-                                                        double du_norm)
-{
-  if (vo_->os_OK(Teuchos::VERB_HIGH))
-    *vo_->os() << num_itrs_ << ": error=" << error << "  L2-error=" << l2_error
-               << " contr. factor=" << du_norm / previous_du_norm << std::endl;
-
-  if (error < tol_) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solver converged: " << num_itrs_
-                 << " itrs, error=" << error << std::endl;
-    return SOLVER_CONVERGED;
-  } else if (error > overflow_tol_) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solve failed, error " << error << " > " << overflow_tol_
-                 << " (overflow)" << std::endl;
-    return SOLVER_OVERFLOW;
-  } else if ((num_itrs_ > 1) &&
-             (error > max_error_growth_factor_ * previous_error)) {
-    if (vo_->os_OK(Teuchos::VERB_MEDIUM))
-      *vo_->os() << "Solver threatens to overflow, error " << error << " > "
-                 << previous_error << " (previous error)" << std::endl;
-    return SOLVER_OVERFLOW;
-  }
-  return SOLVER_CONTINUE;
+  if (this->fn_->IsAdmissible(du)) return std::make_pair(MonitorStatus::CONTINUE, (double) -1.0);
+  else return std::make_pair(MonitorStatus::INADMISSIBLE_SOLUTION, (double) -1.0);
 }
 
 } // namespace AmanziSolvers

--- a/src/solvers/test/solvers_nonlinear.cc
+++ b/src/solvers/test/solvers_nonlinear.cc
@@ -79,7 +79,8 @@ SUITE(SOLVERS)
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NKA_SOLVER_EXACT_JACOBIAN)
   {
-    std::cout << "NKA solver, exact Jacobian..." << std::endl;
+    std::cout << "NKA solver, exact Jacobian..." << std::endl
+              << "-----------------------------" << std::endl;
 
     // create the function class
     auto fn = Teuchos::rcp(new NonlinearProblem(1.0, 1.0, true));
@@ -104,7 +105,10 @@ SUITE(SOLVERS)
 
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NKA_SOLVER_EXACT_JACOBIAN_GLOBALIZED) {
-    std::cout << "NKA solver, exact Jacobian, unstable problem..." << std::endl;
+    std::cout << std::endl
+              << "NKA solver, exact Jacobian, unstable problem..." << std::endl
+              << "-----------------------------------------------" << std::endl;
+        
 
     // create the function class
     auto fn = Teuchos::rcp(new NonlinearProblem6(1.0, 1.0, true, 0.2));
@@ -129,7 +133,9 @@ SUITE(SOLVERS)
 
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NKA_SOLVER_INEXACT_JACOBIAN) {
-    std::cout << "\nNKA solver, inexact Jacobian..." << std::endl;
+    std::cout << std::endl
+              << "NKA solver, inexact Jacobian..." << std::endl
+              << "-------------------------------" << std::endl;
 
     // create the function class
     auto fn = Teuchos::rcp(new NonlinearProblem(1.0, 1.0, false));
@@ -155,7 +161,9 @@ SUITE(SOLVERS)
 
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NKA_SOLVER_INEXACT_JACOBIAN_GLOBALIZED) {
-    std::cout << "\nNKA solver, inexact Jacobian, unstable problem..." << std::endl;
+    std::cout << std::endl
+              << "NKA solver, inexact Jacobian, unstable problem..." << std::endl
+              << "-------------------------------------------------" << std::endl;
 
     // create the function class
     Teuchos::RCP<NonlinearProblem6> fn = Teuchos::rcp(new
@@ -182,7 +190,9 @@ SUITE(SOLVERS)
 
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NEWTON_SOLVER) {
-    std::cout << "\nNewton solver..." << std::endl;
+    std::cout << std::endl
+              << "Newton solver, exact Jacobian..." << std::endl
+              << "--------------------------------" << std::endl;
 
     // create the function class
     auto fn = Teuchos::rcp(new NonlinearProblem(1.0, 1.0, true));
@@ -206,7 +216,9 @@ SUITE(SOLVERS)
 
   /* ******************************************************************/
   TEST_FIXTURE(test_data, NEWTON_SOLVER_NO_GLOBALIZATION_FAILS) {
-    std::cout << "\nNewton solver, unstable problem..." << std::endl;
+    std::cout << std::endl
+              << "Newton solver, exact Jacobian, unstable problem..." << std::endl
+              << "--------------------------------------------------" << std::endl;
 
     // create the function class
     auto fn = Teuchos::rcp(new NonlinearProblem6(1.0, 1.0, true, 0.2));

--- a/src/time_integration/BDF1_TI.hh
+++ b/src/time_integration/BDF1_TI.hh
@@ -270,18 +270,19 @@ BDF1_TI<Vector, VectorSpace>::TimeStep(double dt,
   int ierr, code, itr;
   try {
     ierr = solver_->Solve(u);
-    itr = solver_->num_itrs();
+    itr = solver_->num_iterations();
     code = solver_->returned_code();
   } catch (const Errors::CutTimeStep& e) {
     ierr = 1;
     itr = -1; // This should not be summed up into the global counter.
-    code = AmanziSolvers::SOLVER_INTERNAL_EXCEPTION;
+    code = solver_->returned_code();
   }
 
   if (ierr == 0) {
     if (vo_->os_OK(Teuchos::VERB_HIGH)) {
       *vo_->os() << "success: " << itr << " nonlinear itrs"
-                 << " error=" << solver_->residual() << std::endl;
+                 << " residual=" << solver_->residual()
+                 << " error=" << solver_->error() << std::endl;
     }
   } else {
     if (vo_->os_OK(Teuchos::VERB_HIGH)) {
@@ -311,7 +312,7 @@ BDF1_TI<Vector, VectorSpace>::TimeStep(double dt,
   solver_->set_pc_lag(state_->pc_lag);
 
   // update performance statistics
-  state_->solve_itrs += solver_->num_itrs();
+  state_->solve_itrs += solver_->num_iterations();
   state_->pc_updates += solver_->pc_updates();
   state_->pc_calls += solver_->pc_calls();
 


### PR DESCRIPTION
major refactor of how nonlinear solvers work -- standardizes their interface into an abstraction where each method provides a correction, but all error control, etc, is done in a base class.  Currently tested NKA and Newton -- haven't touch JFNK, AA, Backtracking.

This brings in:

- Konstantin's changes to a norm plus a convergence monitor (i.e. can do all of L2, Linf, or user-provided ENorm for each type of convergence monitor).
- VerboseObject: LOW --> no output, MEDIUM --> output on convergence/divergence/max_iters/etc, HIGH --> output on MEDIUM plus once per iteration with the error and the L2 error.
- Standardizes input names across all solvers
- Standardizes how/when convergence tests are done, so all solvers have all options.