### PR TITLE
Mask-based initialization of all components in a CV

### DIFF
--- a/src/common/interface_platform/InputConverterU_State.cc
+++ b/src/common/interface_platform/InputConverterU_State.cc
@@ -406,7 +406,7 @@ Teuchos::ParameterList InputConverterU::TranslateState_()
         Teuchos::ParameterList& pressure_ic = out_ic.sublist("pressure");
         pressure_ic.sublist("function").sublist(reg_str)
             .set<Teuchos::Array<std::string> >("regions", regions)
-            .set<std::string>("component", "cell")
+            .set<std::string>("component", "*")
             .sublist("function").sublist("function-constant")
             .set<double>("value", p);
       }
@@ -632,7 +632,7 @@ Teuchos::ParameterList InputConverterU::TranslateState_()
         Teuchos::ParameterList& pressure_ic = out_ic.sublist("fracture-pressure");
         pressure_ic.sublist("function").sublist(reg_str)
             .set<Teuchos::Array<std::string> >("regions", regions)
-            .set<std::string>("component", "cell")
+            .set<std::string>("component", "*")
             .sublist("function").sublist("function-constant")
             .set<double>("value", p);
       }

--- a/src/common/interface_platform/test/converter_u_validate4.xml
+++ b/src/common/interface_platform/test/converter_u_validate4.xml
@@ -211,7 +211,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="2.01325e+05"/>

--- a/src/common/interface_platform/test/converter_u_validate5.xml
+++ b/src/common/interface_platform/test/converter_u_validate5.xml
@@ -363,7 +363,7 @@
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.7"/>
@@ -376,7 +376,7 @@
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.8"/>

--- a/src/common/interface_platform/test/converter_u_validate6.xml
+++ b/src/common/interface_platform/test/converter_u_validate6.xml
@@ -257,7 +257,7 @@
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.7"/>
@@ -287,7 +287,7 @@
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.8"/>

--- a/src/common/interface_platform/test/converter_u_validate7.xml
+++ b/src/common/interface_platform/test/converter_u_validate7.xml
@@ -345,7 +345,7 @@
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.01325e+05"/>

--- a/src/common/interface_platform/test/converter_u_validate8.xml
+++ b/src/common/interface_platform/test/converter_u_validate8.xml
@@ -314,7 +314,7 @@
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
-            <Parameter name="component" type="string" value="cell"/>
+            <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0e+6"/>

--- a/src/mesh_functions/CompositeVectorFunctionFactory.cc
+++ b/src/mesh_functions/CompositeVectorFunctionFactory.cc
@@ -92,6 +92,13 @@ CreateCompositeVectorFunction(Teuchos::ParameterList& plist,
         Exceptions::amanzi_throw(msg);
       }
 
+      // parse special case: initialize all existing components
+      if (components.size() == 1 && components[0] == "*") {
+        components.clear();
+        for (auto it = sample.begin(); it != sample.end(); ++it)
+          components.push_back(*it);
+      }
+
       // get the function
       Teuchos::RCP<MultiFunction> func;
       if (sublist.isSublist("function")) {
@@ -120,12 +127,10 @@ CreateCompositeVectorFunction(Teuchos::ParameterList& plist,
         AmanziMesh::Entity_kind kind = sample.Location(*component);
 
         // -- Create the domain,
-        Teuchos::RCP<MeshFunction::Domain> domain =
-          Teuchos::rcp(new MeshFunction::Domain(regions, kind));
+        auto domain = Teuchos::rcp(new MeshFunction::Domain(regions, kind));
 
         // -- and the spec,
-        Teuchos::RCP<MeshFunction::Spec> spec =
-          Teuchos::rcp(new MeshFunction::Spec(domain, func));
+        auto spec = Teuchos::rcp(new MeshFunction::Spec(domain, func));
 
         mesh_func->AddSpec(spec);
         componentname_list.push_back(*component);
@@ -139,8 +144,7 @@ CreateCompositeVectorFunction(Teuchos::ParameterList& plist,
   }
 
   // create the function
-  return Teuchos::rcp(new CompositeVectorFunction(mesh_func,
-          componentname_list));
+  return Teuchos::rcp(new CompositeVectorFunction(mesh_func, componentname_list));
 };
 
 } // namespace

--- a/src/mesh_functions/CompositeVectorFunctionFactory.hh
+++ b/src/mesh_functions/CompositeVectorFunctionFactory.hh
@@ -31,9 +31,13 @@ OR:
 END
 
 ONE OF:
-* `"component`" ``[string]`` Mesh component to evaluate this on.  This is one of "cell", "face", or "node"
+* `"component`" ``[string]`` Mesh component to evaluate this on.  This is one of "cell", "face", "node", "edge",
+  or "boundary_face". The last two may require additional conditions, such as a proper mesh initialization.
+  The mask "*" could be used in place of the component name.
 OR:
-* `"components`" ``[Array(string)]`` Mesh components to evaluate this on.  This is some collection of "cell", "face", and/or "node"
+* `"components`" ``[Array(string)]`` Mesh components to evaluate this on.  This is some collection of "cell", "face", 
+  "node", "edge", and/or "boundary_face". The last two may require additional conditions, such as a proper mesh 
+  initialization.  The array with the single entry "*" could be used to initialize all existing components.
 END
 
 * `"function`" ``[function-spec]`` The spec to provide the actual algebraic function.  


### PR DESCRIPTION
It takes a lot of effort (e.g. in a converter) to figure out which components of a field have to be populated at time zero. But it is easy to say - initialize all components. This PR adds support for component(s) named "*".  