### PR TITLE
amanzi_xml cleanup and refactor

### DIFF
--- a/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
@@ -172,6 +172,9 @@ class ParameterList(base.TeuchosBaseXML):
             assert isinstance(val, ParameterList)
             return val
 
+    def getName(self):
+        return self.get("name")
+    
     def setName(self, name):
         self.set("name", name)
         

--- a/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
@@ -122,7 +122,11 @@ class ParameterList(base.TeuchosBaseXML):
 
     def sort(self):
         """Sorts mychildren() by params first, then lists."""
-        self.getchildren().sort(key=lambda x: x.tag)
+        children = list(self)
+        for child in children:
+            self.remove(child)
+        sorted_children = sorted(children, key=lambda x: x.tag)
+        self.extend(sorted_children)
 
     def indent(self, ntabs, doublespace=False, doublespace_two=False):
         """Properly indent this list (and its Parameters/sublists) with [ntabs] tabs."""

--- a/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
@@ -172,6 +172,9 @@ class ParameterList(base.TeuchosBaseXML):
             assert isinstance(val, ParameterList)
             return val
 
+    def setName(self, name):
+        self.set("name", name)
+        
     def setParameter(self, name, ptype, val):
         """Set parameter name of type ptype to value, creating a new Parameter if necessary."""
         try:
@@ -184,16 +187,12 @@ class ParameterList(base.TeuchosBaseXML):
 
         self.append(parameter.Parameter(name, ptype, val))
 
-
     def getElement(self, name):
         """Get Parameter/sublist from the ParameterList"""
-        return search.childByName(self, name)
+        return search.child_by_name(self, name)
 
     def pop(self, name):
-        return self.getchildren().pop(self.getchildren().index(self.getElement(name)))
-
-    def setName(self, name):
-        self.set("name", name)
+        return search.remove_element(self, name, False, True)
     
 # register
 parser.objects['ParameterList'] = ParameterList

--- a/tools/amanzi_xml/amanzi_xml/utils/errors.py
+++ b/tools/amanzi_xml/amanzi_xml/utils/errors.py
@@ -13,4 +13,13 @@ class NonUniqueXMLError(XMLError):
 class NotNativeSpecError(RuntimeError):
     """Error for attempting to read a non-native spec file."""
     pass
-    
+
+
+def deprecated(msg):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, warnings.DeprecatedWarning)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator
+

--- a/tools/amanzi_xml/amanzi_xml/utils/io.py
+++ b/tools/amanzi_xml/amanzi_xml/utils/io.py
@@ -29,7 +29,7 @@ def fromString(string):
 def toString(plist):
     """Writes a amanzi-xml hierarchy to a string"""
     plist.indent(0)
-    return etree.tostring(plist)
+    return etree.tostring(plist, encoding='unicode')
 
 def toFile(plist, file_or_filename):
     """Writes a amanzi-xml hierarchy to a file"""


### PR DESCRIPTION
amanzi_xml had a few duplicate ways of doing things, and one of them was quite fragile (it didn't allow parameter names to include a / character in them).

Dylan pointed out a different implementation that did work.

This refactors amanzi_xml to use only the correct implementation, and cleans up a few interfaces to standardize conventions across that library.

@jd-moulton I believe there are places in the User Guide or other demos that use amanzi_xml.  I have updated all the ATS ones, but can you point me at any place this gets used by Amanzi?