### PR TITLE
passes python executable provided in bootstrap to a few TPLs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1827,6 +1827,7 @@ if [ -z "${tpl_config_file}" ]; then
       -DBUILD_SHARED_LIBS:BOOL=${shared} \
       -DTPL_DOWNLOAD_DIR:FILEPATH=${tpl_download_dir} \
       -DDISABLE_EXTERNAL_DOWNLOAD=${disable_external_downloads} \
+      -DPYTHON_EXECUTABLE:STRING=${python_exec} \
       ${blas_lapack_opts} \
       ${arch_tpl_opts} \
       ${tpl_build_src_dir}"

--- a/config/SuperBuild/include/Build_SEACAS.cmake
+++ b/config/SuperBuild/include/Build_SEACAS.cmake
@@ -126,6 +126,7 @@ set(SEACAS_CMAKE_CACHE_ARGS
                     -DTPL_ENABLE_Pthread:BOOL=FALSE
                     -DSEACASExodus_ENABLE_THREADSAFE:BOOL=OFF
                     -DSEACASIoss_ENABLE_THREADSAFE:BOOL=OFF
+                    -DPYTHON_EXECUTABLE:STRING=${PYTHON_EXECUTABLE}
                     ${seacas_install_rpath})
 
 # --- Add external project build and tie to the SEACAS build target

--- a/config/SuperBuild/include/Build_Trilinos.cmake
+++ b/config/SuperBuild/include/Build_Trilinos.cmake
@@ -366,6 +366,7 @@ ExternalProject_Add(${Trilinos_BUILD_TARGET}
                                       -DCMAKE_INSTALL_RPATH:PATH=${Trilinos_install_dir}/lib
                                       -DCMAKE_INSTALL_NAME_DIR:PATH=${Trilinos_install_dir}/lib
                                       -DCMAKE_BUILD_TYPE:STRING=${Trilinos_BUILD_TYPE}
+                                      -DPYTHON_EXECUTABLE:STRING=${PYTHON_EXECUTABLE}
 
                     # -- Build
                     BINARY_DIR       ${Trilinos_build_dir}        # Build directory 


### PR DESCRIPTION
This just passes PYTHON_EXECUTABLE, provided via --with-python argument to bootstrap, into Trilinos and SEACAS.

refs #652  but does not try to fix that.