### PR TITLE
Support of vandelay vector for non-uniform face-components

### DIFF
--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -427,6 +427,7 @@ class CompositeVector {
 
   // vector for boundary data
   mutable Teuchos::RCP<Epetra_MultiVector> vandelay_vector_;
+  mutable Teuchos::RCP<Epetra_Import> vandelay_import_;
 };
 
 


### PR DESCRIPTION
If a face  component is based on a BlockMap, then the mesh exterior face map cannot be used. My suggestion is to create a  local importer which takes into account different number of DOFs on interior mesh faces to create an optional new importer.  