### PR TITLE
Domain sets are a collection of small meshes

### DIFF
--- a/src/mesh/CMakeLists.txt
+++ b/src/mesh/CMakeLists.txt
@@ -30,9 +30,10 @@ include_directories(${Boost_INCLUDE_DIRS})
 #
 # Library: mesh
 #
-add_amanzi_library(mesh SOURCE GenerationSpec.cc 
-                               Mesh.cc 
-                               Mesh_Sets.cc 
+add_amanzi_library(mesh SOURCE GenerationSpec.cc
+                               Mesh.cc
+                               Mesh_Sets.cc
+                               DomainSet.cc
                         LINK_LIBS geometry atk ${Epetra_LIBRARIES})
 
 #

--- a/src/mesh/DomainSet.cc
+++ b/src/mesh/DomainSet.cc
@@ -1,0 +1,44 @@
+/*
+  Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL. 
+  Amanzi is released under the three-clause BSD License. 
+  The terms of use and "as is" disclaimer for this license are 
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (coonet@ornl.gov)
+*/
+
+//! A collection of meshes, indexed from a parent entity set.
+
+#include "Mesh.hh"
+#include "DomainSet.hh"
+
+namespace Amanzi {
+namespace AmanziMesh {
+
+DomainSet::DomainSet(const Teuchos::RCP<const Mesh>& parent_,
+                 const std::vector<std::string>& sets_,
+                 Entity_kind kind_,
+                 const std::string& name_)
+    : parent(parent_),
+      sets(sets_),
+      kind(kind_),
+      name(name_)
+{
+  // construct a list of names by GID
+  //
+  // NOTE: we do not check, but sets really probably should be non-overlapping?
+  for (const auto& set : sets) {
+    Entity_ID_List ids;
+    parent->get_set_entities(set, kind, Parallel_type::OWNED, &ids);
+    const auto& map = parent->map(kind, false);
+
+    for (Entity_ID id : ids) {
+      Key mesh_name = name+"_" + std::to_string(map.GID(id));
+      meshes[mesh_name] = id;
+    }
+  }
+}  
+
+
+} // namespace AmanziMesh
+} // namespace Amanzi

--- a/src/mesh/DomainSet.hh
+++ b/src/mesh/DomainSet.hh
@@ -1,0 +1,64 @@
+/*
+  Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL. 
+  Amanzi is released under the three-clause BSD License. 
+  The terms of use and "as is" disclaimer for this license are 
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (coonet@ornl.gov)
+*/
+
+//! A collection of meshes, indexed from a parent entity set.
+
+/*!
+
+A DomainSet is a collection of meshes, generated from a parent mesh and a set of
+entities on that mesh.  For instance, if the parent mesh is a 3D, vertically
+structured columnar mesh, one might create a set of meshes, each of which are
+1D and correspond to cells of the subsurface mesh.  These column meshes might
+be indexed from a set of surface faces (or from the surface mesh's cells).
+
+Alternatively, for e.g. a multi-layer snow model, a DomainSet might be a bunch of
+mini meshes constructed at each surface cell.
+
+Note, this does not actually know how to construct theses meshes, it only deals
+with their names and their relationship to the parent mesh.  To get/store the
+actual mesh, this works with State.
+
+*/
+#pragma once
+
+#include <string>
+#include <vector>
+#include "Teuchos_RCP.hpp"
+
+#include "MeshDefs.hh"
+
+namespace Amanzi {
+namespace AmanziMesh {
+
+class Mesh;
+
+struct DomainSet {
+
+  DomainSet(const Teuchos::RCP<const Mesh>& parent_,
+          const std::vector<std::string>& sets_,
+          Entity_kind kind_,
+          const std::string& name_);
+
+  using DomainSetMap = std::map<Key,Entity_ID>;
+  
+  using const_iterator = DomainSetMap::const_iterator;
+  const_iterator begin() const { return meshes.begin(); }
+  const_iterator end() const { return meshes.end(); }
+  std::size_t size() const { return meshes.size(); }
+
+  Teuchos::RCP<const Mesh> parent;
+  std::vector<std::string> sets;
+  Entity_kind kind;
+  std::string name;
+
+  DomainSetMap meshes;
+};
+
+} // namespace AmanziMesh
+} // namespace Amanzi

--- a/src/pks/PK_Factory.cc
+++ b/src/pks/PK_Factory.cc
@@ -69,52 +69,47 @@ PKFactory::CreatePK(std::string pk_name,
     bool is_ds = Keys::splitDomainSet(pk_name, pk_triple);
     if (is_ds) {
       // flyweight PKs are defined across a domain_set
-      Teuchos::Array<std::string> domain_sets;    
-      domain_sets = global_list->sublist("state")
-                    .get<Teuchos::Array<std::string> >("domain sets", domain_sets);
-      for (auto ds : domain_sets) {
-        if (ds == std::get<0>(pk_triple)) {
-          // flyweight PK, alter the sublist and construct
-          // -- get the domain name and base varname
-          Key pk_flyweight = Keys::getKey(ds+"_*", std::get<2>(pk_triple));
-          Teuchos::ParameterList pk_list_new = global_list->sublist("PKs").sublist(pk_flyweight);
+      Key ds_name = std::get<0>(pk_triple);
+      if (state->HasDomainSet(ds_name)) {
+        // flyweight PK, alter the sublist and construct
+        // -- get the domain name and base varname
+        Key pk_flyweight = Keys::getKey(ds_name+"_*", std::get<2>(pk_triple));
+        Teuchos::ParameterList pk_list_new = global_list->sublist("PKs").sublist(pk_flyweight);
 
-          // -- overwrite the domain name
-          Key new_domain = ds+"_"+std::get<1>(pk_triple);
-          if (pk_list_new.isParameter("domain name"))
-            pk_list_new.set("domain name", new_domain);
+        // -- overwrite the domain name
+        Key new_domain = ds_name+"_"+std::get<1>(pk_triple);
+        if (pk_list_new.isParameter("domain name")) pk_list_new.set("domain name", new_domain);
 
-          // -- overwrite sub pks names with prepended domain
-          if (pk_list_new.isParameter("PKs order")) {
-            auto subpks_names = pk_list_new.get<Teuchos::Array<std::string> >("PKs order");
-            for (auto& subpk_name : subpks_names) {
-              KeyTriple subpk_triple;
-              bool subpk_is_ds = Keys::splitDomainSet(subpk_name, subpk_triple);
+        // -- overwrite sub pks names with prepended domain
+        if (pk_list_new.isParameter("PKs order")) {
+          auto subpks_names = pk_list_new.get<Teuchos::Array<std::string> >("PKs order");
+          for (auto& subpk_name : subpks_names) {
+            KeyTriple subpk_triple;
+            bool subpk_is_ds = Keys::splitDomainSet(subpk_name, subpk_triple);
 
-              if (subpk_is_ds) {
-                subpk_name = Keys::getKey(std::get<0>(subpk_triple)+"_"+std::get<1>(pk_triple),
-                        std::get<2>(subpk_triple));
-              }
+            if (subpk_is_ds) {
+              subpk_name = Keys::getKey(std::get<0>(subpk_triple)+"_"+std::get<1>(pk_triple),
+                      std::get<2>(subpk_triple));
             }
-            pk_list_new.set("PKs order", subpks_names);
           }
-            
-          // push into the PKs list
-          global_list->sublist("PKs").set(pk_name, pk_list_new);
-
-          // get the flyweight subtree
-          if (!pk_tree.isSublist(pk_flyweight)) {
-            std::stringstream msg;
-            msg << "PK_Factory: PK \"" << pk_name << "\" is a flyweight, but missing flyweight PK spec \""
-                << pk_flyweight << "\"\n";
-            Errors::Message message(msg.str());
-            Exceptions::amanzi_throw(message);
-          }            
-          pk_subtree = pk_tree.sublist(pk_flyweight);
-          pk_subtree.setName(pk_name);
-
-          pk_subtree_found = true;
+          pk_list_new.set("PKs order", subpks_names);
         }
+            
+        // push into the PKs list
+        global_list->sublist("PKs").set(pk_name, pk_list_new);
+
+        // get the flyweight subtree
+        if (!pk_tree.isSublist(pk_flyweight)) {
+          std::stringstream msg;
+          msg << "PK_Factory: PK \"" << pk_name << "\" is a flyweight, but missing flyweight PK spec \""
+              << pk_flyweight << "\"\n";
+          Errors::Message message(msg.str());
+          Exceptions::amanzi_throw(message);
+        }            
+        pk_subtree = pk_tree.sublist(pk_flyweight);
+        pk_subtree.setName(pk_name);
+
+        pk_subtree_found = true;
       }
     }
   }

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -24,6 +24,9 @@ initialized (as independent variables are owned by state, not by any PK).
 #include "Epetra_Vector.h"
 
 #include "errors.hh"
+#include "Mesh.hh"
+#include "DomainSet.hh"
+#include "MeshPartition.hh"
 #include "CompositeVector.hh"
 #include "FieldEvaluator_Factory.hh"
 #include "cell_volume_evaluator.hh"
@@ -186,26 +189,31 @@ void State::RegisterDomainMesh(const Teuchos::RCP<AmanziMesh::Mesh>& mesh,
 }
 
 
-void State::RegisterMesh(Key key,
+void State::RegisterMesh(const Key& key,
                          const Teuchos::RCP<AmanziMesh::Mesh>& mesh,
                          bool deformable) {
   meshes_.insert(std::make_pair(key, std::make_pair(mesh,deformable)));
 };
 
 
-void State::AliasMesh(Key target, Key alias) {
+void State::AliasMesh(const Key& target, const Key& alias) {
   bool deformable = IsDeformableMesh(target);
   Teuchos::RCP<AmanziMesh::Mesh> mesh = GetMesh_(target);
   RegisterMesh(alias, mesh, deformable);
+  mesh_aliases_[target] = alias;
 };
 
+bool State::IsAliasedMesh(const Key& key) const {
+  return (bool) mesh_aliases_.count(key);
+}
 
-void State::RemoveMesh(Key key) {
+
+void State::RemoveMesh(const Key& key) {
   meshes_.erase(key);
 };
 
 
-Teuchos::RCP<const AmanziMesh::Mesh> State::GetMesh(Key key) const {
+Teuchos::RCP<const AmanziMesh::Mesh> State::GetMesh(const Key& key) const {
   Teuchos::RCP<const AmanziMesh::Mesh> mesh;
   if (key.empty()) {
     mesh = GetMesh_("domain");
@@ -245,7 +253,7 @@ Teuchos::RCP<AmanziMesh::Mesh> State::GetDeformableMesh(Key key) {
 };
 
 
-bool State::IsDeformableMesh(Key key) const {
+bool State::IsDeformableMesh(const Key& key) const {
   mesh_iterator lb = meshes_.lower_bound(key);
   if (lb != meshes_.end() && !(meshes_.key_comp()(key, lb->first))) {
     return lb->second.second;
@@ -259,7 +267,7 @@ bool State::IsDeformableMesh(Key key) const {
 };
 
 
-Teuchos::RCP<AmanziMesh::Mesh> State::GetMesh_(Key key) const {
+Teuchos::RCP<AmanziMesh::Mesh> State::GetMesh_(const Key& key) const {
   if (key.empty()) return GetMesh_("domain");
   
   mesh_iterator lb = meshes_.lower_bound(key);
@@ -269,6 +277,21 @@ Teuchos::RCP<AmanziMesh::Mesh> State::GetMesh_(Key key) const {
     return Teuchos::null;
   }
 };
+
+
+void State::RegisterDomainSet(const Key& name,
+        const Teuchos::RCP<AmanziMesh::DomainSet> set) {
+  domain_sets_[name] = set;
+}
+
+bool State::HasDomainSet(const Key& name) const {
+  return (bool) domain_sets_.count(name);
+}
+
+Teuchos::RCP<const AmanziMesh::DomainSet>
+State::GetDomainSet(const Key& name) const {
+  return domain_sets_.at(name);
+}
 
 
 // -----------------------------------------------------------------------------
@@ -330,57 +353,59 @@ State::RequireFieldEvaluator(Key key) {
   }
 
   // check to see if we have a flyweight evaluator
-  if (evaluator == Teuchos::null && state_plist_.isParameter("domain sets")) {
+  if (evaluator == Teuchos::null) {
     KeyTriple split;
     bool is_ds = Keys::splitDomainSet(key, split);
     if (is_ds) {
-      auto domain_sets = state_plist_.get<Teuchos::Array<std::string> >("domain sets");
-      for (auto ds : domain_sets) {
-        if (ds == std::get<0>(split)) {
-          // The name is a domain set prefixed name, and we have a domain set
-          // of that name.  Grab the parameter list for the set's list and use
-          // that to construct the evaluator.
-          // -- Get this evaluator's plist.
-          Key lifted_key = Keys::getKey(ds+"_*",std::get<2>(split));
+      Key ds_name = std::get<0>(split);
+      if (HasDomainSet(std::get<0>(split))) {
+        auto ds = GetDomainSet(ds_name);
+        // The name is a domain set prefixed name, and we have a domain set
+        // of that name.  Grab the parameter list for the set's list and use
+        // that to construct the evaluator.
+        // -- Get this evaluator's plist.
+        Key lifted_key = Keys::getKey(ds_name+"_*",std::get<2>(split));
 
-          Teuchos::ParameterList& fm_plist = FEList();
-          if (fm_plist.isSublist(lifted_key)) {
-            Teuchos::ParameterList sublist = fm_plist.sublist(lifted_key);
-            sublist.set("evaluator name", key);
-            sublist.setName(key);
+        Teuchos::ParameterList& fm_plist = FEList();
+        if (fm_plist.isSublist(lifted_key)) {
+          Teuchos::ParameterList sublist = fm_plist.sublist(lifted_key);
+          sublist.set("evaluator name", key);
+          sublist.setName(key);
 
-            // -- Get the model plist.
-            Teuchos::ParameterList model_plist;
-            if (state_plist_.isSublist("model parameters")) {
-              model_plist = state_plist_.sublist("model parameters");
-            }
+          // -- Get the model plist.
+          Teuchos::ParameterList model_plist;
+          if (state_plist_.isSublist("model parameters")) {
+            model_plist = state_plist_.sublist("model parameters");
+          }
 
-            // -- Insert any model parameters.
-            if (sublist.isParameter("model parameters")) {
-              std::string modelname = sublist.get<std::string>("model parameters");
-              Teuchos::ParameterList modellist = GetModelParameters(modelname);
+          // -- Insert any model parameters.
+          if (sublist.isParameter("model parameters")) {
+            std::string modelname = sublist.get<std::string>("model parameters");
+            Teuchos::ParameterList modellist = GetModelParameters(modelname);
+            std::string modeltype = modellist.get<std::string>("model type");
+            sublist.set(modeltype, modellist);
+          } else if (sublist.isParameter("models parameters")) {
+            Teuchos::Array<std::string> modelnames =
+                sublist.get<Teuchos::Array<std::string> >("models parameters");
+            for (Teuchos::Array<std::string>::const_iterator modelname=modelnames.begin();
+                 modelname!=modelnames.end(); ++modelname) {
+              Teuchos::ParameterList modellist = GetModelParameters(*modelname);
               std::string modeltype = modellist.get<std::string>("model type");
               sublist.set(modeltype, modellist);
-            } else if (sublist.isParameter("models parameters")) {
-              Teuchos::Array<std::string> modelnames =
-                  sublist.get<Teuchos::Array<std::string> >("models parameters");
-              for (Teuchos::Array<std::string>::const_iterator modelname=modelnames.begin();
-                   modelname!=modelnames.end(); ++modelname) {
-                Teuchos::ParameterList modellist = GetModelParameters(*modelname);
-                std::string modeltype = modellist.get<std::string>("model type");
-                sublist.set(modeltype, modellist);
-              }
             }
+          }
 
-            // -- Create and set the evaluator.
-            fm_plist.set(key, sublist);
-            FieldEvaluator_Factory evaluator_factory;
-            evaluator = evaluator_factory.createFieldEvaluator(sublist);
+          // -- Create and set the evaluator.
+          fm_plist.set(key, sublist);
+          FieldEvaluator_Factory evaluator_factory;
+          evaluator = evaluator_factory.createFieldEvaluator(sublist);
             
-            SetFieldEvaluator(key, evaluator);
-            break;
-          }            
-        }          
+          SetFieldEvaluator(key, evaluator);
+        }            
+      } else {
+        Errors::Message msg;
+        msg << "Model for field \"" << key << "\" is on a DomainSet, but no DomainSet of name \"" << ds_name << "\" exists in State.";
+        Exceptions::amanzi_throw(msg);
       }
     }
   }
@@ -1487,6 +1512,26 @@ void WriteStateStatistics(const Teuchos::Ptr<State>& S, Teuchos::RCP<VerboseObje
   }
 };
 
+
+Teuchos::ParameterList&
+State::GetEvaluatorList(const Key& key)
+{
+  if (FEList().isParameter(key)) {
+    return FEList().sublist(key);
+  } else {
+    // check for domain set
+    KeyTriple split;
+    bool is_ds = Keys::splitDomainSet(key, split);
+    if (is_ds) {
+      Key lifted_key = Keys::getKey(std::get<0>(split)+"_*", std::get<2>(split));
+      if (FEList().isParameter(lifted_key)) {
+        return FEList().sublist(lifted_key);
+      }
+    }
+  }
+  // return an empty new lsit
+  return FEList().sublist(key);
+}
 
 
 } // namespace Amanzi

--- a/src/state/State.hh
+++ b/src/state/State.hh
@@ -81,8 +81,8 @@ Example:
 #include "Epetra_MultiVector.h"
 
 #include "Mesh.hh"
+#include "DomainSet.hh"
 #include "MeshPartition.hh"
-
 #include "CompositeVector.hh"
 #include "CompositeVectorSpace.hh"
 
@@ -119,6 +119,7 @@ class State {
   typedef std::map<Key, Teuchos::RCP<CompositeVectorSpace> > FieldFactoryMap;
   typedef std::map<Key, Teuchos::RCP<Field> > FieldMap;
   typedef std::map<Key, Teuchos::RCP<FieldEvaluator> > FieldEvaluatorMap;
+  typedef std::map<Key, Teuchos::RCP<AmanziMesh::DomainSet>> DomainSetMap;
   typedef std::map<Key, Teuchos::RCP<Functions::MeshPartition> > MeshPartitionMap;
 
  public:
@@ -178,21 +179,22 @@ class State {
                           bool defoormable=false);
 
   // Register a mesh under a generic key.
-  void RegisterMesh(Key key, const Teuchos::RCP<AmanziMesh::Mesh>& mesh,
+  void RegisterMesh(const Key& key, const Teuchos::RCP<AmanziMesh::Mesh>& mesh,
                     bool deformable=false);
 
   // Alias a mesh to an existing mesh
-  void AliasMesh(Key target, Key alias);
+  void AliasMesh(const Key& target, const Key& alias);
+  bool IsAliasedMesh(const Key& key) const;
 
   // Remove a mesh.
-  void RemoveMesh(Key key);
+  void RemoveMesh(const Key& key);
 
   // Ensure a mesh exists.
-  bool HasMesh(Key key) const { return GetMesh_(key) != Teuchos::null; }
-  bool IsDeformableMesh(Key key) const;
+  bool HasMesh(const Key& key) const { return GetMesh_(key) != Teuchos::null; }
+  bool IsDeformableMesh(const Key& key) const;
 
   // Mesh accessor.
-  Teuchos::RCP<const AmanziMesh::Mesh> GetMesh(Key key=Key("domain")) const;
+  Teuchos::RCP<const AmanziMesh::Mesh> GetMesh(const Key& key=Key("domain")) const;
   Teuchos::RCP<AmanziMesh::Mesh> GetDeformableMesh(Key key=Key("domain"));
 
   // Iterate over meshes.
@@ -200,6 +202,15 @@ class State {
   mesh_iterator mesh_begin() const { return meshes_.begin(); }
   mesh_iterator mesh_end() const { return meshes_.end(); }
   MeshMap::size_type mesh_count() { return meshes_.size(); }
+
+  // DomainSets are collections of meshes, indexed via NAME_GID and referenced
+  // to a parent mesh and sets.
+  //
+  void RegisterDomainSet(const Key& name,
+                         const Teuchos::RCP<AmanziMesh::DomainSet> set);
+  bool HasDomainSet(const Key& name) const;
+  Teuchos::RCP<const AmanziMesh::DomainSet> GetDomainSet(const Key& name) const;
+  
 
   // -----------------------------------------------------------------------------
   // State handles data management.
@@ -283,6 +294,8 @@ class State {
   //
   // -- allows PKs to add to this list to custom evaluators
   Teuchos::ParameterList& FEList() { return state_plist_.sublist("field evaluators"); }
+  Teuchos::ParameterList& GetEvaluatorList(const Key& key);
+  
   // -- allows PKs to add to this list to initial conditions
   Teuchos::ParameterList& ICList() { return state_plist_.sublist("initial conditions"); }
 
@@ -372,7 +385,7 @@ class State {
  private:
 
   // Accessors that return null if the Key does not exist.
-  Teuchos::RCP<AmanziMesh::Mesh> GetMesh_(Key key) const;
+  Teuchos::RCP<AmanziMesh::Mesh> GetMesh_(const Key& key) const;
   Teuchos::RCP<const Field> GetField_(Key fieldname) const;
   Teuchos::RCP<Field> GetField_(Key fieldname);
   Teuchos::RCP<FieldEvaluator> GetFieldEvaluator_(Key key);
@@ -387,10 +400,13 @@ class State {
 
   // Containers
   MeshMap meshes_;
+  std::map<Key,Key> mesh_aliases_;
   FieldMap fields_;
   FieldFactoryMap field_factories_;
   FieldEvaluatorMap field_evaluators_;
+
   MeshPartitionMap mesh_partitions_;
+  DomainSetMap domain_sets_;
 
   // meta-data
   double time_;

--- a/src/utils/Key.hh
+++ b/src/utils/Key.hh
@@ -112,8 +112,17 @@ Key
 readKey(Teuchos::ParameterList& list, const Key& domain, const Key& basename,
         const Key& default_name="");
 
+// helper functions...
+inline bool starts_with(const std::string& key, const std::string& substr) {
+  return key.length() >= substr.length() && key.substr(0,substr.length()) == substr;
+}
 
-} // namespace Key
+inline bool ends_with(const std::string& key, const std::string& substr) {
+  return key.length() >= substr.length() &&
+      key.substr(key.length()-substr.length(), key.length()) == substr;
+}
+
+} // namespace Keys
 } // namespace Amanzi
 
 #endif


### PR DESCRIPTION
This formalizes a DomainSet, a collection of small meshes on which PKs and Evaluators can be named.

It also adds support for these in factories, both in State (for evaluators) and PK_Factory (for PKs) so that users can supply things like "column_*-water_content" evaluator parameters, which will then be instantiated on "column_0-water_content", "column_1-water_content" ... where * is the global ID of an indexing set on an indexing mesh (e.g. cells on the surface mesh in this case).

This provides better support and formalization for things like ATS's Arctic intermediate scale model.