### PR TITLE
Fix on confusing versions between AMANZI_TPLS and AMANZI.

### DIFF
--- a/config/SuperBuild/CMakeLists.txt
+++ b/config/SuperBuild/CMakeLists.txt
@@ -161,7 +161,7 @@ set(TPL_VERSIONS_INCLUDE_FILE ${CMAKE_BINARY_DIR}/tpl_versions.h)
 file(WRITE ${TPL_VERSIONS_INCLUDE_FILE} "")
 install(FILES ${CMAKE_BINARY_DIR}/tpl_versions.h DESTINATION include)
 amanzi_tpl_version_write(FILENAME ${TPL_VERSIONS_INCLUDE_FILE}
-  PREFIX AMANZI
+  PREFIX AMANZI_TPLS
   VERSION ${AMANZI_TPLS_VERSION_MAJOR} ${AMANZI_TPLS_VERSION_MINOR} ${AMANZI_TPLS_VERSION_PATCH})
 
 # ############################################################################ #

--- a/src/common/standalone_simulation_coordinator/Main.cc
+++ b/src/common/standalone_simulation_coordinator/Main.cc
@@ -131,12 +131,12 @@ main(int argc, char* argv[])
 
     if (print_tpl_versions) {
       if (rank == 0) {
-#ifdef AMANZI_MAJOR
-        std::cout << "Amanzi TPL collection version " << XSTR(AMANZI_MAJOR) << "."
-                  << XSTR(AMANZI_MINOR) << "." << XSTR(AMANZI_PATCH) << std::endl;
+          std::cout << "Third party libraries that above amanzi binary is linked against:"
+                    << std::endl;
+#ifdef AMANZI_TPLS_MAJOR
+        std::cout << "Amanzi TPL collection version " << XSTR(AMANZI_TPLS_MAJOR) << "."
+                  << XSTR(AMANZI_TPLS_MINOR) << "." << XSTR(AMANZI_TPLS_PATCH) << std::endl;
 #endif
-        std::cout << "Third party libraries that this amanzi binary is linked against:"
-                  << std::endl;
 #ifdef ALQUIMIA_MAJOR
         std::cout << "  ALQUIMIA       " << XSTR(ALQUIMIA_MAJOR) << "." << XSTR(ALQUIMIA_MINOR)
                   << "." << XSTR(ALQUIMIA_PATCH) << std::endl;


### PR DESCRIPTION
In AMANZI_TPLS version file, it's better to rename AMANZI to AMANZI_TPLS, because it's actually TPLS version rather than AMANZI version.