### PR TITLE
Adds check on VisualizationDomainSets to ensure same variables are visualized across all ranks

### DIFF
--- a/src/state/VisualizationDomainSet.hh
+++ b/src/state/VisualizationDomainSet.hh
@@ -70,7 +70,9 @@ class VisualizationDomainSet : public Visualization {
 
  protected:
   // note this is lazily constructed, so must be mutable
+  // Note that this relies on map being ORDERED!
   mutable std::map<std::string, std::pair<Teuchos::RCP<Epetra_MultiVector>, std::vector<std::string>>> lifted_vectors_;
+  mutable std::vector<std::string> lifted_vector_names_;
 
   std::map<Key, Teuchos::RCP<const AmanziMesh::Mesh>> subdomains_;
 };

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -64,6 +64,7 @@ add_amanzi_library(atk
                            ExprTK.hh
                            StringExt.hh
                            UniqueHelpers.hh
+                           StringReducer.hh
                     LINK_LIBS error_handling ${Epetra_LIBRARIES} ${Teuchos_LIBRARIES} ${HDF5_LIBRARIES})
 
 if (APPLE AND BUILD_SHARED_LIBS)
@@ -83,40 +84,47 @@ if (BUILD_TESTS)
     # Add the utils directory to the include paths
     include_directories(${ATK_SOURCE_DIR})
 
-    ADD_AMANZI_TEST(utils_keys utils_keys
+    add_amanzi_test(utils_keys utils_keys
                     KIND unit
                     SOURCE test/Main.cc test/utils_keys.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
     
-    ADD_AMANZI_TEST(utils_time_step_manager utils_time_step_manager
+    add_amanzi_test(utils_time_step_manager utils_time_step_manager
                     KIND unit
                     SOURCE test/Main.cc test/utils_time_step_manager.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
 
-    ADD_AMANZI_TEST(utils_verbosity utils_verbosity
+    add_amanzi_test(utils_verbosity utils_verbosity
                     KIND unit
                     SOURCE test/Main.cc test/utils_verboseobject.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
 
-    ADD_AMANZI_TEST(utils_units utils_units
+    add_amanzi_test(utils_units utils_units
                     KIND unit
                     SOURCE test/Main.cc test/utils_units.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
 
-    ADD_AMANZI_TEST(utils_spline utils_spline
+    add_amanzi_test(utils_spline utils_spline
                     KIND unit
                     SOURCE test/Main.cc test/utils_spline.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
 
-    ADD_AMANZI_TEST(utils_ioevent utils_ioevent
+    add_amanzi_test(utils_ioevent utils_ioevent
                     KIND unit
                     SOURCE test/Main.cc test/utils_ioevent.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
 
-    ADD_AMANZI_TEST(utils_exprtk utils_exprtk
+    add_amanzi_test(utils_exprtk utils_exprtk
                     KIND unit
                     SOURCE test/Main.cc test/utils_exprtk.cc
                     LINK_LIBS atk ${UnitTest_LIBRARIES})
+
+    add_amanzi_test(utils_reducer utils_reducer
+                    KIND unit
+                    SOURCE test/Main.cc test/utils_reducer.cc
+                    LINK_LIBS atk ${UnitTest_LIBRARIES})
+    add_amanzi_test(utils_reducer_np2 utils_reducer NPROCS 2 KIND unit)
+    add_amanzi_test(utils_reducer_np5 utils_reducer NPROCS 5 KIND unit)
 
 endif()
 

--- a/src/utils/StringReducer.hh
+++ b/src/utils/StringReducer.hh
@@ -1,0 +1,193 @@
+/* -*-  mode: c++; indent-tabs-mode: nil -*- */
+/*
+   Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL.
+   Amanzi is released under the three-clause BSD License.
+   The terms of use and "as is" disclaimer for this license are
+   provided in the top-level COPYRIGHT file.
+   See $ATS_DIR/COPYRIGHT
+
+   Author: Ethan Coon
+*/
+//! Simple utility for doing intersections across a communicator.
+
+/*
+
+This could be made much much more general, but for now it does two jobs:
+
+1. It performs reductions on strings, forming the "max" across a communicator
+(where max means alphabetically last according to std::string::operator> ).
+
+2. It forms the intersection of a sorted list of strings across a communicator,
+finding all strings that are on all ranks.
+
+This gets used by domain sets in visualization, to make sure that IO is done
+only for vectors that live on all ranks (otherwise the IO method hangs).
+
+*/
+
+#pragma once
+
+#include <vector>
+#include <string>
+#include <set>
+
+#include "dbc.hh"
+#include "AmanziTypes.hh"
+
+namespace Amanzi {
+namespace Utils {
+
+namespace Impl {
+
+#ifdef HAVE_MPI
+
+template<int MAXLEN>
+void MyMaxString(char* in, char* out, int *count, MPI_Datatype *dptr) {
+  AMANZI_ASSERT(*count == 1);
+  for (int i=0; i!=*count; ++i) {
+    std::string instr(&in[MAXLEN*i], MAXLEN);
+    std::string outstr(&out[MAXLEN*i], MAXLEN);
+    if (instr > outstr) {
+      for (int j=0; j!=MAXLEN; ++j) out[MAXLEN*i+j] = in[MAXLEN*i+j];
+    }
+  }
+}
+
+template<int MAXLEN>
+void MyMaxStringWrapper(void* in, void *out, int *count, MPI_Datatype *dptr) {
+  MyMaxString<MAXLEN>((char*)in, (char*)out, count, dptr);
+}
+
+#endif
+
+} // namespace Impl
+
+
+//
+// A little helper class that, along with the Impl namespace, allows the
+// determination of the alphabetically last string across a communicator.
+//
+template <int maxlen>
+class StringReducer {
+  static const int MAXLEN = maxlen;
+
+ public:
+  StringReducer(const Comm_ptr_type& comm)
+    : comm_ptr_(comm) {
+
+#ifdef HAVE_MPI
+    // get the raw comm
+    auto comm_raw = Teuchos::rcp_dynamic_cast<const MpiComm_type>(comm);
+    AMANZI_ASSERT(comm_raw);
+    comm_ = comm_raw->Comm();
+
+    // construct the data type
+    MPI_Type_contiguous(MAXLEN, MPI_CHAR, &dtype_);
+    MPI_Type_commit(&dtype_);
+
+    // construct the op
+    MPI_Op_create(Impl::MyMaxStringWrapper<MAXLEN>, 1, &op_);
+
+    int ierr = MPI_Comm_rank(comm_, &rank_);
+    ierr |= MPI_Comm_size(comm_, &size_);
+    AMANZI_ASSERT(!ierr);
+#endif
+  }
+
+  // reduceAll on strings -- returns the alphabetically last string across comm
+  std::string reduceMaxString(const std::string& str) const {
+#ifdef HAVE_MPI
+    // buffer strings
+    std::string string_g(MAXLEN, ' ');
+    std::string string_l(str);
+    string_l.insert(str.size(), MAXLEN-1, ' ');
+
+    // reduce
+    int ierr = MPI_Allreduce((void*) string_l.data(), (void*) string_g.data(), 1, dtype_, op_, comm_);
+    AMANZI_ASSERT(!ierr);
+
+    // erase the trailing spaces
+    int i;
+    for (i=MAXLEN-1; i!=-1; --i) {
+      if (string_g[i] != ' ') break;
+    }
+    return string_g.substr(0,i+1);
+#else
+    return str;
+#endif
+  }
+
+
+  int reduceMinInt(int size) const {
+#ifdef HAVE_MPI
+    int size_g = 0;
+    int ierr = MPI_Allreduce(&size, &size_g, 1, MPI_INT, MPI_MIN, comm_);
+    AMANZI_ASSERT(!ierr);
+    return size_g;
+#else
+    return size;
+#endif
+  }
+
+
+  // intersectAll -- given a SORTED list of strings, returns the SORTED list of
+  // keys that exist on all ranks of comm.
+  //
+  // NOTE: if uncertain, call checkValidInput()!
+  std::vector<std::string> intersectAll(const std::vector<std::string>& in) const {
+
+#ifdef HAVE_MPI
+    std::vector<std::string> out;
+    int nleft = reduceMinInt(in.size());
+    int i = 0;
+    int keep = 0;
+    while (nleft > 0) {
+      std::string l_next = in[i];
+      auto g_next = reduceMaxString(l_next);
+
+      if (g_next == l_next) {
+        // l_next is the largest, maybe all one that all have?
+        keep = 1;
+      } else {
+        // l_next is not the largest, so some other process does not have l_next
+        keep = 0;
+        i++;
+      }
+      if (reduceMinInt(keep) == 1) {
+        // all have l_next
+        out.emplace_back(l_next);
+        i++;
+      }
+
+      nleft = reduceMinInt(in.size() - i);
+    }
+    return out;
+#else
+    return in;
+#endif
+  }
+
+
+  void checkValidInput(const std::vector<std::string>& in) const {
+    std::set<std::string> set(in.begin(), in.end());
+    AMANZI_ASSERT(set.size() == in.size());
+    if (in.size() > 1) {
+      for (int i=0; i!=(in.size()-1); ++i) {
+        AMANZI_ASSERT(in[i+1] > in[i]);
+      }
+    }
+  }
+
+
+ private:
+#ifdef HAVE_MPI
+  MPI_Datatype dtype_;
+  MPI_Op op_;
+  MPI_Comm comm_;
+  int rank_, size_;
+#endif
+  Comm_ptr_type comm_ptr_;
+};
+
+} // namespace Utils
+} // namespace Amanzi

--- a/src/utils/test/Main.cc
+++ b/src/utils/test/Main.cc
@@ -6,7 +6,6 @@
 #include "VerboseObject_objs.hh"
 int main(int argc, char *argv[])
 {
-
+  Teuchos::GlobalMPISession mpiSession(&argc,&argv);
   return UnitTest::RunAllTests ();
-
 }

--- a/src/utils/test/utils_keys.cc
+++ b/src/utils/test/utils_keys.cc
@@ -1,9 +1,7 @@
 /*
-  State
-
-  Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL. 
-  Amanzi is released under the three-clause BSD License. 
-  The terms of use and "as is" disclaimer for this license are 
+  Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
   provided in the top-level COPYRIGHT file.
 
   Authors: Ethan Coon (ecoon@ornl.gov)

--- a/src/utils/test/utils_reducer.cc
+++ b/src/utils/test/utils_reducer.cc
@@ -1,0 +1,105 @@
+/*
+  Copyright 2010-201x held jointly by LANS/LANL, LBNL, and PNNL.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (ecoon@ornl.gov)
+*/
+
+#include "UnitTest++.h"
+#include "StringReducer.hh"
+#include "AmanziComm.hh"
+
+using namespace Amanzi;
+using namespace Amanzi::Utils;
+
+SUITE(STRING_REDUCER) {
+
+TEST(StringReducer_SAME)
+{
+  auto comm = getDefaultComm();
+  StringReducer<20> red(comm);
+
+  // all the same
+  std::vector<std::string> in{"apples", "bananas", "canteloupes"};
+  auto out = red.intersectAll(in);
+  CHECK(out == in);
+}
+
+TEST(StringReducer_ALL_DIFFERENT)
+{
+  auto comm = getDefaultComm();
+  StringReducer<20> red(comm);
+
+  int size = comm->NumProc();
+  int rank = comm->MyPID();
+
+  if (size > 1 && size < 7) {
+    std::vector<std::string> all{"apples", "bananas", "canteloupes", "dates", "elderberries", "figs"};
+    std::vector<std::string> in{all[rank]};
+    auto out = red.intersectAll(in);
+    CHECK_EQUAL(0, out.size());
+  }
+}
+
+TEST(StringReducer_SOME_MISSING)
+{
+  auto comm = getDefaultComm();
+  StringReducer<20> red(comm);
+
+  int size = comm->NumProc();
+  int rank = comm->MyPID();
+
+  if (size > 1) {
+    // first and last are diff
+    std::vector<std::string> in;
+    if (rank == 1) in = {"apples", "bananas", "canteloupes", "dates", "elderberries"};
+    else in = {"bananas", "dates"};
+
+    auto out = red.intersectAll(in);
+    CHECK_EQUAL(2, out.size());
+    CHECK_EQUAL("bananas", out[0]);
+    CHECK_EQUAL("dates", out[1]);
+  }
+}
+
+TEST(StringReducer_DIFFERENT_MISSING)
+{
+  auto comm = getDefaultComm();
+  StringReducer<20> red(comm);
+
+  int size = comm->NumProc();
+  int rank = comm->MyPID();
+
+  if (size > 1) {
+    // first and last are diff
+    std::vector<std::string> in;
+    if (rank == 1) in = {"apples", "bananas", "dates"};
+    else in = {"apples", "canteloupes", "dates"};
+
+    auto out = red.intersectAll(in);
+    CHECK_EQUAL(2, out.size());
+    CHECK_EQUAL("apples", out[0]);
+    CHECK_EQUAL("dates", out[1]);
+  }
+}
+
+
+TEST(StringReducer_SOME_EMPTY)
+{
+  auto comm = getDefaultComm();
+  StringReducer<20> red(comm);
+
+  int size = comm->NumProc();
+  int rank = comm->MyPID();
+
+  // first and last are diff
+  std::vector<std::string> in;
+  if (rank != 0) in = {"apples", "bananas", "dates"};
+
+  auto out = red.intersectAll(in);
+  CHECK_EQUAL(0, out.size());
+}
+
+} // SUITE


### PR DESCRIPTION
Since DomainSets lift variables to visualize on the shared mesh from
which they were constructed, while observations can be done on
individual domains in a domain set, there can be cases where there is
a variable that exists on a single domain (e.g. column:0) but not on
ALL column:*.  The result of that is that the list of "lifted" vectors
is different on different ranks, and VisDomainSet hangs.

Figuring out which vectors exist on all ranks is not trivial --
effectively we have to take the intersection (across ranks) of lists
of variable names.  This is done through a new utility StringReducer
which both does MPI_Allreduce() on strings and provides a nicer
interface to do this intersection.  Tests added.