### PR TITLE
Fix CopyTpetraToHypre

### DIFF
--- a/config/SuperBuild/templates/trilinos-ifpack.patch
+++ b/config/SuperBuild/templates/trilinos-ifpack.patch
@@ -11,16 +11,57 @@ index d70f232946b..a7beafea8de 100644
    // Hypre Setup must be called after matrix has values
    if(SolveOrPrec_ == Solver){
 diff --git a/packages/ifpack2/src/Ifpack2_Hypre_def.hpp b/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
-index 39567505393..32235dbb8f1 100644
+index 3956750..ff9644e 100644
 --- a/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
 +++ b/packages/ifpack2/src/Ifpack2_Hypre_def.hpp
-@@ -844,7 +844,8 @@ void Hypre<MatrixType>::compute(){
+@@ -844,7 +844,7 @@ void Hypre<MatrixType>::compute(){
      if(isInitialized() == false){
        initialize();
      }
 -           
 +    CopyTpetraToHypre();
-+
      // Hypre Setup must be called after matrix has values
      if(SolveOrPrec_ == Hypre_Is_Solver){
        IFPACK2_CHK_ERR(SolverSetupPtr_(Solver_, ParMatrix_, ParX_, ParY_));
+@@ -1187,23 +1187,28 @@ int Hypre<MatrixType>::CopyTpetraToHypre(){
+   if(Matrix.is_null()) 
+     throw std::runtime_error("Hypre<MatrixType>: Unsupported matrix configuration: Tpetra::CrsMatrix required");
+ 
+-  std::vector<GO> new_indices(Matrix->getNodeMaxNumRowEntries());
+-  for(LO i = 0; i < (LO) Matrix->getNodeNumRows(); i++){
+-    Teuchos::ArrayView<const SC> values;
+-    Teuchos::ArrayView<const LO> indices;
+-    Matrix->getLocalRowView(i, indices, values);
+-    for(LO j = 0; j < (LO)indices.size(); j++){
+-      new_indices[j] = GloballyContiguousColMap_->getGlobalElement(indices[j]);
+-    }
+-    GO GlobalRow[1];
+-    GO numEntries = (GO) indices.size();
+-    GlobalRow[0] = GloballyContiguousRowMap_->getGlobalElement(i);    
+-    IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreA_, 1, &numEntries, GlobalRow, new_indices.data(), values.getRawPtr()));
+-  }
++  LO nrows = Matrix->getNodeNumRows(); 
++  Kokkos::View<LO*,Kokkos::DefaultExecutionSpace> colsperrow("ColsPerRow",nrows); 
++  auto rowPtrs = Matrix->getCrsGraph()->getLocalGraph().row_map; 
++  Kokkos::parallel_for(nrows,
++    KOKKOS_LAMBDA(const int i){
++      colsperrow(i) = rowPtrs[i+1]-rowPtrs[i]; 
++  }); 
++
++  auto rowindices = Matrix->getRowMap()->getMyGlobalIndices();
++
++  Kokkos::View<SC*,Kokkos::DefaultExecutionSpace> 
++    values = Matrix->getLocalValuesView(); 
++  Kokkos::View<LO*,Kokkos::DefaultExecutionSpace> 
++    colindices = Matrix->getCrsGraph()->getLocalGraph().entries; 
++
++  IFPACK2_CHK_ERR(HYPRE_IJMatrixSetValues(HypreA_,nrows,colsperrow.data(),
++                                        rowindices.data(),colindices.data(),values.data()));
++
+   IFPACK2_CHK_ERR(HYPRE_IJMatrixAssemble(HypreA_));
+   IFPACK2_CHK_ERR(HYPRE_IJMatrixGetObject(HypreA_, (void**)&ParMatrix_));
+   if (Dump_)
+-    HYPRE_ParCSRMatrixPrint(ParMatrix_,"A.mat");
++    IFPACK2_CHK_ERR(HYPRE_ParCSRMatrixPrint(ParMatrix_,"A.mat"));
+   return 0;
+ } //CopyTpetraToHypre()


### PR DESCRIPTION
- Add patch to fix the CopyTpetraToHypre function from Ifpack2. 
- This will allow to remove the ifpack2 interface from Amanzi in tpetra-solvers branch. 