### PR TITLE
netcdf-fortran cmake fixes

### DIFF
--- a/config/SuperBuild/include/Build_NetCDF_Fortran.cmake
+++ b/config/SuperBuild/include/Build_NetCDF_Fortran.cmake
@@ -19,19 +19,18 @@ amanzi_tpl_version_write(FILENAME ${TPL_VERSIONS_INCLUDE_FILE}
   VERSION ${NetCDF_Fortran_VERSION_MAJOR} ${NetCDF_Fortran_VERSION_MINOR} ${NetCDF_Fortran_VERSION_PATCH})
   
 # --- Patch original code
-#set(NetCDF_Fortran_patch_file )
-#set(NetCDF_Fortran_sh_patch ${NetCDF_Fortran_prefix_dir}/netcdf-fortran-patch-step.sh)
-#configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/netcdf-fortran-patch-step.sh.in
-#               ${NetCDF_Fortran_sh_patch}
-#               @ONLY)
-
+set(NetCDF_Fortran_patch_file netcdf-fortran-4.5.4-cmake.patch)
+set(NetCDF_Fortran_sh_patch ${NetCDF_Fortran_prefix_dir}/netcdf-fortran-patch-step.sh)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/netcdf-fortran-patch-step.sh.in
+               ${NetCDF_Fortran_sh_patch}
+               @ONLY)
 # configure the CMake patch step
-#set(NetCDF_Fortran_cmake_patch ${NetCDF_Fortran_prefix_dir}/netcdf-fortran-patch-step.cmake)
-#configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/netcdf-fortran-patch-step.cmake.in
-#               ${NetCDF_Fortran_cmake_patch}
-#               @ONLY)
+set(NetCDF_Fortran_cmake_patch ${NetCDF_Fortran_prefix_dir}/netcdf-fortran-patch-step.cmake)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/netcdf-fortran-patch-step.cmake.in
+               ${NetCDF_Fortran_cmake_patch}
+               @ONLY)
 
-#set(NetCDF_Fortran_PATCH_COMMAND ${CMAKE_COMMAND} -P ${NetCDF_Fortran_cmake_patch})
+set(NetCDF_Fortran_PATCH_COMMAND ${CMAKE_COMMAND} -P ${NetCDF_Fortran_cmake_patch})
 
 # --- Define the configure command
 set(NetCDF_Fortran_CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:FILEPATH=${TPL_INSTALL_PREFIX}")
@@ -56,7 +55,7 @@ ExternalProject_Add(${NetCDF_Fortran_BUILD_TARGET}
                     URL ${NetCDF_Fortran_URL}                 # URL may be a web site OR a local file
                     URL_MD5 ${NetCDF_Fortran_MD5_SUM}         # md5sum of the archive file
                     DOWNLOAD_NAME ${NetCDF_Fortran_SAVEAS_FILE}  # file name to store
-                    # PATCH_COMMAND ${NetCDF_Fortran_PATCH_COMMAND} 
+                    PATCH_COMMAND ${NetCDF_Fortran_PATCH_COMMAND} 
                     # -- Configure
                     SOURCE_DIR ${NetCDF_Fortran_source_dir}
                     CMAKE_CACHE_ARGS ${AMANZI_CMAKE_CACHE_ARGS}   # Ensure uniform build
@@ -78,5 +77,13 @@ ExternalProject_Add(${NetCDF_Fortran_BUILD_TARGET}
                     ${NetCDF_Fortran_logging_args})
 
 
-# --- Useful variables for packages that depend on NetCDF (Trilinos)
+# --- Useful variables for packages that depend on NetCDF-Fortran (E3SM Land Model, aka ELM)
+build_library_name(netcdff NetCDF_FORTRAN_LIBRARY APPEND_PATH ${TPL_INSTALL_PREFIX}/lib)
 set(NetCDF_FORTRAN_DIR ${TPL_INSTALL_PREFIX})
+set(NetCDF_FORTRAN_INCLUDE_DIRS ${TPL_INSTALL_PREFIX}/include)
+set(NetCDF_FORTRAN_LIBRARIES ${NetCDF_FORTRAN_LIBRARY})
+if (ENABLE_NetCDF4)
+  list(APPEND NetCDF_FORTRAN_LIBRARIES ${NetCDF_C_LIBRARIES} ${HDF5_LIBRARIES})
+  list(APPEND NetCDF_FORTRAN_INCLUDE_DIRS ${NetCDF_INCLUDE_DIRS} ${HDF5_INCLUDE_DIRS})
+  list(REMOVE_DUPLICATES NetCDF_FORTRAN_INCLUDE_DIRS)
+endif()

--- a/config/SuperBuild/templates/netcdf-fortran-4.5.4-cmake.patch
+++ b/config/SuperBuild/templates/netcdf-fortran-4.5.4-cmake.patch
@@ -1,0 +1,45 @@
+--- netcdf-fortran-4.5.4-source/fortran/CMakeLists-orig.txt	2023-02-06 13:33:49.000000000 -0500
++++ netcdf-fortran-4.5.4-source/fortran/CMakeLists.txt	2023-02-06 13:38:03.000000000 -0500
+@@ -148,14 +148,14 @@
+ # ADD_LIBRARY(netcdff STATIC SHARED ${netcdff_SOURCES})
+ # Builds only static, not shared
+ # Compile C-code to object, then link with Fortran
+-ADD_LIBRARY(netcdff_c OBJECT ${netcdff_C_SOURCES})
+-install(TARGETS netcdff_c OBJECTS DESTINATION lib)
+-# or is this better?   list(APPEND NETCDF_C_LIBRARY netcdff_c)
+-SET(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} netcdff_c)
+-set_target_properties(netcdff_c PROPERTIES
++ADD_LIBRARY(netcdf OBJECT ${netcdff_C_SOURCES})
++install(TARGETS netcdf OBJECTS DESTINATION lib)
++# or is this better?   list(APPEND NETCDF_C_LIBRARY netcdf)
++SET(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} netcdf)
++set_target_properties(netcdf PROPERTIES
+     INTERFACE_INCLUDE_DIRECTORIES "${NETCDF_C_INCLUDE_DIR}"
+   )
+-target_include_directories(netcdff_c PUBLIC "${NETCDF_C_INCLUDE_DIR}")
++target_include_directories(netcdf PUBLIC "${NETCDF_C_INCLUDE_DIR}")
+ 
+ ADD_LIBRARY(netcdff ${netcdff_SOURCES})
+ TARGET_LINK_LIBRARIES(netcdff PUBLIC netCDF::netcdf)
+@@ -171,9 +171,9 @@
+   $<INSTALL_INTERFACE:include>
+   )
+ 
+-if (HAVE_NC_USE_PARALLEL_ENABLED)
+-  target_link_libraries(netcdff PUBLIC MPI::MPI_Fortran)
+-endif()
++#if (HAVE_NC_USE_PARALLEL_ENABLED)
++#  target_link_libraries(netcdff PUBLIC MPI::MPI_Fortran)
++#endif()
+ 
+ # copied from netcdf-c... Changed from ADD_DEFINITIONS to TARGET_COMPILE_DEFINITIONS
+ # Option to Build DLL
+@@ -210,7 +210,7 @@
+ ENDIF()
+ 
+ # Installation of the program
+-INSTALL(TARGETS netcdff netcdff_c
++INSTALL(TARGETS netcdff
+     EXPORT netcdffTargets
+     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
+     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib


### PR DESCRIPTION
When using CMake to build NetCDF-Fortran, there appears 2 unknown libraries called 'MPI::MPI_Fortran' and 'netcdff_c', which actually could not be found anywhere.