### PR TITLE
fixes some logic on communication

### DIFF
--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -339,6 +339,7 @@ void
 CompositeVector::ScatterMasterToGhosted(std::string name, bool force) const {
   // NOTE: allowing const is a hack to allow non-owning PKs to nonetheless
   // update ghost cells, which may be necessary for their discretization
+  AMANZI_ASSERT(ghosted_);
 #ifdef HAVE_MPI
 #if MANAGED_COMMUNICATION
   if (ghosted_ && ((!ghost_are_current_[Index_(name)]) || force)) {

--- a/src/data_structures/CompositeVectorSpace.cc
+++ b/src/data_structures/CompositeVectorSpace.cc
@@ -83,7 +83,7 @@ CompositeVectorSpace::SubsetOf(const CompositeVectorSpace& other) const {
   for (name_iterator name=begin(); name!=end(); ++name) {
     if (!other.HasComponent(*name)) return false;
     if (NumVectors(*name) != other.NumVectors(*name)) return false;
-    if (Location(*name) !=other.Location(*name)) return false;
+    if (Location(*name) != other.Location(*name)) return false;
   }
   return true;
 }
@@ -99,6 +99,7 @@ CompositeVectorSpace::Update(const CompositeVectorSpace& other) {
   if (this != &other) {
     if (other.mesh_ != Teuchos::null) SetMesh(other.mesh_);
     AddComponents(other.names_, other.locations_, other.mastermaps_, other.ghostmaps_, other.num_dofs_);
+    if (other.ghosted_) SetGhosted();
   }
   return this;
 };

--- a/src/operators/PDE_DiffusionFV.cc
+++ b/src/operators/PDE_DiffusionFV.cc
@@ -152,12 +152,15 @@ void PDE_DiffusionFV::SetScalarCoefficient(const Teuchos::RCP<const CompositeVec
 
   if (k_ != Teuchos::null) {
     AMANZI_ASSERT(k_->HasComponent("face"));
+    AMANZI_ASSERT(k_->Map().Ghosted());
+
     // NOTE: it seems that Amanzi passes in a cell based kr which is then
     // ignored, and assumed = 1.  This seems dangerous to me. --etc
     // AMANZI_ASSERT(!k_->HasComponent("cell"));
   }
   if (dkdp_ != Teuchos::null) {
     AMANZI_ASSERT(dkdp_->HasComponent("cell"));
+    AMANZI_ASSERT(dkdp_->Map().Ghosted());
   }
 }
 
@@ -218,14 +221,6 @@ void PDE_DiffusionFV::UpdateMatricesNewtonCorrection(
   // Add derivatives to the matrix (Jacobian in this case)
   if (newton_correction_ == OPERATOR_DIFFUSION_JACOBIAN_TRUE && u.get()) {
     AMANZI_ASSERT(u != Teuchos::null);
-
-    if (k_ != Teuchos::null) {
-      if (k_->HasComponent("face")) k_->ScatterMasterToGhosted("face");
-    }
-    if (dkdp_ != Teuchos::null) {
-      if (dkdp_->HasComponent("face")) dkdp_->ScatterMasterToGhosted("face");
-    }
-
     AnalyticJacobian_(*u);
   }
 }
@@ -238,14 +233,6 @@ void PDE_DiffusionFV::UpdateMatricesNewtonCorrection(
   // Add derivatives to the matrix (Jacobian in this case)
   if (newton_correction_ == OPERATOR_DIFFUSION_JACOBIAN_TRUE && u.get()) {
     AMANZI_ASSERT(u != Teuchos::null);
-
-    if (k_ != Teuchos::null) {
-      if (k_->HasComponent("face")) k_->ScatterMasterToGhosted("face");
-    }
-    if (dkdp_ != Teuchos::null) {
-      if (dkdp_->HasComponent("face")) dkdp_->ScatterMasterToGhosted("face");
-    }
-
     AnalyticJacobian_(*u);
   }
 }  
@@ -386,7 +373,10 @@ void PDE_DiffusionFV::AnalyticJacobian_(const CompositeVector& u)
   AmanziMesh::Entity_ID_List cells, faces;
   double dkdp[2], pres[2];
 
-  const Epetra_MultiVector& dKdP_cell = *dkdp_->ViewComponent("cell");
+  dkdp_->ScatterMasterToGhosted("cell");
+  const Epetra_MultiVector& dKdP_cell = *dkdp_->ViewComponent("cell", true);
+  AMANZI_ASSERT(dKdP_cell.MyLength() == ncells_wghost);  
+  
   Teuchos::RCP<const Epetra_MultiVector> dKdP_face;
   if (dkdp_->HasComponent("face")) {
     dKdP_face = dkdp_->ViewComponent("face", true);
@@ -397,16 +387,13 @@ void PDE_DiffusionFV::AnalyticJacobian_(const CompositeVector& u)
     int mcells = cells.size();
 
     WhetStone::DenseMatrix Aface(mcells, mcells);
-
     for (int n = 0; n < mcells; n++) {
       int c1 = cells[n];
       pres[n] = uc[0][c1];
       dkdp[n] = dKdP_cell[0][c1];
     }
 
-    if (mcells == 1) {
-      dkdp[1] = dKdP_face.get() ? (*dKdP_face)[0][f] : 0.;
-    }
+    if (mcells == 1) dkdp[1] = dKdP_face.get() ? (*dKdP_face)[0][f] : 0.;
 
     // find the face direction from cell 0 to cell 1
     const auto& cfaces = mesh_->cell_get_faces(cells[0]);
@@ -415,7 +402,6 @@ void PDE_DiffusionFV::AnalyticJacobian_(const CompositeVector& u)
     int f_index = std::find(cfaces.begin(), cfaces.end(), f) - cfaces.begin();
     ComputeJacobianLocal_(mcells, f, fdirs[f_index], bc_model[f], bc_value[f],
                           pres, dkdp, Aface);
-
     jac_op_->matrices[f] = Aface;
   }
 }


### PR DESCRIPTION
fixes some logic about communication, removes some unnecessary communication, and asserts that communication can happen when it is requested

- ASSERTS when Scatter is called but vector !ghosted
- PDE_DiffusionFV had unnecessary/unused communication
- adds some missing communication that previously relied on the user to have already done

Note that this may mean that Amanzi can remove some Scatter() calls?