### PR TITLE
Optional parameter for initialization logic

### DIFF
--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -715,7 +715,7 @@ void State::InitializeFields(const Tag& tag)
           flag = "[ok]";
           Teuchos::ParameterList sublist = state_plist_.sublist("initial conditions").sublist(e.first);
           sublist.set<double>("time", t_ini);
-          e.second->Initialize(sublist);
+          e.second->Initialize(sublist, true);
         } else {
           // check for domain set
           KeyTriple split;

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -713,9 +713,11 @@ void State::InitializeFields(const Tag& tag)
       if (pre_initialization || !e.second->isInitialized(failed)) {
         if (state_plist_.sublist("initial conditions").isSublist(e.first)) {
           flag = "[ok]";
-          Teuchos::ParameterList sublist = state_plist_.sublist("initial conditions").sublist(e.first);
-          sublist.set<double>("time", t_ini);
-          e.second->Initialize(sublist, true);
+          if (state_plist_.sublist("initial conditions").isSublist(e.first)) {
+            Teuchos::ParameterList sublist = state_plist_.sublist("initial conditions").sublist(e.first);
+            sublist.set<double>("time", t_ini);
+            e.second->Initialize(sublist, true);
+          }
         } else {
           // check for domain set
           KeyTriple split;

--- a/src/state/data/Record.cc
+++ b/src/state/data/Record.cc
@@ -71,7 +71,8 @@ bool Record::ReadCheckpoint(const Checkpoint& chkp, const Tag& tag,
 }
 
 bool Record::Initialize(Teuchos::ParameterList& plist,
-                        const std::vector<std::string>* subfieldnames)
+                        const std::vector<std::string>* subfieldnames,
+			bool force)
 {
   // check meta-data
   if (plist.isParameter("write checkpoint")) {
@@ -85,7 +86,7 @@ bool Record::Initialize(Teuchos::ParameterList& plist,
   }
 
   bool initialized_here = false;
-  if (!initialized()) {
+  if (!initialized() || force) {
     initialized_here = data_.Initialize(plist, vis_fieldname(), subfieldnames);
     if (initialized_here) set_initialized();
   }

--- a/src/state/data/Record.hh
+++ b/src/state/data/Record.hh
@@ -61,7 +61,8 @@ class Record {
   bool ReadCheckpoint(const Checkpoint& chkp, const Tag& tag,
                       const std::vector<std::string>* subfieldnames=nullptr);
   bool Initialize(Teuchos::ParameterList& plist,
-                  const std::vector<std::string>* subfieldnames=nullptr);
+                  const std::vector<std::string>* subfieldnames=nullptr,
+                  bool force = false);
 
   // Data setters/getters
   template <typename T> const T& Get() const {

--- a/src/state/data/RecordSet.cc
+++ b/src/state/data/RecordSet.cc
@@ -41,10 +41,10 @@ void RecordSet::ReadCheckpoint(const Checkpoint& chkp) {
     e.second->ReadCheckpoint(chkp, e.first, subfieldnames());
   }
 }
-bool RecordSet::Initialize(Teuchos::ParameterList& plist) {
+bool RecordSet::Initialize(Teuchos::ParameterList& plist, bool force) {
   bool init = false;
   for (auto& e : records_) {
-    init |= e.second->Initialize(plist, subfieldnames());
+    init |= e.second->Initialize(plist, subfieldnames(), force);
   }
   return init;
 }

--- a/src/state/data/RecordSet.hh
+++ b/src/state/data/RecordSet.hh
@@ -71,7 +71,7 @@ class RecordSet {
   void WriteVis(const Visualization& vis, Tag const * const=nullptr) const;
   void WriteCheckpoint(const Checkpoint& chkp, bool post_mortem=false) const;
   void ReadCheckpoint(const Checkpoint& chkp);
-  bool Initialize(Teuchos::ParameterList& plist);
+  bool Initialize(Teuchos::ParameterList& plist, bool force=false);
   void Assign(const Tag& dest, const Tag& source);
   void AssignPtr(const Tag& dest, const Tag& source);
 


### PR DESCRIPTION
Initialization is enforced in one place only, when we read initial conditions in State. Amanzi "initialize" rule allows to overwrite data using state->initial condition list.