### PR TITLE
Support of multiple initialization flags

### DIFF
--- a/src/common/interface_platform/InputConverterU_MPC.cc
+++ b/src/common/interface_platform/InputConverterU_MPC.cc
@@ -1146,7 +1146,7 @@ void InputConverterU::FinalizeMPC_PKs_(Teuchos::ParameterList& glist)
         }
 
         if (pk == "flow" || pk == "flow fracture") {
-          tmp.sublist("pressure-lambda constraints").set<std::string>("method", "none");
+          tmp.sublist("pressure-lambda constraints").set<std::string>("method", "projection");
         }
 
         if (pk == "energy") {

--- a/src/common/interface_platform/test/converter_u_validate7.xml
+++ b/src/common/interface_platform/test/converter_u_validate7.xml
@@ -657,7 +657,7 @@
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <ParameterList name="pressure-lambda constraints">
-          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="method" type="string" value="projection"/>
           <Parameter name="inflow krel correction" type="bool" value="true"/>
           <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
         </ParameterList>
@@ -777,7 +777,7 @@
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <ParameterList name="pressure-lambda constraints">
-          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="method" type="string" value="projection"/>
           <Parameter name="inflow krel correction" type="bool" value="true"/>
           <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
         </ParameterList>

--- a/src/mesh_functions/CompositeVectorFunctionFactory.cc
+++ b/src/mesh_functions/CompositeVectorFunctionFactory.cc
@@ -23,11 +23,12 @@ namespace Functions {
 
 Teuchos::RCP<CompositeVectorFunction>
 CreateCompositeVectorFunction(Teuchos::ParameterList& plist,
-        const CompositeVectorSpace& sample) {
+        const CompositeVectorSpace& sample,
+        std::vector<std::string>& componentname_list) {
 
   Teuchos::RCP<MeshFunction> mesh_func =
     Teuchos::rcp(new MeshFunction(sample.Mesh()));
-  std::vector<std::string> componentname_list;
+  componentname_list.clear();
 
   // top level plist contains sublists containing the entry
   for (Teuchos::ParameterList::ConstIterator lcv=plist.begin();

--- a/src/mesh_functions/CompositeVectorFunctionFactory.hh
+++ b/src/mesh_functions/CompositeVectorFunctionFactory.hh
@@ -55,7 +55,8 @@ namespace Functions {
 
 Teuchos::RCP<CompositeVectorFunction>
 CreateCompositeVectorFunction(Teuchos::ParameterList& plist,
-        const CompositeVectorSpace& factory);
+        const CompositeVectorSpace& factory,
+        std::vector<std::string>& componentname_list);
 
 } // namespace
 } // namespace

--- a/src/mpc/test/mpc_benchmark_single.xml
+++ b/src/mpc/test/mpc_benchmark_single.xml
@@ -357,7 +357,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.7"/>
@@ -370,7 +370,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.8"/>

--- a/src/mpc/test/mpc_coupled_flow.xml
+++ b/src/mpc/test/mpc_coupled_flow.xml
@@ -284,7 +284,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{ALL}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>
@@ -299,7 +299,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{ALL}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>

--- a/src/mpc/test/mpc_coupled_flow_transport.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport.xml
@@ -315,7 +315,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>
@@ -330,7 +330,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>

--- a/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
@@ -303,7 +303,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>
@@ -318,7 +318,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="1.01325e+05"/>

--- a/src/mpc/test/mpc_reactive_transport.cc
+++ b/src/mpc/test/mpc_reactive_transport.cc
@@ -69,7 +69,6 @@ using namespace Amanzi::AmanziGeometry;
   glist->sublist("cycle driver").sublist("restart").set<std::string>("file name", "chk_rt00005.h5");
   glist->sublist("state").sublist("initial conditions").remove("geochemical conditions", false);
   S = Teuchos::null;
-  /*
   avg2 = 0.;
 
   /*

--- a/src/mpc/test/mpc_reactive_transport.cc
+++ b/src/mpc/test/mpc_reactive_transport.cc
@@ -66,11 +66,13 @@ using namespace Amanzi::AmanziGeometry;
   }
 
   // restart simulation and compare results
-  /*
   glist->sublist("cycle driver").sublist("restart").set<std::string>("file name", "chk_rt00005.h5");
   glist->sublist("state").sublist("initial conditions").remove("geochemical conditions", false);
   S = Teuchos::null;
   avg2 = 0.;
+
+  /*
+  state_plist = glist->sublist("state");
   S = Teuchos::rcp(new Amanzi::State(state_plist));
   S->RegisterMesh("domain", mesh);
   

--- a/src/mpc/test/mpc_walkabout_2D.xml
+++ b/src/mpc/test/mpc_walkabout_2D.xml
@@ -136,6 +136,19 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.01325e+05"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">

--- a/src/pks/energy/test/energy_one_phase.cc
+++ b/src/pks/energy/test/energy_one_phase.cc
@@ -115,6 +115,6 @@ TEST(ENERGY_ONE_PHASE) {
 
   auto temp = *S->GetFieldData("temperature")->ViewComponent("cell");
   for (int c = 0; c < 20; ++c) { 
-    CHECK_CLOSE(1.5, temp[0][c], 1e-8);
+    CHECK_CLOSE(1.5, temp[0][c], 2e-8);
   }
 }

--- a/src/pks/flow/Darcy_PK.cc
+++ b/src/pks/flow/Darcy_PK.cc
@@ -306,6 +306,7 @@ void Darcy_PK::Initialize(const Teuchos::Ptr<State>& S)
       Epetra_MultiVector& lambda = *solution->ViewComponent("face");
 
       DeriveFaceValuesFromCellValues(p, lambda);
+      Teuchos::rcp_dynamic_cast<Field_CompositeVector>(S->GetField(pressure_key_, passwd_))->set_initialized("face");
     }
   }
 
@@ -383,7 +384,7 @@ void Darcy_PK::InitializeFields_()
 {
   Teuchos::OSTab tab = vo_->getOSTab();
 
-  InitializeField_(S_.ptr(), passwd_, saturation_liquid_key_, 1.0);
+  InitializeField_(S_.ptr(), saturation_liquid_key_, saturation_liquid_key_, 1.0);
   InitializeField_(S_.ptr(), passwd_, prev_saturation_liquid_key_, 1.0);
 }
 

--- a/src/pks/flow/Flow_PK.cc
+++ b/src/pks/flow/Flow_PK.cc
@@ -238,7 +238,6 @@ void Flow_PK::InitializeFields_()
   InitializeField_(S_.ptr(), passwd_, specific_storage_key_, 0.0);
   InitializeField_(S_.ptr(), passwd_, specific_yield_key_, 0.0);
 
-  InitializeField_(S_.ptr(), passwd_, pressure_key_, 0.0);
   InitializeField_(S_.ptr(), passwd_, hydraulic_head_key_, 0.0);
   InitializeField_(S_.ptr(), passwd_, pressure_head_key_, 0.0);
 

--- a/src/pks/flow/Richards_PK.cc
+++ b/src/pks/flow/Richards_PK.cc
@@ -515,6 +515,7 @@ void Richards_PK::Initialize(const Teuchos::Ptr<State>& S)
   if (ti_list_->isSublist("pressure-lambda constraints") && pressure.HasComponent("face")) {
     DeriveFaceValuesFromCellValues(*pressure.ViewComponent("cell"),
                                    *pressure.ViewComponent("face"));
+    Teuchos::rcp_dynamic_cast<Field_CompositeVector>(S->GetField(pressure_key_, passwd_))->set_initialized("face");
   }
 
   // error control options
@@ -707,6 +708,7 @@ void Richards_PK::Initialize(const Teuchos::Ptr<State>& S)
 
   // Verbose output of initialization statistics.
   InitializeStatistics_();
+
 }
 
 

--- a/src/pks/flow/test/flow_darcy_misc.xml
+++ b/src/pks/flow/test/flow_darcy_misc.xml
@@ -197,7 +197,7 @@
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="Computational domain"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant"> <!-- time component -->
                 <Parameter name="value" type="double" value="0."/>

--- a/src/pks/flow/test/flow_darcy_transient_2D.xml
+++ b/src/pks/flow/test/flow_darcy_transient_2D.xml
@@ -149,6 +149,19 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/src/pks/flow/test/flow_darcy_transient_3D.xml
+++ b/src/pks/flow/test/flow_darcy_transient_3D.xml
@@ -146,6 +146,19 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="ALL">

--- a/src/pks/flow/test/flow_richards_2D.xml
+++ b/src/pks/flow/test/flow_richards_2D.xml
@@ -215,6 +215,20 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/src/pks/flow/test/flow_richards_bc_cribs.xml
+++ b/src/pks/flow/test/flow_richards_bc_cribs.xml
@@ -422,7 +422,7 @@
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="101325."/>

--- a/src/pks/flow/test/flow_richards_boundary_solver.xml
+++ b/src/pks/flow/test/flow_richards_boundary_solver.xml
@@ -181,6 +181,19 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/src/pks/flow/test/flow_richards_fractures.xml
+++ b/src/pks/flow/test/flow_richards_fractures.xml
@@ -172,7 +172,7 @@
         <ParameterList name="function">
           <ParameterList name="ALL">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="90000.0"/>

--- a/src/pks/flow/test/flow_richards_newton_tpfa.xml
+++ b/src/pks/flow/test/flow_richards_newton_tpfa.xml
@@ -213,6 +213,20 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 

--- a/src/pks/flow/test/flow_richards_seepage_tpfa.xml
+++ b/src/pks/flow/test/flow_richards_seepage_tpfa.xml
@@ -301,6 +301,20 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/pks/navier_stokes/test/navier_stokes_2D.xml
+++ b/src/pks/navier_stokes/test/navier_stokes_2D.xml
@@ -192,6 +192,20 @@
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
 
+      <ParameterList name="pressure">
+        <ParameterList name="function">
+          <ParameterList name="All Cells">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
       <ParameterList name="fluid_velocity">
         <ParameterList name="function">
           <ParameterList name="All Nodes">

--- a/src/state/Field.hh
+++ b/src/state/Field.hh
@@ -51,14 +51,14 @@ class Field {
   FieldType type() const { return type_; }
   bool io_checkpoint() const { return io_checkpoint_; }
   bool io_vis() const { return io_vis_; }
-  bool initialized() const { return initialized_; }
+  virtual bool initialized() const { return initialized_; }
 
   // mutators
   void set_owner(std::string owner) { owner_ = owner; }
   void set_vis_key(std::string key) { vis_key_ = key; }
   void set_io_checkpoint(bool io_checkpoint=true) { io_checkpoint_ = io_checkpoint; }
   void set_io_vis(bool io_vis=true) { io_vis_ = io_vis; }
-  void set_initialized(bool initialized=true) { initialized_ = initialized; }
+  virtual void set_initialized(bool initialized=true) { initialized_ = initialized; }
 
   void RequireCopy(Key tag);
   void RequireCopy(Key tag, Key new_owner);

--- a/src/state/FieldEvaluator.cc
+++ b/src/state/FieldEvaluator.cc
@@ -16,7 +16,9 @@ dependency tree.
 
 namespace Amanzi {
 
-FieldEvaluator::FieldEvaluator(Teuchos::ParameterList& plist) : plist_(plist) {
+FieldEvaluator::FieldEvaluator(Teuchos::ParameterList& plist) :
+    plist_(plist),
+    type_(EvaluatorType::UNKNOWN) {
   vo_ = Teuchos::rcp(new VerboseObject(plist.name(), plist));
 };
 
@@ -24,6 +26,7 @@ FieldEvaluator::FieldEvaluator(Teuchos::ParameterList& plist) : plist_(plist) {
 
 FieldEvaluator::FieldEvaluator(const FieldEvaluator& other) :
     plist_(other.plist_),
+    type_(other.type_),
     vo_(other.vo_) {}
 
 std::ostream&

--- a/src/state/FieldEvaluator.hh
+++ b/src/state/FieldEvaluator.hh
@@ -86,10 +86,10 @@ class FieldEvaluator {
           Key requester, Key wrt_key) = 0;
 
   // Update the field if needed.
-  //  virtual UpdateField(const Teuchos::Ptr<State>& S) = 0;
+  // virtual UpdateField(const Teuchos::Ptr<State>& S) = 0;
 
   // Update the field's derivative with respect to wrt_key if needed.
-  //  virtual UpdateFieldDerivative(const Teuchos::Ptr<State>& S, Key wrt_key) = 0;
+  // virtual UpdateFieldDerivative(const Teuchos::Ptr<State>& S, Key wrt_key) = 0;
 
 
   virtual bool IsDependency(const Teuchos::Ptr<State>& S, Key key) const = 0;
@@ -100,6 +100,9 @@ class FieldEvaluator {
   virtual std::string WriteToString() const = 0;
 
   friend std::ostream& operator<<(std::ostream&, const FieldEvaluator&);
+
+  // special flags
+  virtual bool IsPrimary() { return false; }
 
  protected:
   // parameter list for the object

--- a/src/state/FieldEvaluator.hh
+++ b/src/state/FieldEvaluator.hh
@@ -54,6 +54,7 @@ registered with the evaluator factory.
 #include "Teuchos_RCP.hpp"
 
 #include "State.hh"
+#include "StateDefs.hh"
 
 namespace Amanzi {
 
@@ -102,9 +103,11 @@ class FieldEvaluator {
   friend std::ostream& operator<<(std::ostream&, const FieldEvaluator&);
 
   // special flags
-  virtual bool IsPrimary() { return false; }
+  EvaluatorType get_type() const { return type_; }
 
  protected:
+  EvaluatorType type_;
+
   // parameter list for the object
   Teuchos::ParameterList plist_;
 

--- a/src/state/Field_CompositeVector.cc
+++ b/src/state/Field_CompositeVector.cc
@@ -158,6 +158,7 @@ void Field_CompositeVector::Initialize(Teuchos::ParameterList& plist) {
 
   // ------ Set values using a function -----
   if (plist.isSublist("function")) {
+    std::vector<std::string> complist;
     Teuchos::ParameterList func_plist = plist.sublist("function");
  
     // -- potential use of a mapping operator first -- 
@@ -179,7 +180,7 @@ void Field_CompositeVector::Initialize(Teuchos::ParameterList& plist) {
 
       // evaluate the full xD velocity function 
       Teuchos::RCP<Functions::CompositeVectorFunction> func = 
-          Functions::CreateCompositeVectorFunction(func_plist, vel_vec->Map()); 
+          Functions::CreateCompositeVectorFunction(func_plist, vel_vec->Map(), complist);
       func->Compute(0.0, vel_vec.ptr()); 
  
       // CV's map may differ from the regular mesh face map 
@@ -204,10 +205,11 @@ void Field_CompositeVector::Initialize(Teuchos::ParameterList& plist) {
  
     } else { 
       // no map, just evaluate the function 
-      Teuchos::RCP<Functions::CompositeVectorFunction> func = 
-          Functions::CreateCompositeVectorFunction(func_plist, data_->Map()); 
+      auto func = Functions::CreateCompositeVectorFunction(func_plist, data_->Map(), complist); 
       func->Compute(0.0, data_.ptr()); 
-      set_initialized(); 
+
+      for (const auto& comp : complist) set_initialized(comp);
+      // set_initialized(); 
     }
   }
 
@@ -623,8 +625,34 @@ long int Field_CompositeVector::GetLocalElementCount() {
   return count;
 }
 
-// void Field_CompositeVector::CopyFace2BndFace(const Epetra_MultiVector& vec_face, Epetra_MultiVector& vec_bndface) {
-//   for (int bf=0   
-// }
+
+bool Field_CompositeVector::initialized() const {
+  bool flag(true);
+  for (auto name = data_->begin(); name != data_->end(); ++name) {
+    if (*name != "boundary_face") {
+      if (initialized_comp_.find(*name) == initialized_comp_.end()) return false;
+      flag &= initialized_comp_.at(*name);
+    }
+  }
+  return flag;
+}
+
+
+void Field_CompositeVector::set_initialized(bool flag) {
+  for (auto name = data_->begin(); name != data_->end(); ++name) {
+    initialized_comp_[*name] = flag;
+  }
+}
   
+
+bool Field_CompositeVector::initialized(const std::string& comp) const {
+  if (initialized_comp_.find(comp) == initialized_comp_.end()) return false;
+  return initialized_comp_.at(comp);
+}
+
+
+void Field_CompositeVector::set_initialized(const std::string& comp, bool flag) {
+  if (data_->HasComponent(comp)) initialized_comp_[comp] = flag;
+}
+
 } // namespace Amanzi

--- a/src/state/Field_CompositeVector.hh
+++ b/src/state/Field_CompositeVector.hh
@@ -132,6 +132,19 @@ public:
 
   long int GetLocalElementCount();
 
+  // initialization
+  // -- this function assumes that all components of the data vector
+  //    were initialized. If component is missing, it returns false
+  virtual bool initialized() const;
+  // -- sets all components of the data vector to the given flag
+  virtual void set_initialized(bool initialized=true);
+
+  // component-wise initialization
+  // -- returns false if component is either missing or not initialized
+  bool initialized(const std::string& comp) const;
+  // -- does nothing if component does not exist in the data vector
+  void set_initialized(const std::string& comp, bool initialized=true);
+
 protected:
   bool ReadCheckpoint_(std::string filename);
   void ReadCellsFromCheckpoint_(const std::string& filename); // for ICs
@@ -149,7 +162,9 @@ private:
   // check to ensure subfield names are set
   void EnsureSubfieldNames_();
 
-}; // class Field
+  // component information
+  std::map<std::string, bool> initialized_comp_;
+};
 
 } // namespace Amanzi
 

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -34,6 +34,7 @@ initialized (as independent variables are owned by state, not by any PK).
 #include "rank_evaluator.hh"
 #include "primary_variable_field_evaluator.hh"
 #include "State.hh"
+#include "StateDefs.hh"
 
 namespace Amanzi {
 
@@ -1006,8 +1007,10 @@ void State::InitializeEvaluators() {
     *vo.os() << "initializing evaluators..." << std::endl;
   }
   for (evaluator_iterator f_it = field_evaluator_begin(); f_it != field_evaluator_end(); ++f_it) {
-    f_it->second->HasFieldChanged(Teuchos::Ptr<State>(this), "state");
-    if (!f_it->second->IsPrimary()) fields_[f_it->first]->set_initialized();
+    if (f_it->second->get_type() != EvaluatorType::PRIMARY) {
+      f_it->second->HasFieldChanged(Teuchos::Ptr<State>(this), "state");
+      fields_[f_it->first]->set_initialized();
+    }
   }
 };
 

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -1007,7 +1007,7 @@ void State::InitializeEvaluators() {
   }
   for (evaluator_iterator f_it = field_evaluator_begin(); f_it != field_evaluator_end(); ++f_it) {
     f_it->second->HasFieldChanged(Teuchos::Ptr<State>(this), "state");
-    fields_[f_it->first]->set_initialized();
+    if (!f_it->second->IsPrimary()) fields_[f_it->first]->set_initialized();
   }
 };
 

--- a/src/state/StateDefs.hh
+++ b/src/state/StateDefs.hh
@@ -24,6 +24,8 @@ namespace Amanzi {
 // Fields
 typedef enum { NULL_FIELD_TYPE, COMPOSITE_VECTOR_FIELD, CONSTANT_VECTOR, CONSTANT_SCALAR } FieldType;
 
+typedef enum { UNKNOWN, PRIMARY, SECONDARY, INDEPENDENT } EvaluatorType;
+
 } // namespace
 
 #endif

--- a/src/state/independent_variable_field_evaluator.cc
+++ b/src/state/independent_variable_field_evaluator.cc
@@ -25,6 +25,7 @@ IndependentVariableFieldEvaluator::IndependentVariableFieldEvaluator(Teuchos::Pa
     temporally_variable_(true),
     computed_once_(false) {
 
+  type_ = EvaluatorType::INDEPENDENT;
   my_key_ = plist_.get<std::string>("evaluator name");
   temporally_variable_ = !plist_.get<bool>("constant in time", false);
 }

--- a/src/state/independent_variable_field_evaluator_fromfunction.cc
+++ b/src/state/independent_variable_field_evaluator_fromfunction.cc
@@ -46,7 +46,8 @@ void IndependentVariableFieldEvaluatorFromFunction::UpdateField_(const Teuchos::
     // Create the function.
     Teuchos::RCP<const CompositeVector> cv = S->GetFieldData(my_key_);
     AMANZI_ASSERT(plist_.isSublist("function"));
-    func_ = Functions::CreateCompositeVectorFunction(plist_.sublist("function"), cv->Map());
+    std::vector<std::string> complist;
+    func_ = Functions::CreateCompositeVectorFunction(plist_.sublist("function"), cv->Map(), complist);
   }
 
   // NOTE: IndependentVariableFieldEvaluatorFromFunctions own their own data.

--- a/src/state/primary_variable_field_evaluator.cc
+++ b/src/state/primary_variable_field_evaluator.cc
@@ -21,6 +21,7 @@ namespace Amanzi {
 PrimaryVariableFieldEvaluator::PrimaryVariableFieldEvaluator(
     Teuchos::ParameterList& plist) :
     FieldEvaluator(plist) {
+  type_ = EvaluatorType::PRIMARY;
   my_key_ = plist_.get<std::string>("evaluator name");
 }
 

--- a/src/state/primary_variable_field_evaluator.hh
+++ b/src/state/primary_variable_field_evaluator.hh
@@ -64,6 +64,9 @@ class PrimaryVariableFieldEvaluator : public FieldEvaluator {
 
   virtual std::string WriteToString() const;
 
+  // special flags
+  virtual bool IsPrimary() { return true; }
+
  protected:
   Key my_key_;
   KeySet requests_;

--- a/src/state/secondary_variable_field_evaluator.cc
+++ b/src/state/secondary_variable_field_evaluator.cc
@@ -22,6 +22,8 @@ SecondaryVariableFieldEvaluator::SecondaryVariableFieldEvaluator(
         Teuchos::ParameterList& plist) :
     FieldEvaluator(plist)
 {
+  type_ = EvaluatorType::SECONDARY;
+
   // process the plist
   if (plist_.isParameter("evaluator name")) {
     my_key_ = plist_.get<std::string>("evaluator name");

--- a/src/state/secondary_variables_field_evaluator.cc
+++ b/src/state/secondary_variables_field_evaluator.cc
@@ -22,6 +22,8 @@ SecondaryVariablesFieldEvaluator::SecondaryVariablesFieldEvaluator(
             Teuchos::ParameterList& plist) :
     FieldEvaluator(plist)
 {
+  type_ = EvaluatorType::SECONDARY;
+
   // process the plist
   if (plist_.isParameter("evaluator names")) {
     Teuchos::Array<std::string> names =


### PR DESCRIPTION
Design strategy is to make initialized() and set_initialized() virtual functions. Due to possibility of having multiple fields, each derived class implements different logic. So far, only Field_CompositeVector changes 
the initialization logic. Two functions that initialize particular components have been added to this class. 

Additional logic has been added to State to avoid setting initialization flags for primary evaluators. This should be done inside PKs. To support this, a new function, IsPrimary() has been added. Not the best solution, and I tend to add a field enum if there is a consensus.
  
The logic has been tested with Amanzi PK.