### PR TITLE
minor updates for use of domain sets, adds override qualifiers to silence clang warnings

### DIFF
--- a/src/mesh/mesh_mstk/MeshSurfaceCell.hh
+++ b/src/mesh/mesh_mstk/MeshSurfaceCell.hh
@@ -56,7 +56,7 @@ class MeshSurfaceCell : public Mesh {
 
   // Parent entity in the source mesh if mesh was derived from another mesh
   virtual
-  Entity_ID entity_get_parent(const Entity_kind kind, const Entity_ID entid) const {
+  Entity_ID entity_get_parent(const Entity_kind kind, const Entity_ID entid) const override {
     AMANZI_ASSERT(kind == CELL);
     AMANZI_ASSERT(entid == 0);
     return parent_face_;
@@ -64,7 +64,7 @@ class MeshSurfaceCell : public Mesh {
 
   // Get cell type - UNKNOWN, TRI, QUAD, ... See MeshDefs.hh
   virtual
-  Cell_type cell_get_type(const Entity_ID cellid) const {
+  Cell_type cell_get_type(const Entity_ID cellid) const override {
     return cell_type_;
   }
 
@@ -78,11 +78,11 @@ class MeshSurfaceCell : public Mesh {
   // particular category (OWNED, GHOST, ALL)
   virtual
   unsigned int num_entities(const Entity_kind kind,
-                            const Parallel_type ptype) const;
+                            const Parallel_type ptype) const override;
 
   // Global ID of any entity
   virtual
-  Entity_ID GID(const Entity_ID lid, const Entity_kind kind) const {
+  Entity_ID GID(const Entity_ID lid, const Entity_kind kind) const override {
     return lid;
   }
 
@@ -97,7 +97,7 @@ class MeshSurfaceCell : public Mesh {
   // Get nodes of a cell
   virtual
   void cell_get_nodes(const Entity_ID cellid,
-                      Entity_ID_List *nodeids) const;
+                      Entity_ID_List *nodeids) const override;
 
   // Get nodes of face
   // On a distributed mesh, all nodes (OWNED or GHOST) of the face
@@ -107,12 +107,12 @@ class MeshSurfaceCell : public Mesh {
   // In 2D, nfnodes is 2
   virtual
   void face_get_nodes(const Entity_ID faceid,
-                      Entity_ID_List *nodeids) const;
+                      Entity_ID_List *nodeids) const override;
 
   // Get nodes of edge
   virtual
   void edge_get_nodes(const Entity_ID edgeid,
-                      Entity_ID *nodeid0, Entity_ID *nodeid1) const;
+                      Entity_ID *nodeid0, Entity_ID *nodeid1) const override;
 
   // Upward adjacencies
   //-------------------
@@ -123,7 +123,7 @@ class MeshSurfaceCell : public Mesh {
   virtual
   void node_get_cells(const Entity_ID nodeid,
                       const Parallel_type ptype,
-                      Entity_ID_List *cellids) const;
+                      Entity_ID_List *cellids) const override;
 
   // Faces of type 'ptype' connected to a node - The order of faces is
   // not guarnateed to be the same for corresponding nodes on
@@ -131,7 +131,7 @@ class MeshSurfaceCell : public Mesh {
   virtual
   void node_get_faces(const Entity_ID nodeid,
                       const Parallel_type ptype,
-                      Entity_ID_List *faceids) const;
+                      Entity_ID_List *faceids) const override;
 
   // Get faces of ptype of a particular cell that are connected to the
   // given node - The order of faces is not guarnateed to be the same
@@ -140,12 +140,12 @@ class MeshSurfaceCell : public Mesh {
   void node_get_cell_faces(const Entity_ID nodeid,
                            const Entity_ID cellid,
                            const Parallel_type ptype,
-                           Entity_ID_List *faceids) const;
+                           Entity_ID_List *faceids) const override;
   // Cells of type 'ptype' connected to an edges
   virtual
   void edge_get_cells(const Entity_ID edgeid,
                       const Parallel_type ptype,
-                      Entity_ID_List *cellids) const;
+                      Entity_ID_List *cellids) const override;
 
   // Same level adjacencies
   //-----------------------
@@ -160,7 +160,7 @@ class MeshSurfaceCell : public Mesh {
   virtual
   void cell_get_face_adj_cells(const Entity_ID cellid,
           const Parallel_type ptype,
-          Entity_ID_List *fadj_cellids) const;
+          Entity_ID_List *fadj_cellids) const override;
 
   // Node connected neighboring cells of given cell
   // (a hex in a structured mesh has 26 node connected neighbors)
@@ -168,7 +168,7 @@ class MeshSurfaceCell : public Mesh {
   virtual
   void cell_get_node_adj_cells(const Entity_ID cellid,
           const Parallel_type ptype,
-          Entity_ID_List *nadj_cellids) const;
+          Entity_ID_List *nadj_cellids) const override;
 
 
 
@@ -180,7 +180,7 @@ class MeshSurfaceCell : public Mesh {
   // Node coordinates - 3 in 3D and 2 in 2D
   virtual
   void node_get_coordinates(const Entity_ID nodeid,
-                            AmanziGeometry::Point *ncoord) const {
+                            AmanziGeometry::Point *ncoord) const override {
     (*ncoord) = nodes_[nodeid];
   }
 
@@ -189,7 +189,7 @@ class MeshSurfaceCell : public Mesh {
   // Number of nodes is the vector size divided by number of spatial dimensions
   virtual
   void face_get_coordinates(const Entity_ID faceid,
-                            std::vector<AmanziGeometry::Point> *fcoords) const {
+                            std::vector<AmanziGeometry::Point> *fcoords) const override {
     fcoords->resize(2);
     (*fcoords)[0] = nodes_[faceid];
     (*fcoords)[1] = nodes_[(faceid + 1) % nodes_.size()];
@@ -202,7 +202,7 @@ class MeshSurfaceCell : public Mesh {
   // Number of nodes is vector size divided by number of spatial dimensions
   virtual
   void cell_get_coordinates(const Entity_ID cellid,
-                            std::vector<AmanziGeometry::Point> *ccoords) const {
+                            std::vector<AmanziGeometry::Point> *ccoords) const override {
     (*ccoords) = nodes_;
   }
 
@@ -214,14 +214,14 @@ class MeshSurfaceCell : public Mesh {
   // Set coordinates of node
   virtual
   void node_set_coordinates(const Entity_ID nodeid,
-                            const AmanziGeometry::Point ncoord) {
+                            const AmanziGeometry::Point ncoord) override {
     nodes_[nodeid] = ncoord;
   }
 
 
   virtual
   void node_set_coordinates(const Entity_ID nodeid,
-                            const double *ncoord) {
+                            const double *ncoord) override {
     
     Errors::Message mesg("Not implemented");
     Exceptions::amanzi_throw(mesg);
@@ -237,35 +237,34 @@ class MeshSurfaceCell : public Mesh {
   int deform(const std::vector<double>& target_cell_volumes_in,
              const std::vector<double>& min_cell_volumes_in,
              const Entity_ID_List& fixed_nodes,
-             const bool move_vertical);
+             const bool move_vertical) override;
   //
   // Epetra maps
   //------------
   virtual
-  const Epetra_Map& cell_map(bool include_ghost) const {
+  const Epetra_Map& cell_map(bool include_ghost) const override {
     return *cell_map_;
   }
 
   virtual
-  const Epetra_Map& face_map(bool include_ghost) const {
+  const Epetra_Map& face_map(bool include_ghost) const override {
     return *face_map_;
   }
 
   // dummy implementation so that frameworks can skip or overwrite
-  const Epetra_Map& edge_map(bool include_ghost) const
-  {
+  const Epetra_Map& edge_map(bool include_ghost) const override {
     Errors::Message mesg("Edges not implemented in this framework");
     Exceptions::amanzi_throw(mesg);
     throw(mesg);
   };
 
   virtual
-  const Epetra_Map& node_map(bool include_ghost) const {
+  const Epetra_Map& node_map(bool include_ghost) const override {
     return *face_map_;
   }
 
   virtual
-  const Epetra_Map& exterior_face_map(bool include_ghost) const {
+  const Epetra_Map& exterior_face_map(bool include_ghost) const override {
     return *face_map_;
   }
 
@@ -281,7 +280,7 @@ class MeshSurfaceCell : public Mesh {
   // Epetra vector defined on all owned faces into an Epetra vector
   // defined only on exterior faces
   virtual
-  const Epetra_Import& exterior_face_importer(void) const {
+  const Epetra_Import& exterior_face_importer(void) const override {
     return *exterior_face_importer_;
   }
 
@@ -295,31 +294,31 @@ class MeshSurfaceCell : public Mesh {
   virtual
   unsigned int get_set_size(const Set_ID setid,
                             const Entity_kind kind,
-                            const Parallel_type ptype) const;
+                            const Parallel_type ptype) const override;
 
   virtual
   unsigned int get_set_size(const std::string setname,
                             const Entity_kind kind,
-                            const Parallel_type ptype) const;
+                            const Parallel_type ptype) const override;
   
   // Get list of entities of type 'category' in set
   virtual
   void get_set_entities(const Set_ID setid,
                         const Entity_kind kind,
                         const Parallel_type ptype,
-                        Entity_ID_List *entids) const;
+                        Entity_ID_List *entids) const override;
 
   virtual
   void get_set_entities_and_vofs(const std::string setname,
           const Entity_kind kind,
           const Parallel_type ptype,
           Entity_ID_List *entids,
-          std::vector<double> *vofs) const;
+          std::vector<double> *vofs) const override;
 
 
   // Miscellaneous functions
   virtual
-  void write_to_exodus_file(const std::string filename) const;
+  void write_to_exodus_file(const std::string filename) const override;
 
  protected:
 
@@ -331,7 +330,7 @@ class MeshSurfaceCell : public Mesh {
   void cell_get_faces_and_dirs_internal_(const Entity_ID cellid,
           Entity_ID_List *faceids,
           std::vector<int> *face_dirs,
-          const bool ordered=false) const;
+          const bool ordered=false) const override;
 
   // Cells connected to a face - this function is implemented in each
   // mesh framework. The results are cached in the base class

--- a/src/state/Field_CompositeVector.hh
+++ b/src/state/Field_CompositeVector.hh
@@ -134,7 +134,7 @@ public:
   long int GetLocalElementCount();
 
 protected:
-  bool ReadCheckpoint_(std::string filename);
+  bool ReadCheckpoint_(std::string filename, Comm_ptr_type comm=Teuchos::null);
   void ReadCellsFromCheckpoint_(std::string filename); // for ICs
   void ReadAttributeFromExodusII_(Teuchos::ParameterList& plist); 
   void ReadVariableFromExodusII_(Teuchos::ParameterList& plist); 

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -197,6 +197,7 @@ void State::AliasMesh(Key target, Key alias) {
   bool deformable = IsDeformableMesh(target);
   Teuchos::RCP<AmanziMesh::Mesh> mesh = GetMesh_(target);
   RegisterMesh(alias, mesh, deformable);
+  mesh_aliases_.push_back(alias);
 };
 
 

--- a/src/state/State.hh
+++ b/src/state/State.hh
@@ -183,6 +183,9 @@ class State {
 
   // Alias a mesh to an existing mesh
   void AliasMesh(Key target, Key alias);
+  bool IsAliasedMesh(Key alias) const {
+    return !(std::find(mesh_aliases_.begin(), mesh_aliases_.end(), alias) == mesh_aliases_.end());
+  }
 
   // Remove a mesh.
   void RemoveMesh(Key key);
@@ -385,6 +388,7 @@ class State {
   void InitializeIOFlags_();
 
   // Containers
+  std::vector<Key> mesh_aliases_;
   MeshMap meshes_;
   FieldMap fields_;
   FieldFactoryMap field_factories_;

--- a/src/utils/Key.hh
+++ b/src/utils/Key.hh
@@ -60,9 +60,9 @@ getKey(const Key& domain, const Key& name)
 
 // Split a DOMAIN-VARNAME key.
 inline KeyPair
-splitKey(const Key& name)
+splitKey(const Key& name, const char split='-')
 {
-  std::size_t pos = name.find('-');
+  std::size_t pos = name.find(split);
   if (pos == std::string::npos) 
     return std::make_pair(Key(""), name);
   else


### PR DESCRIPTION
Several minor tweaks to how keys are processed:

Mostly this allows Checkpointing to happen on either a single file on MPI_COMM_WORLD or on one-file-per-process on MPI_COMM_SELF.  This is needed for column meshes, which live on MPI_COMM_SELF.  This also adds the ability to restart from such files or to grab initial conditions from such files.