### PR TITLE
Adds ATS as a submodule for direct compilation within Amanzi

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/physics/ats"]
 	path = src/physics/ats
 	url = https://github.com/amanzi/ats
+        branch = dev/build_system

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/physics/ats"]
 	path = src/physics/ats
 	url = https://github.com/amanzi/ats
-        branch = dev/build_system
+        branch = dev/ats_submodule

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/physics/ats"]
+	path = src/physics/ats
+	url = https://github.com/amanzi/ats

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -130,6 +130,7 @@ shared=${FALSE}
 spacedim=2
 silo=${FALSE}
 physics=${TRUE}
+ats=${FALSE}
 build_stage_1=${FALSE}
 build_stage_2=${FALSE}
 
@@ -336,7 +337,8 @@ Value in brackets indicates default setting.
   crunchtope              build the CrunchTope geochemistry backend ['"${crunchtope}"']
   alquimia                build the Alquimia geochemistry solver APIs ['"${alquimia}"']
 
-  physics		  build subset of Amanzi used in ATS ['"${physics}"']
+  physics		  build Amanzi native physics ['"${physics}"']
+  ats   		  build Amanzi with ATS ['"${ats}"']
 
   test_suite              run Amanzi Test Suite before installing ['"${test_suite}"']
   reg_tests               build regression tests into Amanzi Test Suite ['"${reg_tests}"']
@@ -485,6 +487,7 @@ Build Features:
     pflotran            ='"${pflotran}"'
     crunchtope          ='"${crunchtope}"'
     physics             ='"${physics}"'
+    ats                 ='"${ats}"'
     Spack               ='"${Spack}"'
     xsdk                ='"${xsdk}"'
 
@@ -892,6 +895,14 @@ function build_cmake
 # ---------------------------------------------------------------------------- #
 # Git functions
 # ---------------------------------------------------------------------------- #
+function ats_git_clone
+{
+    ${git_binary} submodule update --init ats
+    if [$? -ne 0 ]; then
+        error_message "Failed to pull submodule ATS"
+        exit_now 30
+    fi
+}
 
 function ascem_git_clone
 {
@@ -1564,6 +1575,12 @@ fi
 
 status_message "Build Amanzi with configure file ${tpl_config_file}"
 
+# clone subrepos
+if [ "${ats}" ]; then
+    # MAYBE SOON? git_change_branch "ats-master"
+    ats_git_clone
+fi
+
 # Configure the Amanzi build
 cmd_configure="${cmake_binary} \
     -C${tpl_config_file} \
@@ -1586,7 +1603,8 @@ cmd_configure="${cmake_binary} \
     -DENABLE_ALQUIMIA:BOOL=${alquimia} \
     -DENABLE_PFLOTRAN:BOOL=${pflotran} \
     -DENABLE_CRUNCHTOPE:BOOL=${crunchtope} \
-    -DENABLE_Physics:BOOL=${physics} \
+    -DENABLE_NativePhysics:BOOL=${physics} \
+    -DENABLE_ATS:BOOL=${ats} \
     -DBUILD_SHARED_LIBS:BOOL=${shared} \
     -DCCSE_BL_SPACEDIM:INT=${spacedim} \
     -DENABLE_Regression_Tests:BOOL=${reg_tests} \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -897,6 +897,8 @@ function build_cmake
 # ---------------------------------------------------------------------------- #
 function ats_git_clone
 {
+    error_message "should not be cloning ats..."
+    exit_now 30
     # have to deal with branches at some point?
     ${git_binary} submodule update --init --remote ats
     if [$? -ne 0 ]; then
@@ -1577,7 +1579,7 @@ fi
 status_message "Build Amanzi with configure file ${tpl_config_file}"
 
 # clone subrepos
-if [ "${ats}" ]; then
+if [ "${ats}" -eq "${TRUE}" ]; then
     ats_git_clone
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -897,7 +897,8 @@ function build_cmake
 # ---------------------------------------------------------------------------- #
 function ats_git_clone
 {
-    ${git_binary} submodule update --init ats
+    # have to deal with branches at some point?
+    ${git_binary} submodule update --init --remote ats
     if [$? -ne 0 ]; then
         error_message "Failed to pull submodule ATS"
         exit_now 30
@@ -1577,7 +1578,6 @@ status_message "Build Amanzi with configure file ${tpl_config_file}"
 
 # clone subrepos
 if [ "${ats}" ]; then
-    # MAYBE SOON? git_change_branch "ats-master"
     ats_git_clone
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -897,10 +897,8 @@ function build_cmake
 # ---------------------------------------------------------------------------- #
 function ats_git_clone
 {
-    error_message "should not be cloning ats..."
-    exit_now 30
     # have to deal with branches at some point?
-    ${git_binary} submodule update --init --remote ats
+    ${git_binary} submodule update --init --remote src/physics/ats
     if [$? -ne 0 ]; then
         error_message "Failed to pull submodule ATS"
         exit_now 30

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,24 +56,32 @@ endif()
 
 add_subdirectory(common/interface_platform)
 
+message(STATUS "Amanzi: enabled physics packages:")
+message(STATUS "=================================")
+message(STATUS "Native: ${ENABLE_NativePhysics}")
+message(STATUS "ATS: ${ENABLE_ATS}")
+
+
 if (ENABLE_Unstructured)  
   add_subdirectory(pks)
 
-  if (ENABLE_Physics)
+  if (ENABLE_NativePhysics)
      # Multiprocess coordinator
      add_subdirectory(mpc)
 
      # unstructured grid simulation driver, and Amanzi binaries
      add_subdirectory(executables)
-  endif()
+   endif()
+
+   add_subdirectory(physics)
 endif()
 
 # structured grid
-if (ENABLE_Structured AND ENABLE_Physics)
+if (ENABLE_Structured AND ENABLE_NativePhysics)
   add_subdirectory(structured_grid)
 endif()
 
 # standalone driver (produces mesh-independent executable)
-if (ENABLE_Physics)
+if (ENABLE_NativePhysics)
   add_subdirectory(common/standalone_simulation_coordinator)
 endif()

--- a/src/physics/CMakeLists.txt
+++ b/src/physics/CMakeLists.txt
@@ -1,0 +1,3 @@
+if (ENABLE_ATS)
+  add_subdirectory(ats)
+endif()

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -81,7 +81,7 @@ add_install_include_file(${pks_inc_files})
 if (BUILD_TESTS) 
 endif()
 
-if (ENABLE_NativePhysics)
+if (ENABLE_AmanziPhysicsModule)
   add_subdirectory(eos)
   add_subdirectory(flow)
   add_subdirectory(navier_stokes)
@@ -93,7 +93,7 @@ add_subdirectory(chemistry)
 # ok, transport is physics but oh well...
 add_subdirectory(transport)
 
-if (ENABLE_NativePhysics)
+if (ENABLE_AmanziPhysicsModule)
   add_subdirectory(energy)
   add_subdirectory(dummy)
 endif()

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -81,7 +81,7 @@ add_install_include_file(${pks_inc_files})
 if (BUILD_TESTS) 
 endif()
 
-if (ENABLE_Physics)
+if (ENABLE_NativePhysics)
   add_subdirectory(eos)
   add_subdirectory(flow)
   add_subdirectory(navier_stokes)
@@ -93,7 +93,7 @@ add_subdirectory(chemistry)
 # ok, transport is physics but oh well...
 add_subdirectory(transport)
 
-if (ENABLE_Physics)
+if (ENABLE_NativePhysics)
   add_subdirectory(energy)
   add_subdirectory(dummy)
 endif()

--- a/src/pks/mpc_pk/CMakeLists.txt
+++ b/src/pks/mpc_pk/CMakeLists.txt
@@ -49,7 +49,7 @@ include_directories(${ASCEMIO_INCLUDE_DIR})
 #
 # Install Targets
 #
-if (ENABLE_Physics)
+if (ENABLE_AmanziPhysicsModule)
   set(mpc_tree_inc_files
       PK_MPCStrong.hh
       PK_MPCWeak.hh
@@ -126,7 +126,7 @@ if (BUILD_TESTS)
     set(amanzi_libs geometry mesh mesh_audit mesh_factory state energy operators whetstone data_structures)
 
     # Test: 1
-    #if (ENABLE_Physics) 
+    #if (ENABLE_AmanziPhysicsModule) 
     #  add_amanzi_test(energy_test energy_test
     #                  KIND int
     #                  SOURCE test/Main.cc test/energy_test.cc

--- a/src/utils/Factory.hh
+++ b/src/utils/Factory.hh
@@ -110,6 +110,7 @@ public:
 
 protected:
   static map_type* GetMap() {
+    static map_type* map_;
     if (!map_) {
       map_ = new map_type;
     }

--- a/tools/cmake/AmanziOptions.cmake
+++ b/tools/cmake/AmanziOptions.cmake
@@ -91,5 +91,7 @@ include(RegisterEvaluators)
 option(ENABLE_NewTimeIntegrators "Build Amanzi with dev time integrators" FALSE)
 
 # Turn off physics, just build the framework
-option(ENABLE_Physics "Build Amanzi with physics libraries" TRUE)
+option(ENABLE_NativePhysics "Build Amanzi with native physics libraries" TRUE)
+option(ENABLE_ATS "Build Amanzi with ATS" FALSE)
+
 


### PR DESCRIPTION
This allows ATS to be directly downloaded from Amanzi:

```
git submodule update --init --remote
```

and then installed via bootstrap:

```
bootstrap.sh ... --disable-physics --enable-ats
```
