### PR TITLE
Changes the default COMM in extracted meshes

### DIFF
--- a/src/mesh/mesh_extracted/MeshColumn.cc
+++ b/src/mesh/mesh_extracted/MeshColumn.cc
@@ -23,6 +23,14 @@ MeshColumn::MeshColumn(const Teuchos::RCP<Mesh>& col3D_mesh,
   AMANZI_ASSERT(col3D_mesh_->space_dimension() == 3);
   AMANZI_ASSERT(col3D_mesh_->manifold_dimension() == 3);
 
+  // set my cells
+  if (vo_->os_OK(Teuchos::VERB_HIGH))
+    *vo_->os() << " constructing MeshColumn mesh with col3D_mesh parent that has "
+               << col3D_mesh_->num_entities(AmanziMesh::Entity_kind::CELL, AmanziMesh::Parallel_type::OWNED)
+               << " cells and "
+               << col3D_mesh_->num_entities(AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_type::OWNED)
+               << " faces." << std::endl;
+
   // set supporting subclasses
   set_space_dimension(3);
   set_manifold_dimension(3);

--- a/src/mesh/mesh_extracted/MeshColumn.hh
+++ b/src/mesh/mesh_extracted/MeshColumn.hh
@@ -381,6 +381,7 @@ class MeshColumn : public Mesh {
                                  const Parallel_type ptype,
                                  Entity_ID_List *entids,
                                  std::vector<double> *vofs) const override {
+    entids->clear();
     switch (kind) {
       case FACE: {
         Entity_ID_List faces;
@@ -439,6 +440,7 @@ class MeshColumn : public Mesh {
         count++;
       }
     }
+    AMANZI_ASSERT(count <= 2);
   }
 
 
@@ -449,6 +451,7 @@ class MeshColumn : public Mesh {
                                 const Parallel_type ptype,
                                 Entity_ID_List *cellids) const override {
     col3D_mesh_->face_get_cells(column_faces_[faceid], ptype, cellids);
+    AMANZI_ASSERT(cellids->size() <= 2);
   }
 
 

--- a/src/mesh/mesh_extracted/MeshSurfaceCell.cc
+++ b/src/mesh/mesh_extracted/MeshSurfaceCell.cc
@@ -41,6 +41,13 @@ MeshSurfaceCell::MeshSurfaceCell(const Teuchos::RCP<const Mesh>& parent_mesh,
   set_manifold_dimension(2);
 
   // set my cells
+  if (vo_->os_OK(Teuchos::VERB_HIGH))
+    *vo_->os() << " constructing SurfaceCell mesh with parent that has "
+               << parent_->num_entities(AmanziMesh::Entity_kind::CELL, AmanziMesh::Parallel_type::OWNED)
+               << " cells and "
+               << parent_->num_entities(AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_type::OWNED)
+               << " faces." << std::endl;
+
   Entity_ID_List my_cells;
   parent_->get_set_entities(setname, AmanziMesh::Entity_kind::FACE, AmanziMesh::Parallel_type::OWNED, &my_cells);
   AMANZI_ASSERT(my_cells.size() == 1);


### PR DESCRIPTION
Previously, extracted meshes were contructed, by default, with the
parent mesh's comm.  This changes that default to instead construct
with the comm provided in the factory's constructor, which is the same
for all other mesh types.

This is necessary because it allows the user to pass in MPI_COMM_SELF
or other communicators if either the MeshFactory::create() call is not
collective and/or if the meshes are intended to be constructed
serially (e.g. for column mesh extraction).

Note, the old behavior can be recovered by using the same factory to
create the parent mesh and the child mesh, or construct the child
mesh's factory with the parent mesh's communicator.

This does not effect the export option "create subcommunicator" which
uses MPI_Comm_split to create a subcommunicator of the parent's comm
with only ranks that have extracted entities.  That create() call must
be collective on the parent mesh.