### PR TITLE
Ecoon/mesh refactor predevicework

### DIFF
--- a/src/mesh/MeshAudit_decl.hh
+++ b/src/mesh/MeshAudit_decl.hh
@@ -27,10 +27,11 @@ public:
 
  protected:
   // helpers for doing the testing
-  bool areDistinctValues_(const AmanziMesh::cEntity_ID_View& list) const;
+  bool areDistinctValues_(const AmanziMesh::View_type<const Entity_ID, MemSpace_kind::HOST>& list) const;
   void writeList_(const Entity_ID_List&) const;
   bool globalAny_(bool) const;
-  int isSameFace_(const AmanziMesh::cEntity_ID_View, const AmanziMesh::cEntity_ID_View) const;
+  int isSameFace_(const AmanziMesh::View_type<const Entity_ID, MemSpace_kind::HOST>,
+                  const AmanziMesh::View_type<const Entity_ID, MemSpace_kind::HOST>) const;
 
  protected:
   Teuchos::RCP<const Mesh_type> mesh_;

--- a/src/mesh/MeshAudit_impl.hh
+++ b/src/mesh/MeshAudit_impl.hh
@@ -360,7 +360,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_cell_to_nodes() const
 {
   Entity_ID_List bad_cells, bad_cells1;
   Entity_ID_View free_nodes;
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
     try {
@@ -397,7 +397,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_cell_to_nodes() const
 template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_node_refs_by_cells() const
 {
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
   std::vector<bool> ref(nnodes_all_, false);
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
@@ -429,7 +429,7 @@ template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_cell_to_faces() const
 {
   Entity_ID_List bad_cells, bad_cells1;
-  cEntity_ID_View cface;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cface;
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
     try {
@@ -468,7 +468,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_cell_to_faces() const
 template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_face_refs_by_cells() const
 {
-  cEntity_ID_View cface;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cface;
   std::vector<unsigned int> refs(nfaces_all_, 0);
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
@@ -512,7 +512,7 @@ template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_face_to_nodes() const
 {
   Entity_ID_List bad_faces, bad_faces1;
-  cEntity_ID_View fnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> fnode;
 
   for (Entity_ID j = 0; j < nfaces_all_; ++j) {
     try {
@@ -549,7 +549,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_face_to_nodes() const
 template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_node_refs_by_faces() const
 {
-  cEntity_ID_View fnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> fnode;
   std::vector<bool> ref(nnodes_all_, false);
 
   for (Entity_ID j = 0; j < nfaces_all_; ++j) {
@@ -580,8 +580,8 @@ bool MeshAudit_Geometry<Mesh_type>::check_node_refs_by_faces() const
 template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_cell_to_face_dirs() const
 {
-  cEntity_ID_View faces;
-  cEntity_Direction_View fdirs;
+  View_type<const Entity_ID, MemSpace_kind::HOST> faces;
+  View_type<const Direction_type, MemSpace_kind::HOST> fdirs;
   Entity_ID_List bad_cells, bad_cells_exc;
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
@@ -625,7 +625,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_cell_degeneracy() const
 {
   os_ << "Checking cells for topological degeneracy ..." << std::endl;
 
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
   Entity_ID_List bad_cells;
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
@@ -655,6 +655,11 @@ bool MeshAudit_Geometry<Mesh_type>::check_cell_degeneracy() const
 template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_cell_to_faces_to_nodes() const
 {
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cface;
+  Entity_ID_View fnode_ref;
+  View_type<const Entity_ID, MemSpace_kind::HOST> fnode;
+  View_type<const Direction_type, MemSpace_kind::HOST> fdirs;
   Entity_ID_List bad_cells0;
   Entity_ID_List bad_cells1;
 
@@ -788,7 +793,7 @@ template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_cell_to_coordinates() const
 {
   int spdim = mesh_->getSpaceDimension();
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
   Entity_ID_List bad_cells, bad_cells_exc;
 
   for (Entity_ID j = 0; j < ncells_all_; ++j) {
@@ -841,7 +846,7 @@ template<class Mesh_type>
 bool MeshAudit_Geometry<Mesh_type>::check_face_to_coordinates() const
 {
   int spdim = mesh_->getSpaceDimension();
-  cEntity_ID_View fnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> fnode;
   Entity_ID_List bad_faces, bad_faces_exc;
 
   for (Entity_ID j = 0; j < nfaces_all_; ++j) {
@@ -896,11 +901,11 @@ bool MeshAudit_Geometry<Mesh_type>::check_face_cell_adjacency_consistency() cons
     try {
       bool bad_data = false;
 
-      cEntity_ID_View fcells;
+      View_type<const Entity_ID, MemSpace_kind::HOST> fcells;
       mesh_->getFaceCells(f, Parallel_kind::ALL, fcells);
       for (const auto& c : fcells) {
-        cEntity_ID_View cfaces;
-        cEntity_Direction_View cfdirs;
+        View_type<const Entity_ID, MemSpace_kind::HOST> cfaces;
+        View_type<const Direction_type, MemSpace_kind::HOST> cfdirs;
         mesh_->getCellFacesAndDirs(c, cfaces, &cfdirs);
 
         // find the match
@@ -971,7 +976,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_face_normal_relto_cell() const
     try {
       auto fc = mesh_->getFaceCentroid(j);
 
-      cEntity_ID_View fcells;
+      View_type<const Entity_ID, MemSpace_kind::HOST> fcells;
       mesh_->getFaceCells(j, Parallel_kind::ALL, fcells);
       for (int k = 0; k < fcells.size(); ++k) {
         AmanziGeometry::Point cc = mesh_->getCellCentroid(fcells[k]);
@@ -1015,7 +1020,7 @@ bool MeshAudit_Geometry<Mesh_type>::check_face_normal_orientation() const
     try {
       AmanziGeometry::Point fnormal = mesh_->getFaceNormal(j);
 
-      cEntity_ID_View fcells;
+      View_type<const Entity_ID, MemSpace_kind::HOST> fcells;
       mesh_->getFaceCells(j, Parallel_kind::ALL, fcells);
       for (int k = 0; k < fcells.size(); ++k) {
         int orientation = 0;
@@ -1269,7 +1274,7 @@ bool MeshAudit_Maps<Mesh_type>::check_face_to_nodes_ghost_data() const
   int nface_own = face_map_own.NumMyElements();
   int nface_use = face_map_use.NumMyElements();
 
-  cEntity_ID_View fnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> fnode;
   Entity_ID_List bad_faces, bad_faces1, bad_faces2;
 
   // Create a matrix of the GIDs for all owned faces.
@@ -1392,7 +1397,7 @@ bool MeshAudit_Maps<Mesh_type>::check_cell_to_nodes_ghost_data() const
   int ncell_own = cell_map_own.NumMyElements();
   int ncell_use = cell_map_use.NumMyElements();
 
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
   Entity_ID_List bad_cells;
 
   int maxnodes = 0;
@@ -1477,7 +1482,7 @@ bool MeshAudit_Maps<Mesh_type>::check_cell_to_faces_ghost_data() const
   int ncell_own = cell_map_own.NumMyElements();
   int ncell_use = cell_map_use.NumMyElements();
 
-  cEntity_ID_View cface;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cface;
   Entity_ID_List bad_cells;
 
   // Create a matrix of the GIDs for all owned cells.
@@ -1936,7 +1941,7 @@ bool MeshAudit_Maps<Mesh_type>::check_face_partition() const
   // Mark all the faces contained by owned cells.
   bool owned[nfaces_all_];
   for (int j = 0; j < nfaces_all_; ++j) owned[j] = false;
-  cEntity_ID_View cface;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cface;
   for (Entity_ID j = 0; j < mesh_->getMap(AmanziMesh::Entity_kind::CELL, false).NumMyElements(); ++j) {
     mesh_->getCellFaces(j, cface);
     for (int k = 0; k < cface.size(); ++k) owned[cface[k]] = true;
@@ -1964,7 +1969,7 @@ bool MeshAudit_Maps<Mesh_type>::check_node_partition() const
   // Mark all the nodes contained by owned cells.
   bool owned[nnodes_all_];
   for (int j = 0; j < nnodes_all_; ++j) owned[j] = false;
-  cEntity_ID_View cnode;
+  View_type<const Entity_ID, MemSpace_kind::HOST> cnode;
   for (Entity_ID j = 0; j < mesh_->getMap(AmanziMesh::Entity_kind::CELL, false).NumMyElements(); ++j) {
     mesh_->getCellNodes(j, cnode);
     for (int k = 0; k < cnode.size(); ++k) owned[cnode[k]] = true;
@@ -1988,7 +1993,7 @@ bool MeshAudit_Maps<Mesh_type>::check_node_partition() const
 
 // Returns true if the values in the list are distinct -- no repeats.
 template<class Mesh_type>
-bool MeshAudit_Base<Mesh_type>::areDistinctValues_(const cEntity_ID_View &list) const
+bool MeshAudit_Base<Mesh_type>::areDistinctValues_(const View_type<const Entity_ID, MemSpace_kind::HOST> &list) const
 {
   Entity_ID_List copy(list.data(), list.data()+list.size());
   sort(copy.begin(), copy.end());
@@ -2002,7 +2007,7 @@ bool MeshAudit_Base<Mesh_type>::areDistinctValues_(const cEntity_ID_View &list) 
 // faces.  Implicitly assumes non-degenerate faces; the results are not
 // reliable otherwise.
 template<class Mesh_type>
-int MeshAudit_Base<Mesh_type>::isSameFace_(const cEntity_ID_View fnode1, const cEntity_ID_View fnode2) const
+int MeshAudit_Base<Mesh_type>::isSameFace_(const View_type<const Entity_ID, MemSpace_kind::HOST> fnode1, const View_type<const Entity_ID, MemSpace_kind::HOST> fnode2) const
 {
   int nn = fnode1.size();
 

--- a/src/mesh/MeshCache_decl.hh
+++ b/src/mesh/MeshCache_decl.hh
@@ -413,13 +413,13 @@ struct MeshCache {
   // -------------------
   //
   // a list of ALL face LIDs that are on the boundary
-  decltype(auto) // MeshView<const Entity_ID*, MEM>
+  decltype(auto) // MeshView<const Entity_ID, MEM>
   getBoundaryFaces() const {
       return maps_.getBoundaryFaces<MEM>();
   }
 
   // a list of ALL node LIDs that are on the boundary
-  decltype(auto) // MeshView<const Entity_ID*, MEM>
+  decltype(auto) // MeshView<const Entity_ID, MEM>
   getBoundaryNodes() const {
       return maps_.getBoundaryNodes<MEM>();
   }
@@ -460,12 +460,12 @@ struct MeshCache {
                  const Entity_kind kind,
                  const Parallel_kind ptype) const;
 
-  decltype(auto) // cEntity_ID_View
+  decltype(auto) // View_type<const Entity_ID,MEM>
   getSetEntities(const std::string& region_name,
           const Entity_kind kind,
           const Parallel_kind ptype) const;
 
-  decltype(auto) // pair<cEntity_ID_View, cDouble_View>
+  decltype(auto) // pair<View_type<const Entity_ID,MEM>, cDouble_View>
   getSetEntitiesAndVolumeFractions(const std::string& region_name,
           const Entity_kind kind,
           const Parallel_kind ptype) const;
@@ -600,7 +600,7 @@ struct MeshCache {
   // note, no AccessPattern_kind -- as this creates a view there is no need
   template<AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
   KOKKOS_INLINE_FUNCTION
-  decltype(auto) // cEntity_ID_View
+  decltype(auto) // View_type<const Entity_ID,MEM>
   getCellFaces(const Entity_ID c) const;
 
   // note, no AccessPattern_kind -- only works on cached
@@ -608,28 +608,28 @@ struct MeshCache {
   const Entity_ID& getCellFace(const Entity_ID c, const size_type i) const;
 
   KOKKOS_INLINE_FUNCTION
-  decltype(auto) // Kokkos::pair<cEntity_ID_View, cEntity_Direction_View>
+  decltype(auto) // Kokkos::pair<View_type<const Entity_ID,MEM>, View_type<const Direction_type,MEM>>
   getCellFacesAndDirections(const Entity_ID c) const;
 
   KOKKOS_INLINE_FUNCTION
-  decltype(auto) // Kokkos::pair<cEntity_ID_View, cPoint_View>
+  decltype(auto) // Kokkos::pair<View_type<const Entity_ID,MEM>, cPoint_View>
   getCellFacesAndBisectors(const Entity_ID c) const;
 
   template<AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
   KOKKOS_INLINE_FUNCTION
   void getCellFaces(const Entity_ID c,
-                    cEntity_ID_View& faces) const;
+                    View_type<const Entity_ID,MEM>& faces) const;
 
   KOKKOS_INLINE_FUNCTION
   void getCellFacesAndDirs(const Entity_ID c,
-                           cEntity_ID_View& faces,
-                           cEntity_Direction_View * const dirs) const;
+                           View_type<const Entity_ID,MEM>& faces,
+                           View_type<const Direction_type,MEM> * const dirs) const;
 
 
   KOKKOS_INLINE_FUNCTION
   void getCellFacesAndBisectors(
           const Entity_ID c,
-          cEntity_ID_View& faces,
+          View_type<const Entity_ID,MEM>& faces,
           cPoint_View * const bisectors) const;
 
   // //
@@ -649,7 +649,7 @@ struct MeshCache {
   //[[deprecated("Prefer to use non-void variant that returns edges directly")]]
   template<AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
   KOKKOS_INLINE_FUNCTION
-  void getCellEdges(const Entity_ID c, cEntity_ID_View& edges) const;
+  void getCellEdges(const Entity_ID c, View_type<const Entity_ID,MEM>& edges) const;
 
   // // Get nodes of a cell.
   // template<AccessPattern_kind = AccessPattern_kind::DEFAULT>
@@ -664,7 +664,7 @@ struct MeshCache {
 
   //[[deprecated("Prefer to use non-void variant that returns nodes directly")]]
   KOKKOS_INLINE_FUNCTION
-  void getCellNodes(const Entity_ID c, cEntity_ID_View& nodes) const;
+  void getCellNodes(const Entity_ID c, View_type<const Entity_ID,MEM>& nodes) const;
 
   KOKKOS_INLINE_FUNCTION Entity_ID
   getCellCellBelow(const Entity_ID cellid) const; 
@@ -697,18 +697,18 @@ struct MeshCache {
   const Entity_ID& getFaceEdge(const Entity_ID f, const size_type i) const;
 
   KOKKOS_INLINE_FUNCTION
-  decltype(auto) // Kokkos::pair<cEntity_ID_View, cEntity_Direction_View>
+  decltype(auto) // Kokkos::pair<View_type<const Entity_ID,MEM>, View_type<const Direction_type,MEM>>
   getFaceEdgesAndDirections(const Entity_ID f) const;
 
   //[[deprecated("Prefer to use non-void variant that returns edges directly")]]
   KOKKOS_INLINE_FUNCTION
-  void getFaceEdges(const Entity_ID f, cEntity_ID_View& fedges) const;
+  void getFaceEdges(const Entity_ID f, View_type<const Entity_ID,MEM>& fedges) const;
 
   //[[deprecated("Prefer to use non-void variant that returns edges directly")]]
   KOKKOS_INLINE_FUNCTION
   void getFaceEdgesAndDirs(const Entity_ID f,
-                           cEntity_ID_View& edges,
-                           cEntity_Direction_View * const dirs=nullptr) const;
+                           View_type<const Entity_ID,MEM>& edges,
+                           View_type<const Direction_type,MEM> * const dirs=nullptr) const;
 
   KOKKOS_INLINE_FUNCTION
   std::vector<int> getFaceCellEdgeMap(const Entity_ID faceid,
@@ -729,7 +729,7 @@ struct MeshCache {
   const Entity_ID& getFaceNode(const Entity_ID f, const size_type i) const;
   // //[[deprecated("Prefer to use non-void variant that returns nodes directly")]]
   KOKKOS_INLINE_FUNCTION
-  void getFaceNodes(const Entity_ID f, cEntity_ID_View& nodes) const;
+  void getFaceNodes(const Entity_ID f, View_type<const Entity_ID,MEM>& nodes) const;
 
   // //
   // // NOT CURRENTLY IMPLEMENTED, here to satisfy the interface
@@ -763,7 +763,7 @@ struct MeshCache {
   //[[deprecated("Prefer to use non-void variant that returns nodes directly")]]
   template<AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
   KOKKOS_INLINE_FUNCTION
-  void getEdgeNodes(const Entity_ID e, cEntity_ID_View& nodes) const;
+  void getEdgeNodes(const Entity_ID e, View_type<const Entity_ID,MEM>& nodes) const;
 
   // //-------------------
   // // Upward adjacencies
@@ -780,7 +780,7 @@ struct MeshCache {
   size_type getFaceNumCells(const Entity_ID f, const Parallel_kind ptype) const;
 
   KOKKOS_INLINE_FUNCTION
-  decltype(auto) // cEntity_ID_View
+  decltype(auto) // View_type<const Entity_ID,MEM>
   getFaceCells(const Entity_ID f, const Parallel_kind ptype) const;
 
   KOKKOS_INLINE_FUNCTION
@@ -790,7 +790,7 @@ struct MeshCache {
   KOKKOS_INLINE_FUNCTION
   void getFaceCells(const Entity_ID f,
                     const Parallel_kind ptype,
-                    cEntity_ID_View & cells) const;
+                    View_type<const Entity_ID,MEM> & cells) const;
 
   KOKKOS_INLINE_FUNCTION
   std::size_t getCellMaxFaces() const;
@@ -812,7 +812,7 @@ struct MeshCache {
   KOKKOS_INLINE_FUNCTION
   void getEdgeCells(const Entity_ID e,
                     const Parallel_kind ptype,
-                    cEntity_ID_View& cells) const;
+                    View_type<const Entity_ID,MEM>& cells) const;
 
   // // Faces of type 'ptype' connected to an edge
   // // NOTE: The order of faces is not guaranteed to be the same for
@@ -826,7 +826,7 @@ struct MeshCache {
   KOKKOS_INLINE_FUNCTION
   void getEdgeFaces(const Entity_ID edgeid,
                     const Parallel_kind ptype,
-                    cEntity_ID_View& faces) const; 
+                    View_type<const Entity_ID,MEM>& faces) const; 
 
   // // Cells of type 'ptype' connected to a node
   // // NOTE: The order of cells is not guaranteed to be the same for
@@ -841,7 +841,7 @@ struct MeshCache {
   KOKKOS_INLINE_FUNCTION
   void getNodeCells(const Entity_ID n,
                     const Parallel_kind ptype,
-                    cEntity_ID_View& cells) const;
+                    View_type<const Entity_ID,MEM>& cells) const;
 
   // // Faces of type parallel 'ptype' connected to a node
   // // NOTE: The order of faces is not guarnateed to be the same for
@@ -855,7 +855,7 @@ struct MeshCache {
   KOKKOS_INLINE_FUNCTION
   void getNodeFaces(const Entity_ID n,
                     const Parallel_kind ptype,
-                    cEntity_ID_View& faces) const; 
+                    View_type<const Entity_ID,MEM>& faces) const; 
 
   void PrintMeshStatistics() const; 
 
@@ -866,7 +866,7 @@ struct MeshCache {
   // // The order of edges is not guaranteed to be the same for corresponding
   // // node on different processors
   // KOKKOS_INLINE_FUNCTION
-  // cEntity_ID_View getNodeEdges(const Entity_ID n,
+  // View_type<const Entity_ID,MEM> getNodeEdges(const Entity_ID n,
   //         const Parallel_kind ptype) const {
   //   Errors::Message msg("MeshCache::getNodeEdges not implemented");
   //   Exceptions::amanzi_throw(msg);
@@ -877,7 +877,7 @@ struct MeshCache {
   // KOKKOS_INLINE_FUNCTION
   // void getNodeEdges(const Entity_ID n,
   //                   const Parallel_kind ptype,
-  //                   cEntity_ID_View& edgeids) const {
+  //                   View_type<const Entity_ID,MEM>& edgeids) const {
   //   Errors::Message msg("MeshCache::getNodeEdges not implemented");
   //   Exceptions::amanzi_throw(msg);
   // }

--- a/src/mesh/MeshDefs.hh
+++ b/src/mesh/MeshDefs.hh
@@ -24,7 +24,7 @@
 #include "errors.hh"
 #include "Point.hh"
 
-#include "MeshUtils.hh"
+#include "MeshView.hh"
 
 namespace Amanzi {
 namespace AmanziMesh {
@@ -236,131 +236,6 @@ enum class AccessPattern_kind {
   FRAMEWORK
 };
 
-
-template<MemSpace_kind MEM>
-struct MeshCache;
-
-template<MemSpace_kind MEM = MemSpace_kind::HOST, AccessPattern_kind AP = AccessPattern_kind::DEFAULT> 
-struct Getter {
-  template<typename DATA, typename MF, typename FF, typename CF> 
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get(bool cached, DATA& d, MF& mf, FF&& f, CF&& c, const Entity_ID i){
-      using type_t = typename DATA::t_dev::traits::value_type; 
-      // To avoid the cast to non-reference 
-      if (cached) return static_cast<type_t>(view<MEM>(d)(i));
-      if constexpr(MEM == MemSpace_kind::HOST){
-        if constexpr (!std::is_same_v<FF,decltype(nullptr)>)
-          if(mf.get())
-            return f(i);
-      }
-      if constexpr (!std::is_same_v<CF,decltype(nullptr)>)
-        return c(i);
-      assert(false); 
-      return type_t{}; 
-  }
-}; // Getter
-
-template<MemSpace_kind MEM> 
-struct Getter<MEM,AccessPattern_kind::CACHE> {
-  template<typename DATA, typename MF, typename FF, typename CF> 
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get(bool cached, DATA& d, MF&, FF&&, CF&&, const Entity_ID i){
-      assert(cached);
-      return view<MEM>(d)(i);
-  }
-}; // Getter
-
-template<MemSpace_kind MEM> 
-struct Getter<MEM,AccessPattern_kind::FRAMEWORK> {
-  template<typename DATA, typename MF, typename FF, typename CF> 
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get(bool, DATA&, MF& mf, FF&& f, CF&&, const Entity_ID i){
-      static_assert(!std::is_same<FF,decltype(nullptr)>::value); 
-      static_assert(MEM == MemSpace_kind::HOST);
-      assert(mf.get()); 
-      return f(i);
-  }
-}; // Getter
-
-
-template<MemSpace_kind MEM> 
-struct Getter<MEM,AccessPattern_kind::COMPUTE> {
-  template<typename DATA, typename MF, typename FF, typename CF> 
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get(bool, DATA&, MF&, FF&&, CF&& c, const Entity_ID i){
-    static_assert(!std::is_same<CF,decltype(nullptr)>::value); 
-    return c(i); 
-  }
-}; // Getter
-
-
-// Getters for raggedViews
-template<MemSpace_kind MEM = MemSpace_kind::HOST, AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
-struct RaggedGetter{ 
-  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
-  static KOKKOS_INLINE_FUNCTION decltype(auto)
-  get (bool cached, DATA& d, MF& mf, FF&& f, CFD&& cd, CF&& c, const Entity_ID n) {
-    using view_t = typename decltype(d.template getRow<MEM>(n))::const_type;
-    if (cached) {
-      return static_cast<view_t>(d.template getRowUnmanaged<MEM>(n));  
-    }
-    if constexpr(MEM == MemSpace_kind::HOST){
-
-      if constexpr (!std::is_same<FF,decltype(nullptr)>::value){
-        if(mf.get()){
-          return static_cast<view_t>(f(n));
-        }
-      }
-      if constexpr (!std::is_same<CF,decltype(nullptr)>::value){
-        return static_cast<view_t>(c(c));
-      }
-    } else {
-      if constexpr (!std::is_same<CFD,decltype(nullptr)>::value) {
-        static_cast<view_t>(cd(c)); 
-      }
-    }
-    assert(false && "No access to cache/framework/compute available"); 
-    return view_t{}; 
-  }
-};
-
-template<MemSpace_kind MEM>
-struct RaggedGetter<MEM,AccessPattern_kind::CACHE>{
-  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get (bool cached, DATA& d, MF&, FF&&, CFD&&, CF&&, const Entity_ID n) { 
-    assert(cached);
-    return d.template getRowUnmanaged<MEM>(n); 
-  }
-};
-
-template<MemSpace_kind MEM>
-struct RaggedGetter<MEM,AccessPattern_kind::FRAMEWORK>{
-  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get (bool, DATA&, MF& mf, FF&& f, CFD&&, CF&&, const Entity_ID n) { 
-    static_assert(!std::is_same<FF,decltype(nullptr)>::value); 
-    static_assert(MEM == MemSpace_kind::HOST);
-    assert(mf.get()); 
-    return f(n);
-  }
-};
-
-template<MemSpace_kind MEM>
-struct RaggedGetter<MEM,AccessPattern_kind::COMPUTE>{
-  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
-  static KOKKOS_INLINE_FUNCTION decltype(auto) 
-  get (bool, DATA&, MF&, FF&&, CFD&& cd, CF&& c, const Entity_ID n) { 
-    if constexpr(MEM == MemSpace_kind::HOST){
-      static_assert(!std::is_same<CF,decltype(nullptr)>::value); 
-      return c(n); 
-    }else{
-      static_assert(MEM==MemSpace_kind::DEVICE); 
-      static_assert(!std::is_same<CFD,decltype(nullptr)>::value); 
-      return cd(n); 
-    }
-  }
-};
 
 using MeshSets = std::map<std::tuple<std::string,Entity_kind,Parallel_kind>, Entity_ID_DualView>;
 using MeshSetVolumeFractions = std::map<std::tuple<std::string,Entity_kind,Parallel_kind>, Double_DualView>;

--- a/src/mesh/MeshDefs.hh
+++ b/src/mesh/MeshDefs.hh
@@ -22,6 +22,7 @@
 #include "Epetra_Import.h"
 
 #include "errors.hh"
+#include "AmanziTypes.hh"
 #include "Point.hh"
 
 #include "MeshView.hh"
@@ -32,15 +33,31 @@ namespace AmanziMesh {
 //
 // Typedefs
 //
+using size_type = Kokkos::MeshView<int*, Kokkos::DefaultHostExecutionSpace>::size_type;
 using Entity_ID = int;
 using Entity_GID = int;
 using Set_ID = int;
-using size_type = Kokkos::MeshView<int*, Kokkos::DefaultHostExecutionSpace>::size_type;
+using Direction_type = int;
+
+namespace Impl {
+template<MemSpace_kind MEM>
+struct MemorySpace {
+  using space = Amanzi::DefaultMemorySpace;
+};
+
+template<>
+struct MemorySpace<MemSpace_kind::HOST> {
+  using space = Amanzi::DefaultHostMemorySpace;
+};
+
+} // namespace Impl
 
 //
 // Views are on host or device
 //
-template<typename T> using View_type = Kokkos::MeshView<T*, Kokkos::DefaultHostExecutionSpace>;
+template<typename T, MemSpace_kind MEM=MemSpace_kind::HOST>
+using View_type = Kokkos::MeshView<T*, typename Impl::MemorySpace<MEM>::space>;
+
 using Entity_ID_View = View_type<Entity_ID>;
 using cEntity_ID_View = View_type<const Entity_ID>;
 using Entity_GID_View = View_type<Entity_GID>;
@@ -79,12 +96,6 @@ struct RaggedArray_View {
 };
 
 
-using Map_type = Epetra_Map;
-using Map_ptr_type = Teuchos::RCP<Map_type>;
-using Import_type = Epetra_Import;
-using Import_ptr_type = Teuchos::RCP<Import_type>;
-
-
 // Cells (aka zones/elements) are the highest dimension entities in a mesh
 // Nodes (aka vertices) are lowest dimension entities in a mesh
 // Faces in a 3D mesh are 2D entities, in a 2D mesh are 1D entities
@@ -102,11 +113,6 @@ enum Entity_kind : int
   BOUNDARY_FACE = 13
 };
 
-// Check if Entity_kind is valid
-// inline
-// bool validEntityKind (const int kind) {
-//   return (kind >= Entity_kind::NODE && kind <= Entity_kind::CELL);
-// }
 
 // entity kind from string
 inline
@@ -235,7 +241,6 @@ enum class AccessPattern_kind {
   COMPUTE,
   FRAMEWORK
 };
-
 
 using MeshSets = std::map<std::tuple<std::string,Entity_kind,Parallel_kind>, Entity_ID_DualView>;
 using MeshSetVolumeFractions = std::map<std::tuple<std::string,Entity_kind,Parallel_kind>, Double_DualView>;

--- a/src/mesh/MeshFramework.hh
+++ b/src/mesh/MeshFramework.hh
@@ -145,7 +145,7 @@ class MeshFramework  {
 
   // DEVELOPER NOTE: serial meshes need not provide this method -- the default
   // returns a list of LIDs.
-  virtual cEntity_GID_View getEntityGIDs(const Entity_kind kind, const Parallel_kind ptype) const;
+  virtual View_type<const Entity_GID,MemSpace_kind::HOST> getEntityGIDs(const Entity_kind kind, bool ghosted) const;
 
   // corresponding entity in the parent mesh
   virtual Entity_ID getEntityParent(const Entity_kind kind, const Entity_ID entid) const;
@@ -184,13 +184,13 @@ class MeshFramework  {
   // effect of this is that master and ghost entities will have the same
   // hierarchical topology.
   void getCellFaces(const Entity_ID c,
-                    cEntity_ID_View& faces) const {
+                    View_type<const Entity_ID,MemSpace_kind::HOST>& faces) const {
     getCellFacesAndDirs(c, faces, nullptr);
   }
 
   void getCellFaceDirs(const Entity_ID c,
-                       cEntity_Direction_View& dirs) const {
-    cEntity_ID_View faces;
+                       View_type<const Direction_type,MemSpace_kind::HOST>& dirs) const {
+    View_type<const Entity_ID,MemSpace_kind::HOST> faces;
     getCellFacesAndDirs(c, faces, &dirs);
   }
 
@@ -207,14 +207,14 @@ class MeshFramework  {
   // direction as the cell polygon, and -1 otherwise
   virtual void getCellFacesAndDirs(
     const Entity_ID c,
-    cEntity_ID_View& faces,
-    cEntity_Direction_View * const dirs) const = 0;
+    View_type<const Entity_ID,MemSpace_kind::HOST>& faces,
+    View_type<const Direction_type,MemSpace_kind::HOST> * const dirs) const = 0;
 
-  virtual void getCellEdges(const Entity_ID c, cEntity_ID_View& edges) const;
-  virtual void getCellNodes(const Entity_ID c, cEntity_ID_View& nodes) const;
+  virtual void getCellEdges(const Entity_ID c, View_type<const Entity_ID,MemSpace_kind::HOST>& edges) const;
+  virtual void getCellNodes(const Entity_ID c, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const;
 
   void getFaceEdges(const Entity_ID f,
-                  cEntity_ID_View& edges) const {
+                  View_type<const Entity_ID,MemSpace_kind::HOST>& edges) const {
     getFaceEdgesAndDirs(f, edges);
   }
 
@@ -233,16 +233,16 @@ class MeshFramework  {
   // this direction cannot be relied upon to compute, say, a contour
   // integral around the 2D cell.
   virtual void getFaceEdgesAndDirs(const Entity_ID f,
-          cEntity_ID_View& edges,
-          cEntity_Direction_View * const dirs=nullptr) const;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& edges,
+          View_type<const Direction_type,MemSpace_kind::HOST> * const dirs=nullptr) const;
 
   // Get nodes of face
   //
   // In 3D, the nodes of the face are returned in ccw order consistent
   // with the face normal.
-  virtual void getFaceNodes(const Entity_ID f, cEntity_ID_View& nodes) const = 0;
+  virtual void getFaceNodes(const Entity_ID f, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const = 0;
 
-  virtual void getEdgeNodes(const Entity_ID e, cEntity_ID_View& nodes) const;
+  virtual void getEdgeNodes(const Entity_ID e, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const;
 
   //-------------------
   // Upward adjacencies
@@ -252,7 +252,7 @@ class MeshFramework  {
   // processors
   virtual void getFaceCells(const Entity_ID f,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& cells) const = 0;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& cells) const = 0;
 
   // Cells of a given Parallel_kind connected to an edge
   //
@@ -260,28 +260,28 @@ class MeshFramework  {
   // edges on different processors
   virtual void getEdgeCells(const Entity_ID edgeid,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& cellids) const;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const;
 
   // Faces of type 'ptype' connected to an edge
   // NOTE: The order of faces is not guaranteed to be the same for
   // corresponding edges on different processors
   virtual void getEdgeFaces(const Entity_ID edgeid,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& faceids) const;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const;
 
   // Cells of type 'ptype' connected to a node
   // NOTE: The order of cells is not guaranteed to be the same for
   // corresponding nodes on different processors
   virtual void getNodeCells(const Entity_ID nodeid,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& cellids) const;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const;
 
   // Faces of type parallel 'ptype' connected to a node
   // NOTE: The order of faces is not guarnateed to be the same for
   // corresponding nodes on different processors
   virtual void getNodeFaces(const Entity_ID nodeid,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& faceids) const = 0;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const = 0;
 
   // Edges of type 'ptype' connected to a node
   //
@@ -289,7 +289,7 @@ class MeshFramework  {
   // node on different processors
   virtual void getNodeEdges(const Entity_ID nodeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& edgeids) const;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids) const;
 
   //--------------------------------------------------------------
   // Mesh Sets for ICs, BCs, Material Properties and whatever else
@@ -304,13 +304,13 @@ class MeshFramework  {
   virtual void getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
           const Entity_kind kind,
           const Parallel_kind ptype,
-          cEntity_ID_View& entids) const;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& entids) const;
 
   void hasEdgesOrThrow() const;
 
 protected:
   void throwNotImplemented_(const std::string& fname) const;
-  Cell_kind getCellType_(const Entity_ID c, const cEntity_ID_View& faces) const;
+  Cell_kind getCellType_(const Entity_ID c, const View_type<const Entity_ID,MemSpace_kind::HOST>& faces) const;
 
  protected:
   Comm_ptr_type comm_;

--- a/src/mesh/MeshMaps_decl.hh
+++ b/src/mesh/MeshMaps_decl.hh
@@ -71,6 +71,7 @@
 #pragma once
 
 #include "AmanziTypes.hh"
+#include "ViewUtils.hh"
 
 namespace Amanzi {
 namespace AmanziMesh {

--- a/src/mesh/MeshMaps_impl.hh
+++ b/src/mesh/MeshMaps_impl.hh
@@ -24,7 +24,7 @@ std::pair<Map_ptr_type, Map_ptr_type>
 createMapsFromMeshGIDs(const Mesh_type& mesh, const Entity_kind kind)
 {
   Entity_ID num_owned = mesh.getNumEntities(kind, Parallel_kind::OWNED);
-  cEntity_GID_View gids = mesh.getEntityGIDs(kind, Parallel_kind::ALL);
+  cEntity_GID_View gids = mesh.getEntityGIDs(kind, true);
   return std::make_pair(
     Teuchos::rcp(new Epetra_Map(-1, gids.size(), gids.data(), 0, *mesh.getComm())),
     Teuchos::rcp(new Epetra_Map(-1, num_owned, gids.data(), 0, *mesh.getComm())));

--- a/src/mesh/MeshSets.cc
+++ b/src/mesh/MeshSets.cc
@@ -20,7 +20,7 @@ namespace AmanziMesh {
 // This function simply delegates to the other functions in Impl, depending
 // upon region type, mesh type (extracted meshes) and entity type.
 //
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSet(const AmanziGeometry::Region& region,
                 const Entity_kind kind,
                 const Parallel_kind ptype,
@@ -67,7 +67,7 @@ resolveMeshSet(const AmanziGeometry::Region& region,
   }
 }
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetVolumeFractions(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
@@ -152,13 +152,13 @@ namespace Impl {
 //
 // This helper function resolves sets on this mesh, never a parent mesh.
 //
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSet_(const AmanziGeometry::Region& region,
                 const Entity_kind kind,
                 const Parallel_kind ptype,
                 const MeshCache<MemSpace_kind::HOST>& mesh)
 {
-  cEntity_ID_View result;
+  View_type<const Entity_ID, MemSpace_kind::HOST> result;
   if (AmanziGeometry::RegionType::ENUMERATED == region.get_type()) {
     auto region_enumerated = dynamic_cast<const AmanziGeometry::RegionEnumerated*>(&region);
     AMANZI_ASSERT(region_enumerated);
@@ -255,7 +255,7 @@ resolveMeshSetPoint(const AmanziGeometry::RegionPoint& region,
 // Conceptually the implementation should just call with NODE instead of
 // BOUNDARY_NODE, then filter to only BOUNDARY_NODE entities (respectively
 // FACE).
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveBoundaryEntityMeshSet(const AmanziGeometry::Region& region,
                              const Entity_kind kind,
                              const Parallel_kind ptype,
@@ -272,7 +272,7 @@ resolveBoundaryEntityMeshSet(const AmanziGeometry::Region& region,
 // Resolves sets that are discretely enumerated on the parent mesh.
 //
 // Remember, this could be volume extraction or surface extraction.
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveIDMeshSetFromParent(const AmanziGeometry::Region& region,
                            const Entity_kind kind,
                            const Parallel_kind ptype,
@@ -296,7 +296,7 @@ resolveIDMeshSetFromParent(const AmanziGeometry::Region& region,
   }
 
   // Get parent mesh entities
-  cEntity_ID_View parent_entities = resolveMeshSet(region,
+  View_type<const Entity_ID, MemSpace_kind::HOST> parent_entities = resolveMeshSet(region,
           parent_kind, ptype, parent_mesh);
 
   // filter, leaving only the extracted entities
@@ -380,7 +380,7 @@ resolveIDMeshSetFromParent(const AmanziGeometry::Region& region,
 // parent entity.  This is a lot like the ID version above, but we don't have
 // the region's entity kind to help us guess...
 //
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveGeometricMeshSetFromParent(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
@@ -391,12 +391,12 @@ resolveGeometricMeshSetFromParent(const AmanziGeometry::Region& region,
     // extracted surface mesh
     if (kind == Entity_kind::NODE) {
       // nodes are nodes -- resolve and filter
-      cEntity_ID_View parent_entities =
+      View_type<const Entity_ID, MemSpace_kind::HOST> parent_entities =
         resolveMeshSet(region, Entity_kind::NODE, ptype, parent_mesh);
       return Impl::filterParentEntities(mesh, Entity_kind::NODE, ptype, parent_entities);
     } else if (kind == Entity_kind::CELL) {
       // cells are faces -- resolve and filter
-      cEntity_ID_View parent_entities =
+      View_type<const Entity_ID, MemSpace_kind::HOST> parent_entities =
         resolveMeshSet(region, Entity_kind::FACE, ptype, parent_mesh);
       return Impl::filterParentEntities(mesh, Entity_kind::CELL, ptype, parent_entities);
     } else if (kind == Entity_kind::FACE) {
@@ -435,7 +435,7 @@ resolveGeometricMeshSetFromParent(const AmanziGeometry::Region& region,
 //
 // Helper function to return ALL entities
 //
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetAll(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
@@ -451,7 +451,7 @@ resolveMeshSetAll(const AmanziGeometry::Region& region,
 //
 // Helper function to return BOUNDARY entities
 //
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetBoundary(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
@@ -490,7 +490,7 @@ resolveMeshSetBoundary(const AmanziGeometry::Region& region,
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetEnumerated(const AmanziGeometry::RegionEnumerated& region,
                          const Entity_kind kind,
                          const Parallel_kind ptype,
@@ -520,7 +520,7 @@ resolveMeshSetEnumerated(const AmanziGeometry::RegionEnumerated& region,
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetGeometric(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
@@ -552,7 +552,7 @@ resolveMeshSetGeometric(const AmanziGeometry::Region& region,
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetLabeledSet(const AmanziGeometry::RegionLabeledSet& region,
                          const Entity_kind kind,
                          const Parallel_kind ptype,
@@ -564,19 +564,19 @@ resolveMeshSetLabeledSet(const AmanziGeometry::RegionLabeledSet& region,
         << "\" of type LABLEDSET was requested for the first time after the framework mesh was deleted.";
     Exceptions::amanzi_throw(msg);
   }
-  cEntity_ID_View ents;
+  View_type<const Entity_ID, MemSpace_kind::HOST> ents;
   mesh.getMeshFramework()->getSetEntities(region, kind, ptype, ents);
   return ents;
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveMeshSetLogical(const AmanziGeometry::RegionLogical& region,
                       const Entity_kind kind,
                       const Parallel_kind ptype,
                       const MeshCache<MemSpace_kind::HOST>& mesh)
 {
-  cEntity_ID_View result;
+  View_type<const Entity_ID, MemSpace_kind::HOST> result;
   switch(region.get_operation()) {
     case (AmanziGeometry::BoolOpType::COMPLEMENT) : {
       // Get the set of ALL entities of the right kind and type.
@@ -657,11 +657,11 @@ resolveMeshSetLogical(const AmanziGeometry::RegionLogical& region,
 
 //
 // Filter for the direct parent entity.
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 filterParentEntities(const MeshCache<MemSpace_kind::HOST>& mesh,
                      Entity_kind kind,
                      Parallel_kind ptype,
-                     const cEntity_ID_View& parent_entities)
+                     const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities)
 {
   Entity_ID_View result;
   Entity_ID_List vresult;
@@ -687,10 +687,10 @@ filterParentEntities(const MeshCache<MemSpace_kind::HOST>& mesh,
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 filterParentEntities_SurfaceCellToCell(const MeshCache<MemSpace_kind::HOST>& mesh,
         Parallel_kind ptype,
-        const cEntity_ID_View& parent_entities)
+        const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities)
 {
   Entity_ID_View result;
   Entity_ID_List vresult;
@@ -722,10 +722,10 @@ filterParentEntities_SurfaceCellToCell(const MeshCache<MemSpace_kind::HOST>& mes
 }
 
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 filterParentEntities_SurfaceFaceToFace(const MeshCache<MemSpace_kind::HOST>& mesh,
         Parallel_kind ptype,
-        const cEntity_ID_View& parent_entities)
+        const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities)
 {
   Entity_ID_View result;
   Entity_ID_List vresult;

--- a/src/mesh/MeshSets.hh
+++ b/src/mesh/MeshSets.hh
@@ -38,12 +38,12 @@ class MeshCache;
 // This casts as needed to find the right implementation.  Note that some
 // require casting, some do not, so we avoid if possible.
 //
-cEntity_ID_View resolveMeshSet(const AmanziGeometry::Region& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSet(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetVolumeFractions(
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetVolumeFractions(
   const AmanziGeometry::Region& region,
   const Entity_kind kind,
   const Parallel_kind ptype,
@@ -53,57 +53,57 @@ cEntity_ID_View resolveMeshSetVolumeFractions(
 
 namespace Impl {
 
-cEntity_ID_View resolveMeshSet_(const AmanziGeometry::Region& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSet_(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveBoundaryEntityMeshSet(const AmanziGeometry::Region& region,
                              const Entity_kind kind,
                              const Parallel_kind ptype,
                              const MeshCache<MemSpace_kind::HOST>& parent_mesh);
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveIDMeshSetFromParent(const AmanziGeometry::Region& region,
                            const Entity_kind kind,
                            const Parallel_kind ptype,
                            const MeshCache<MemSpace_kind::HOST>& mesh,
                            const MeshCache<MemSpace_kind::HOST>& parent_mesh);
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 resolveGeometricMeshSetFromParent(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh,
         const MeshCache<MemSpace_kind::HOST>& parent_mesh);
 
-cEntity_ID_View resolveMeshSetAll(const AmanziGeometry::Region& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetAll(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetBoundary(const AmanziGeometry::Region& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetBoundary(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetEnumerated(const AmanziGeometry::RegionEnumerated& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetEnumerated(const AmanziGeometry::RegionEnumerated& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetGeometric(const AmanziGeometry::Region& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetGeometric(const AmanziGeometry::Region& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetLabeledSet(const AmanziGeometry::RegionLabeledSet& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetLabeledSet(const AmanziGeometry::RegionLabeledSet& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
 
-cEntity_ID_View resolveMeshSetLogical(const AmanziGeometry::RegionLogical& region,
+View_type<const Entity_ID, MemSpace_kind::HOST> resolveMeshSetLogical(const AmanziGeometry::RegionLogical& region,
         const Entity_kind kind,
         const Parallel_kind ptype,
         const MeshCache<MemSpace_kind::HOST>& mesh);
@@ -113,21 +113,20 @@ cEntity_ID_View resolveMeshSetPoint(const AmanziGeometry::RegionPoint& region,
         const Parallel_kind ptype,
 	const MeshCache<MemSpace_kind::HOST>& mesh);
 
-  
-cEntity_ID_View filterParentEntities(const MeshCache<MemSpace_kind::HOST>& mesh,
+View_type<const Entity_ID, MemSpace_kind::HOST> filterParentEntities(const MeshCache<MemSpace_kind::HOST>& mesh,
         Entity_kind kind,
         Parallel_kind ptype,
-        const cEntity_ID_View& parent_entities);
+        const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities);
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 filterParentEntities_SurfaceCellToCell(const MeshCache<MemSpace_kind::HOST>& mesh,
         Parallel_kind ptype,
-        const cEntity_ID_View& parent_entities);
+        const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities);
 
-cEntity_ID_View
+View_type<const Entity_ID, MemSpace_kind::HOST>
 filterParentEntities_SurfaceFaceToFace(const MeshCache<MemSpace_kind::HOST>& mesh,
         Parallel_kind ptype,
-        const cEntity_ID_View& parent_entities);
+        const View_type<const Entity_ID, MemSpace_kind::HOST>& parent_entities);
 
 } // namespace Impl
 } // namespace AmanziMesh

--- a/src/mesh/MeshUtils.hh
+++ b/src/mesh/MeshUtils.hh
@@ -1,570 +1,149 @@
 /*
-  Copyright 2010-201x held jointly by LANL, ORNL, LBNL, and PNNL.
+  Copyright 2010-202x held jointly by participating institutions.
   Amanzi is released under the three-clause BSD License.
   The terms of use and "as is" disclaimer for this license are
   provided in the top-level COPYRIGHT file.
 
-  Authors: Ethan Coon (coonet@ornl.gov)
-           Julien Loiseau (jloiseau@lanl.gov)
-           Rao Garimella (rao@lanl.gov)
+  Authors: Julien Loiseau
 */
-
-//! Implement detail utility functions for doing mesh cache work
 
 #pragma once
 
-#include <set>
-#include "Kokkos_Core.hpp"
-#include "Kokkos_DualView.hpp"
+#include "AmanziTypes.hh"
+#include "ViewUtils.hh"
+#include "MeshDefs.hh"
 
-enum class MemSpace_kind {
-  HOST,
-  DEVICE
+namespace Amanzi {
+namespace AmanziMesh {
+
+//
+// These Getter and RaggedGetter functions are used within MeshCache to create
+// a standard way of choosing between access patterns.
+//
+// Move these to an Impl namespace?
+//
+
+template<MemSpace_kind MEM = MemSpace_kind::HOST, AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
+struct Getter {
+  template<typename DATA, typename MF, typename FF, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get(bool cached, DATA& d, MF& mf, FF&& f, CF&& c, const Entity_ID i){
+      using type_t = typename DATA::t_dev::traits::value_type;
+      // To avoid the cast to non-reference
+      if (cached) return static_cast<type_t>(view<MEM>(d)(i));
+      if constexpr(MEM == MemSpace_kind::HOST){
+        if constexpr (!std::is_same_v<FF,decltype(nullptr)>)
+          if(mf.get())
+            return f(i);
+      }
+      if constexpr (!std::is_same_v<CF,decltype(nullptr)>)
+        return c(i);
+      assert(false);
+      return type_t{};
+  }
+}; // Getter
+
+template<MemSpace_kind MEM>
+struct Getter<MEM,AccessPattern_kind::CACHE> {
+  template<typename DATA, typename MF, typename FF, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get(bool cached, DATA& d, MF&, FF&&, CF&&, const Entity_ID i){
+      assert(cached);
+      return view<MEM>(d)(i);
+  }
+}; // Getter
+
+template<MemSpace_kind MEM>
+struct Getter<MEM,AccessPattern_kind::FRAMEWORK> {
+  template<typename DATA, typename MF, typename FF, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get(bool, DATA&, MF& mf, FF&& f, CF&&, const Entity_ID i){
+      static_assert(!std::is_same<FF,decltype(nullptr)>::value);
+      static_assert(MEM == MemSpace_kind::HOST);
+      assert(mf.get());
+      return f(i);
+  }
+}; // Getter
+
+
+template<MemSpace_kind MEM>
+struct Getter<MEM,AccessPattern_kind::COMPUTE> {
+  template<typename DATA, typename MF, typename FF, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get(bool, DATA&, MF&, FF&&, CF&& c, const Entity_ID i){
+    static_assert(!std::is_same<CF,decltype(nullptr)>::value);
+    return c(i);
+  }
+}; // Getter
+
+
+// Getters for raggedViews
+template<MemSpace_kind MEM = MemSpace_kind::HOST, AccessPattern_kind AP = AccessPattern_kind::DEFAULT>
+struct RaggedGetter{
+  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get (bool cached, DATA& d, MF& mf, FF&& f, CFD&& cd, CF&& c, const Entity_ID n) {
+    using view_t = typename decltype(d.template getRow<MEM>(n))::const_type;
+    if (cached) {
+      return static_cast<view_t>(d.template getRowUnmanaged<MEM>(n));
+    }
+    if constexpr(MEM == MemSpace_kind::HOST){
+
+      if constexpr (!std::is_same<FF,decltype(nullptr)>::value){
+        if(mf.get()){
+          return static_cast<view_t>(f(n));
+        }
+      }
+      if constexpr (!std::is_same<CF,decltype(nullptr)>::value){
+        return static_cast<view_t>(c(c));
+      }
+    } else {
+      if constexpr (!std::is_same<CFD,decltype(nullptr)>::value) {
+        static_cast<view_t>(cd(c));
+      }
+    }
+    assert(false && "No access to cache/framework/compute available");
+    return view_t{};
+  }
 };
 
 template<MemSpace_kind MEM>
-using MemoryLocation = std::conditional_t<MEM==MemSpace_kind::DEVICE, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>; 
-
-//
-// NOTE: begin/end must live in Kokkos namespace to work!
-//
-// This simply allows ranged-based for loops on Kokkos Views that are on host.
-// We use this a lot...
-//
-namespace Kokkos {
-
-template<class DataType, class... Properties>
-struct MeshView; 
-
-namespace Impl {
-
-template<typename T, typename ...Args>
-struct View_iter {
-  using iterator_category = std::forward_iterator_tag;
-  using value_type = T;
-  using difference_type = int;
-  using pointer = value_type*;
-  using reference = value_type&;
-  using View_type = MeshView<T*, Args...>;
-
-  KOKKOS_INLINE_FUNCTION View_iter(const View_type& v) : View_iter(v,0) {}
-  KOKKOS_INLINE_FUNCTION View_iter(const View_type& v, int i) : v_(v), i_(i) {}
-
-  KOKKOS_INLINE_FUNCTION reference operator*() const { return v_(i_); }
-  KOKKOS_INLINE_FUNCTION pointer operator->() { return &v_(i_); }
-
-  // prefix
-  KOKKOS_INLINE_FUNCTION View_iter& operator++() { i_++; return *this; }
-  KOKKOS_INLINE_FUNCTION View_iter& operator--() { i_--; return *this; }
-  // postfix
-  KOKKOS_INLINE_FUNCTION View_iter operator++(int) { View_iter tmp(*this); ++(*this); return tmp; }
-
-  KOKKOS_INLINE_FUNCTION friend View_iter operator+(const View_iter& v, const int& d) {
-    View_iter tmp(v); tmp+=d; return tmp;
+struct RaggedGetter<MEM,AccessPattern_kind::CACHE>{
+  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get (bool cached, DATA& d, MF&, FF&&, CFD&&, CF&&, const Entity_ID n) {
+    assert(cached);
+    return d.template getRowUnmanaged<MEM>(n);
   }
-  KOKKOS_INLINE_FUNCTION friend View_iter operator+(const int& d, const View_iter& v) {
-    return v + d;
-  }
-  KOKKOS_INLINE_FUNCTION friend int operator-(const View_iter& l, const View_iter& r){
-    return l.i_-r.i_;
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator==(const View_iter& a, const View_iter& b) {
-    return a.v_ == b.v_ && a.i_ == b.i_;
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator!=(const View_iter& a, const View_iter& b) {
-    return !(a == b);
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator<(const View_iter& l, const View_iter& r) {
-    return l.v_ == r.v_ && l.i_ < r.i_;
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator<=(const View_iter& l, const View_iter& r) {
-    return l.v_ == r.v_ && l.i_ <= r.i_;
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator>(const View_iter& l, const View_iter& r) {
-    return l.v_ == r.v_ && l.i_ > r.i_;
-  }
-  KOKKOS_INLINE_FUNCTION friend bool operator>=(const View_iter& l, const View_iter& r) {
-    return l.v_ == r.v_ && l.i_ >= r.i_;
-  }
-  KOKKOS_INLINE_FUNCTION View_iter& operator+=(const int& incr){
-    this->i_ += incr;
-    return *this;
-  }
-  KOKKOS_INLINE_FUNCTION View_iter& operator-=(const int& decr){
-    this->i_ -= decr;
-    return *this;
-  }
-  KOKKOS_INLINE_FUNCTION View_iter operator-(const int& decr){
-    this->i_ -= decr;
-    return *this;
-  }
-
-private:
-  int i_;
-  View_type v_;
 };
 
-} // namespace Impl 
-
-template<class DataType, class... Properties>
-struct MeshView: public Kokkos::View<DataType, Properties...>{
-
-  using baseView = Kokkos::View<DataType, Properties...>; 
-  using baseView::baseView; 
-  using iterator = Impl::View_iter<std::remove_pointer_t<DataType>, Properties...>; 
-  using const_iterator = Impl::View_iter<const std::remove_pointer_t<DataType>, Properties...>; 
-  using traits = ViewTraits<DataType, Properties...>;
-
-  using const_type = MeshView<typename traits::const_data_type, typename traits::array_layout,
-            typename traits::device_type, typename traits::memory_traits>;
-
-  MeshView(const baseView& bv): baseView(bv) {}
-  MeshView(const MeshView& bv): baseView(bv) {}
-  
-  KOKKOS_FUNCTION MeshView& operator=(const MeshView& other){
-    baseView::operator=(other);
-    return *this; 
+template<MemSpace_kind MEM>
+struct RaggedGetter<MEM,AccessPattern_kind::FRAMEWORK>{
+  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get (bool, DATA&, MF& mf, FF&& f, CFD&&, CF&&, const Entity_ID n) {
+    static_assert(!std::is_same<FF,decltype(nullptr)>::value);
+    static_assert(MEM == MemSpace_kind::HOST);
+    assert(mf.get());
+    return f(n);
   }
-
-  KOKKOS_FUNCTION MeshView& operator=(const MeshView&& other){
-    baseView::operator=(other);
-    return *this; 
-  }
- 
-  using HostMirror =
-    MeshView<typename traits::non_const_data_type, typename traits::array_layout,
-              Device<DefaultHostExecutionSpace,
-              typename traits::host_mirror_space::memory_space>>;
-
-  KOKKOS_INLINE_FUNCTION iterator begin() const {
-    return iterator(*this);
-  }
-
-  KOKKOS_INLINE_FUNCTION iterator end() const {
-    return iterator(*this, this->size());
-  }
-
-  KOKKOS_INLINE_FUNCTION const_iterator cbegin() const {
-    return const_iterator(*this);
-  }
-
-  KOKKOS_INLINE_FUNCTION const_iterator cend() const {
-    return const_iterator(*this, this->size());
-  }
-
-  void insert(iterator v0_e, iterator v1_b, iterator v1_e) {
-    //assert(v0_e - *this->end() != 0 && "Only insert at end supported for MeshViews"); 
-    std::size_t size = v1_e-v1_b; 
-    std::size_t csize = this->size(); 
-    Kokkos::resize(*this, size+csize); 
-    for(int i = csize; i < this->size(); ++i, ++v1_b) this->operator[](i) = *(v1_b); 
-  }
-
-  template<typename MV>
-  KOKKOS_INLINE_FUNCTION void fromConst(const MV& cmv) {
-    Kokkos::resize(*this, cmv.size());
-    Kokkos::deep_copy(*this, cmv);     
-  }
-
-}; 
-
-template<class SubDataType, class... SubProperties, class... Args>
-MeshView<SubDataType, SubProperties...> subview(Kokkos::MeshView<SubDataType, SubProperties...> v, Args... args){
-  MeshView ret(Kokkos::subview((typename Kokkos::MeshView<SubDataType, SubProperties...>::baseView)v, std::forward<Args>(args)...));
-  return ret;
-}
-
-template<class DataType, class Arg1Type = void, class Arg2Type = void, class Arg3Type = void>
-struct MeshDualView: public Kokkos::ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type>{
-
-  using traits = Kokkos::ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type>; 
-  using host_mirror_space = typename traits::host_mirror_space; 
-  using t_dev = MeshView<typename traits::data_type, Arg2Type, Arg2Type, Arg3Type>; 
-  using t_host = typename t_dev::HostMirror; 
-  using t_modified_flags = MeshView<unsigned int[2], LayoutLeft, Kokkos::HostSpace>;
-  t_modified_flags modified_flags;
-
-  KOKKOS_INLINE_FUNCTION t_host view_host() const {return h_view;}
-  KOKKOS_INLINE_FUNCTION t_dev view_device() const {return d_view;}
-
-  t_dev d_view; 
-  t_host h_view;
-
-  MeshDualView() = default;
-  MeshDualView(const std::string& label,
-           const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
-      : modified_flags(t_modified_flags("DualView::modified_flags")),
-        d_view(label, n0),
-        h_view(create_mirror_view(d_view))  // without UVM, host View mirrors
-  {}
-  MeshDualView(const MeshDualView& src): d_view(src.d_view), h_view(src.h_view), modified_flags(src.modified_flags){}
-  template <class SS, class LS, class DS, class MS>
-  MeshDualView(const MeshDualView<SS, LS, DS, MS>& src)
-      : modified_flags(src.modified_flags),
-        d_view(src.d_view),
-        h_view(src.h_view) {}
-
-  void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
-    if (modified_flags.data() == nullptr) {
-      modified_flags = t_modified_flags("DualView::modified_flags");
-    }
-    if (modified_flags(1) >= modified_flags(0)) {
-      /* Resize on Device */
-      ::Kokkos::resize(d_view, n0);
-      h_view = create_mirror_view(d_view);
-
-      /* Mark Device copy as modified */
-      modified_flags(1) = modified_flags(1) + 1;
-
-    } else {
-      /* Realloc on Device */
-
-      ::Kokkos::realloc(d_view, n0);
-
-      const bool sizeMismatch = (h_view.extent(0) != n0) ;
-      if (sizeMismatch)
-        ::Kokkos::resize(h_view, n0);
-
-      t_host temp_view = create_mirror_view(d_view);
-
-      /* Remap on Host */
-      Kokkos::deep_copy(temp_view, h_view);
-
-      h_view = temp_view;
-
-      d_view = create_mirror_view(typename t_dev::execution_space(), h_view);
-
-      /* Mark Host copy as modified */
-      modified_flags(0) = modified_flags(0) + 1;
-    }
-  }
-
-}; 
-
-
-} // namespace Kokkos
-
-using size_type = Kokkos::MeshView<int*, Kokkos::DefaultHostExecutionSpace>::size_type;
-
-namespace Amanzi {
-
-//
-// Utility functions for Kokkos operations
-//
-
-//
-// Get the right view from a dual view
-//
-template<MemSpace_kind M, typename DualView>
-KOKKOS_INLINE_FUNCTION
-auto& // Kokkos::MeshView of the same type as DV, on M
-view(DualView& dv)
-{
-  if constexpr(M == MemSpace_kind::HOST) {
-    return dv.h_view;
-  } else {
-    return dv.d_view;
-  }
-}
-
-template<typename View, typename T>
-KOKKOS_INLINE_FUNCTION
-void initView(View& v,const T& t){ 
-  for(auto& vv: v) vv = t; 
-}
-
-//
-// Conversion from view on host to vector
-//
-template<typename T, typename ...Args>
-std::vector<std::remove_cv_t<T>>
-asVector(const Kokkos::MeshView<T*, Args...> view)
-{
-  static_assert(Kokkos::SpaceAccessibility<typename Kokkos::MeshView<T*, Args...>::execution_space,
-                typename Kokkos::HostSpace>::accessible);
-  // currently no fix for this -- C++20 will use span
-  std::vector<std::remove_cv_t<T>> vec;
-  vec.reserve(view.size());
-  for (int i=0; i!=view.size(); ++i) vec.emplace_back(view[i]);
-  return vec;
-}
-
-
-//
-// Conversion from vector to non-owning view on host.
-//
-template<typename T>
-Kokkos::MeshView<const T*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-toNonOwningView(const std::vector<T>& vec)
-{
-  using View_type = Kokkos::MeshView<const T*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
-  View_type my_view(vec.data(), vec.size());
-  return my_view;
-}
-
-template<typename V, typename T>
-void vectorToConstView(V& view, const std::vector<T> vec){
-  Kokkos::MeshView<T*> lview; 
-  Kokkos::resize(lview,vec.size());
-  for(int i = 0; i < lview.size(); ++i)
-    lview[i] = vec[i]; 
-  view = lview; 
-}
-
-template<typename V, typename T>
-void vectorToView(V& view, const std::vector<T> vec){
-  Kokkos::resize(view,vec.size());
-  for(int i = 0; i < view.size(); ++i)
-    view[i] = vec[i]; 
-}
-
-template<typename V, typename T>
-void setToView(V& view, const std::set<T> vec){
-  Kokkos::resize(view,vec.size());
-  int i = 0; 
-  for(const auto& v: vec)
-    view[i++] = v; 
-}
-
-//
-// Conversion between list and dual view through deep copy and sync.
-//
-// NOTE: change this to DefaultDevice!
-template<typename T, typename MemSpace = Kokkos::HostSpace>
-Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>
-asDualView(const std::vector<T>& in)
-{
-  using DV_type = Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>;
-  DV_type dv;
-  dv.resize(in.size()); 
-  Kokkos::deep_copy(dv.h_view, toNonOwningView(in));
-  Kokkos::deep_copy(dv.d_view,dv.h_view); 
-  return dv;
-}
-
-template<typename T, typename MemSpace = Kokkos::HostSpace, typename ...Args>
-Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>
-asDualView(const Kokkos::MeshView<T*, Args...>& in)
-{
-  Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace> dv;
-  dv.resize(in.size()); 
-  Kokkos::deep_copy(dv.h_view,in); 
-  Kokkos::deep_copy(dv.d_view,dv.h_view); 
-  return dv;
-}
-  
-template<class ...> struct types {};
-template<class T> struct function_traits : function_traits<decltype(&T::operator())> {};
-template<class T,class C> struct function_traits<T C::*> : function_traits<T> {
-  using class_type=C;
 };
-template<class R,class ...PP> struct function_traits<R(PP...)> {
-  using return_type=R;
-  using parameter_types=std::tuple<PP...>;
-};
-template<class R,class ...PP> struct function_traits<R(PP...) const> : function_traits<R(PP...)> {};
-// In C++23, these can be merged into the above:
-template<class R,class ...PP> struct function_traits<R(PP...) noexcept> : function_traits<R(PP...)> {};
-template<class R,class ...PP> struct function_traits<R(PP...) const noexcept> : function_traits<R(PP...)> {};
 
-template<class V>
-using dual_view_t=Kokkos::MeshDualView<typename V::data_type,Kokkos::DefaultHostExecutionSpace>;
-
-namespace detail {
-  template<typename Func,typename F,typename ...PP>
-  auto asDualViews(Func &mesh_func,int count,std::tuple<F,PP...>*) {
-    std::tuple<dual_view_t<PP>...> dvs;
-    std::apply([count](auto &... dv) {(dv.resize(count),...);},dvs); 
-    for(int i=0;i<count;++i)
-      std::apply([&](auto &...dv) {mesh_func(i,dv.h_view...);},dvs);
-    std::apply([](auto &...dv) {(Kokkos::deep_copy(dv.d_view,dv.h_view),...);},dvs);
-    return dvs;
-  }  
-}
-
-template<typename Func>
-auto
-asDualView(Func &&mesh_func, int count)
-{
-  return detail::asDualViews(
-			     mesh_func,
-			     count,
-			     static_cast<typename function_traits<std::remove_reference_t<Func>>::parameter_types*>(nullptr));
-}
-  
-// note, this template is left here despite not being used in case of future
-// refactoring for a more general struct.
-template<typename T>
-struct RaggedArray_DualView {
-
-  using View_type = Kokkos::MeshView<T*, Kokkos::DefaultHostExecutionSpace>;
-  using Entity_ID_View = View_type;
-
-  using type_t = T; 
-
-  template<MemSpace_kind MEM>
-  using constview = Kokkos::MeshView<const T*, MemoryLocation<MEM>>; 
-
-  Kokkos::MeshDualView<int*> rows;
-  Kokkos::MeshDualView<T*> entries;
-
-  using host_mirror_space = typename Kokkos::MeshDualView<T*>::host_mirror_space;
-  using execution_space = typename Kokkos::MeshDualView<T*>::execution_space;
-
-  RaggedArray_DualView() {}
-
-
-  RaggedArray_DualView(const std::vector<std::vector<T>>& vect){ 
-
-    rows.resize(vect.size()+1); 
-    int count = 0; 
-    view<MemSpace_kind::HOST>(rows)[0] = count; 
-    for(int i = 1 ; i < vect.size()+1; ++i){
-      count += vect[i-1].size(); 
-      view<MemSpace_kind::HOST>(rows)[i] = count; 
-    }
-
-    entries.resize(count);
-
-    int cur = 0; 
-    for(int i = 0; i < vect.size(); ++i){
-      for(int j = 0 ; j < vect[i].size(); ++j){
-        view<MemSpace_kind::HOST>(entries)[cur++] = vect[i][j]; 
-      }
-    } 
-    update<MemSpace_kind::DEVICE>(); 
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  auto
-  getRowUnmanaged(int row) {
-    const std::size_t size = view<MEM>(rows)[row+1] - view<MEM>(rows)[row];
-    const auto ptr = view<MEM>(entries).data()+view<MEM>(rows)[row];
-    return Kokkos::MeshView<T*, MemoryLocation<MEM>>(ptr, size);
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  auto
-  getRowUnmanaged(int row) const {
-    const std::size_t size = view<MEM>(rows)[row+1] - view<MEM>(rows)[row];
-    const auto ptr = view<MEM>(entries).data()+view<MEM>(rows)[row];
-    return Kokkos::MeshView<T*, MemoryLocation<MEM>>(ptr, size);
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  auto
-  getRow(int row) {
-    return Kokkos::subview(view<MEM>(entries), Kokkos::make_pair(view<MEM>(rows)[row], view<MEM>(rows)[row+1]));
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  auto
-  getRow(int row) const {
-    return Kokkos::subview(view<MEM>(entries), Kokkos::make_pair(view<MEM>(rows)[row], view<MEM>(rows)[row+1]));
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  T& get(int row, int i) {
-    return view<MEM>(entries)[view<MEM>(rows)[row]+i];
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  const T& get(int row, int i) const {
-    return view<MEM>(entries)[view<MEM>(rows)[row]+i];
-  }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  int size() const {return view<MEM>(rows).size()-1; }
-
-  template<MemSpace_kind MEM>
-  KOKKOS_INLINE_FUNCTION
-  int size(int row) const { return view<MEM>(rows)[row+1] - view<MEM>(rows)[row]; }
-
-  template<MemSpace_kind MEM> 
-  void update(){ 
-    if constexpr (MEM == MemSpace_kind::HOST){
-      Kokkos::deep_copy(rows.view_host(),rows.view_device()); 
-      Kokkos::deep_copy(entries.view_host(),entries.view_device()); 
+template<MemSpace_kind MEM>
+struct RaggedGetter<MEM,AccessPattern_kind::COMPUTE>{
+  template<typename DATA, typename MF, typename FF, typename CFD, typename CF>
+  static KOKKOS_INLINE_FUNCTION decltype(auto)
+  get (bool, DATA&, MF&, FF&&, CFD&& cd, CF&& c, const Entity_ID n) {
+    if constexpr(MEM == MemSpace_kind::HOST){
+      static_assert(!std::is_same<CF,decltype(nullptr)>::value);
+      return c(n);
     }else{
-      Kokkos::deep_copy(rows.view_device(),rows.view_host()); 
-      Kokkos::deep_copy(entries.view_device(),entries.view_host()); 
+      static_assert(MEM==MemSpace_kind::DEVICE);
+      static_assert(!std::is_same<CFD,decltype(nullptr)>::value);
+      return cd(n);
     }
   }
-
-  bool operator!=(const RaggedArray_DualView& oth){
-    return oth.rows.view_host().size() != rows.view_host().size() 
-    && oth.entries.view_host().size() != entries.view_host().size(); 
-  }
-
-  void resize(int s1, int s2) {
-    rows.resize(s1+1);
-    entries.resize(s1*s2);  
-    rows.h_view[0] = 0; 
-    for(int i = 1 ; i < s1+1; ++i){
-      rows.h_view[i] = rows.h_view[i-1]+s2; 
-    }
-    update<MemSpace_kind::DEVICE>(); 
-  } 
-
 };
 
-//
-// Cache a RaggedArray from a callable, e.g. getCellFaces()
-//
-template<typename T, typename Func>
-auto asRaggedArray_DualView(Func mesh_func, int count) {
-  RaggedArray_DualView<T> adj;
-  adj.rows.resize(count+1);
-
-  // do a count first, setting rows
-  std::vector<Kokkos::MeshView<const T*, Kokkos::DefaultHostExecutionSpace>> ents(count);
-  int total = 0;
-  for (int i=0; i!=count; ++i) {
-    view<MemSpace_kind::HOST>(adj.rows)[i] = total;
-
-    mesh_func(i, ents[i]);
-    total += ents[i].size();
-  }
-  view<MemSpace_kind::HOST>(adj.rows)[count] = total;
-  adj.entries.resize(total);
-
-  for (int i=0; i!=count; ++i) {
-    auto row_view = adj.template getRowUnmanaged<MemSpace_kind::HOST>(i);
-    assert(row_view.extent(0) == ents[i].size()); 
-    Kokkos::deep_copy(row_view, ents[i]); 
-  }
-  Kokkos::deep_copy(adj.rows.view_device(), adj.rows.view_host()); 
-  Kokkos::deep_copy(adj.entries.view_device(),adj.entries.view_host()); 
-  return adj;
-}
-
-template<typename T, typename List> 
-KOKKOS_INLINE_FUNCTION
-bool is_present(const T& v, const List& l){ 
-  for(int i = 0 ; i < l.size(); ++i){ 
-    if(v == l[i])
-      return true; 
-  }
-  return false; 
-}
-
-// Find the right number of threads 
-template<typename T>
-constexpr int ThreadsPerTeams(){ 
-  #ifdef KOKKOS_ENABLE_CUDA
-  if constexpr (std::is_same_v<T,Kokkos::Cuda>){
-    return 32;
-  }else // (std::is_same_v<T,Kokkos::Serial>){
-  #endif
-  { 
-    return 1;
-  }
-}
+} // namespace AmanziMesh
 } // namespace Amanzi

--- a/src/mesh/Mesh_Helpers_impl.hh
+++ b/src/mesh/Mesh_Helpers_impl.hh
@@ -13,6 +13,7 @@
 #include "Point.hh"
 #include "Geometry.hh"
 #include "MeshDefs.hh"
+#include "ViewUtils.hh"
 
 namespace Amanzi {
 namespace AmanziMesh {

--- a/src/mesh/mesh_logical/MeshEmbeddedLogical.cc
+++ b/src/mesh/mesh_logical/MeshEmbeddedLogical.cc
@@ -126,7 +126,7 @@ MeshEmbeddedLogical::MeshEmbeddedLogical(const Comm_ptr_type& comm,
   Epetra_Map cell_owned_map(-1, ncells_total_owned, 0, *getComm());
 
   // -- create a map on the background mesh of all CELLs
-  auto bg_cell_gids = bg_mesh_->getMeshFramework()->getEntityGIDs(Entity_kind::CELL, Parallel_kind::ALL);
+  auto bg_cell_gids = bg_mesh_->getMeshFramework()->getEntityGIDs(Entity_kind::CELL, true);
   Epetra_Map bg_cell_all_map(-1, ncells_bg_all, bg_cell_gids.data(), 0, *bg_mesh_->getComm());
   Epetra_Map bg_cell_owned_map(-1, ncells_bg_owned, bg_cell_gids.data(), 0, *bg_mesh_->getComm());
 
@@ -155,7 +155,7 @@ MeshEmbeddedLogical::MeshEmbeddedLogical(const Comm_ptr_type& comm,
   Epetra_Map face_owned_map(-1, nfaces_total_owned, 0, *getComm());
 
   // -- create a map on the background mesh of all FACEs
-  auto bg_face_gids = bg_mesh_->getMeshFramework()->getEntityGIDs(Entity_kind::FACE, Parallel_kind::ALL);
+  auto bg_face_gids = bg_mesh_->getMeshFramework()->getEntityGIDs(Entity_kind::FACE, true);
   Epetra_Map bg_face_all_map(-1, nfaces_bg_all, bg_face_gids.data(), 0, *bg_mesh_->getComm());
   Epetra_Map bg_face_owned_map(-1, nfaces_bg_owned, bg_face_gids.data(), 0, *bg_mesh_->getComm());
 

--- a/src/mesh/mesh_logical/test/mesh_logical_geometry.cc
+++ b/src/mesh/mesh_logical/test/mesh_logical_geometry.cc
@@ -1,5 +1,3 @@
-/* -*-  mode: c++; c-default-style: "google"; indent-tabs-mode: nil -*- */
-
 #include <UnitTest++.h>
 
 #include <mpi.h>
@@ -8,6 +6,7 @@
 #include "Teuchos_RCP.hpp"
 #include "AmanziComm.hh"
 
+#include "MeshDefs.hh"
 #include "RegionEnumerated.hh"
 #include "MeshLogical.hh"
 #include "MeshLogicalFactory.hh"
@@ -16,6 +15,7 @@
 
 #include "demo_mesh.hh"
 
+using namespace Amanzi;
 using namespace Amanzi::AmanziMesh;
 using namespace Amanzi::AmanziGeometry;
 

--- a/src/mesh/mesh_mstk/Mesh_MSTK.cc
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.cc
@@ -472,8 +472,8 @@ Cell_kind Mesh_MSTK::getCellType(const Entity_ID cellid) const
 // direction as the cell polygon, and -1 otherwise
 //---------------------------------------------------------
 void Mesh_MSTK::getCellFacesAndDirs_ordered_(const Entity_ID cellid,
-                                                cEntity_ID_View& faceids,
-                                                cEntity_Direction_View * face_dirs) const
+                                                View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+                                                View_type<const Direction_type,MemSpace_kind::HOST> * face_dirs) const
 {
   if (getManifoldDimension() == 3) {
     Cell_kind celltype = getCellType(cellid);
@@ -606,8 +606,8 @@ void Mesh_MSTK::getCellFacesAndDirs_ordered_(const Entity_ID cellid,
 
 
 void Mesh_MSTK::getCellFacesAndDirs_unordered_(const Entity_ID cellid,
-        cEntity_ID_View& faceids,
-        cEntity_Direction_View * face_dirs) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+        View_type<const Direction_type,MemSpace_kind::HOST> * face_dirs) const
 {
   
   Entity_ID_View lfaceids; 
@@ -695,8 +695,8 @@ void Mesh_MSTK::getCellFacesAndDirs_unordered_(const Entity_ID cellid,
 
 
 void Mesh_MSTK::getCellFacesAndDirs(const Entity_ID cellid,
-        cEntity_ID_View& faceids,
-        cEntity_Direction_View * const face_dirs) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+        View_type<const Direction_type,MemSpace_kind::HOST> * const face_dirs) const
 {
   AMANZI_ASSERT(faces_initialized_);
   if (cells_initialized_) {
@@ -708,7 +708,7 @@ void Mesh_MSTK::getCellFacesAndDirs(const Entity_ID cellid,
 
 
 void Mesh_MSTK::getCellEdges(const Entity_ID cellid,
-        cEntity_ID_View& edgeids) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids) const
 {
   Entity_ID_View ledgeids; 
   AMANZI_ASSERT(edges_initialized_);
@@ -789,7 +789,7 @@ void Mesh_MSTK::getCellEdges(const Entity_ID cellid,
 // consistent with the face normal
 //---------------------------------------------------------
 void Mesh_MSTK::getCellNodes(const Entity_ID cellid,
-                               cEntity_ID_View& nodeids) const
+                               View_type<const Entity_ID,MemSpace_kind::HOST>& nodeids) const
 {
   Entity_ID_View lnodeids; 
   int nn, lid;
@@ -821,8 +821,8 @@ void Mesh_MSTK::getCellNodes(const Entity_ID cellid,
 
 
 void Mesh_MSTK::getFaceEdgesAndDirs(const Entity_ID faceid,
-                                                  cEntity_ID_View& edgeids,
-                                                  cEntity_Direction_View * edge_dirs) const
+                                                  View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids,
+                                                  View_type<const Direction_type,MemSpace_kind::HOST> * edge_dirs) const
 {  
   AMANZI_ASSERT(faces_initialized_);
   AMANZI_ASSERT(edges_initialized_);
@@ -898,7 +898,7 @@ void Mesh_MSTK::getFaceEdgesAndDirs(const Entity_ID faceid,
 // In 2D, nfnodes is 2
 //---------------------------------------------------------
 void Mesh_MSTK::getFaceNodes(const Entity_ID faceid,
-                           cEntity_ID_View& nodeids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& nodeids) const
 {
   AMANZI_ASSERT(faces_initialized_);
   Entity_ID_View lnodeids; 
@@ -939,7 +939,7 @@ void Mesh_MSTK::getFaceNodes(const Entity_ID faceid,
 // Get nodes of an edge
 //---------------------------------------------------------
 void Mesh_MSTK::getEdgeNodes(const Entity_ID edgeid,
-                           cEntity_ID_View& nodes) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const
 {
   Entity_ID_View lnodes; 
   AMANZI_ASSERT(edges_initialized_);
@@ -963,7 +963,7 @@ void Mesh_MSTK::getEdgeNodes(const Entity_ID edgeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getNodeCells(const Entity_ID nodeid,
                            const Parallel_kind ptype,
-                           cEntity_ID_View& cellids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const
 {
   Entity_ID_View lcellids; 
   int idx, lid, nc;
@@ -1041,7 +1041,7 @@ void Mesh_MSTK::getNodeCells(const Entity_ID nodeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getNodeFaces(const Entity_ID nodeid,
                            const Parallel_kind ptype,
-                           cEntity_ID_View& faceids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const
 {
   Entity_ID_View lfaceids; 
   int idx, lid, n;
@@ -1116,7 +1116,7 @@ void Mesh_MSTK::getNodeFaces(const Entity_ID nodeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getNodeEdges(const Entity_ID nodeid,
                            const Parallel_kind ptype,
-                           cEntity_ID_View& edgeids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids) const
 {
   Entity_ID_View ledgeids; 
   int idx, lid, nc;
@@ -1160,7 +1160,7 @@ void Mesh_MSTK::getNodeEdges(const Entity_ID nodeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getEdgeFaces(const Entity_ID edgeid,
                            const Parallel_kind ptype,
-                           cEntity_ID_View& faceids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const
 {
   Entity_ID_View lfaceids; 
   int idx, lid, nc;
@@ -1204,7 +1204,7 @@ void Mesh_MSTK::getEdgeFaces(const Entity_ID edgeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getEdgeCells(const Entity_ID edgeid,
                            const Parallel_kind ptype,
-                           cEntity_ID_View& cellids) const
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const
 {
   Entity_ID_View lcellids; 
   MEdge_ptr me = (MEdge_ptr) edge_id_to_handle_[edgeid];
@@ -1249,7 +1249,7 @@ void Mesh_MSTK::getEdgeCells(const Entity_ID edgeid,
 //---------------------------------------------------------
 void Mesh_MSTK::getFaceCells(const Entity_ID faceid,
         const Parallel_kind ptype,
-        cEntity_ID_View& cellids) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const
 {
   AMANZI_ASSERT(faces_initialized_);
   Entity_ID_List vcellids; 
@@ -1975,7 +1975,7 @@ void
 Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
                             const Entity_kind kind,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& entids) const
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& entids) const
 {
   Entity_ID_View lentids; 
   if (kind != createEntityKind(region.entity_str())) {

--- a/src/mesh/mesh_mstk/Mesh_MSTK.hh
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.hh
@@ -151,12 +151,12 @@ class Mesh_MSTK : public MeshFramework {
   // In 2D, direction is 1 if face/edge is defined in the same
   // direction as the cell polygon, and -1 otherwise
   virtual void getCellFacesAndDirs(const Entity_ID cellid,
-          cEntity_ID_View& faceids,
-          cEntity_Direction_View * const face_dirs) const override;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+          View_type<const Direction_type,MemSpace_kind::HOST> * const face_dirs) const override;
 
   // Get edges of a cell
   virtual void getCellEdges(const Entity_ID cellid,
-                  cEntity_ID_View& edgeids) const override;
+                  View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids) const override;
 
   // Get nodes of cell
   // On a distributed mesh, all nodes (OWNED or GHOST) of the cell
@@ -168,13 +168,13 @@ class Mesh_MSTK : public MeshFramework {
   // In 2D, the nodes of the polygon will be returned in ccw order
   // consistent with the face normal
   virtual void getCellNodes(const Entity_ID cellid,
-                          cEntity_ID_View& nodeids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& nodeids) const override;
 
 
   // Edges and edge directions of a face
   virtual void getFaceEdgesAndDirs(const Entity_ID cellid,
-                           cEntity_ID_View& edgeids,
-                           cEntity_Direction_View * edgedirs) const override;
+                           View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids,
+                           View_type<const Direction_type,MemSpace_kind::HOST> * edgedirs) const override;
 
   // Get nodes of face
   // On a distributed mesh, all nodes (OWNED or GHOST) of the face
@@ -183,12 +183,12 @@ class Mesh_MSTK : public MeshFramework {
   // with the face normal
   // In 2D, nfnodes is 2
   virtual void getFaceNodes(const Entity_ID faceid,
-                          cEntity_ID_View& nodeids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& nodeids) const override;
 
   // Get nodes of edge On a distributed mesh all nodes (OWNED or
   // GHOST) of the face are returned
   virtual void getEdgeNodes(const Entity_ID edgeid,
-                          cEntity_ID_View& nodes) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const override;
 
   //
   // Upward adjacencies
@@ -196,32 +196,32 @@ class Mesh_MSTK : public MeshFramework {
   // Cells connected to a face
   virtual void getFaceCells(const Entity_ID faceid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& cellids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const override;
 
   // Cells of type 'ptype' connected to an edge
   virtual void getEdgeCells(const Entity_ID edgeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& cellids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const override;
 
   // Faces of type 'ptype' connected to an edge
   virtual void getEdgeFaces(const Entity_ID edgeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& faceids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const override;
 
   // Cells of type 'ptype' connected to a node
   virtual void getNodeCells(const Entity_ID nodeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& cellids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const override;
 
   // Faces of type 'ptype' connected to a node
   virtual void getNodeFaces(const Entity_ID nodeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& faceids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const override;
 
   // Edges of type 'ptype' connected to a node
   virtual void getNodeEdges(const Entity_ID nodeid,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& edgeids) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids) const override;
 
   //
   // Get list of entities of type kind from a framework set.
@@ -235,7 +235,7 @@ class Mesh_MSTK : public MeshFramework {
   virtual void getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
           const Entity_kind kind,
           const Parallel_kind ptype,
-          cEntity_ID_View& entids) const override;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& entids) const override;
 
   // Run MSTK's internal checks - meant for debugging only
   // Returns true if everything is ok, false otherwise
@@ -316,12 +316,12 @@ class Mesh_MSTK : public MeshFramework {
   }
 
   void getCellFacesAndDirs_ordered_(const Entity_ID cellid,
-          cEntity_ID_View& faceids,
-          cEntity_Direction_View * face_dirs) const;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+          View_type<const Direction_type,MemSpace_kind::HOST> * face_dirs) const;
 
   void getCellFacesAndDirs_unordered_(const Entity_ID cellid,
-          cEntity_ID_View &faceids,
-          cEntity_Direction_View * face_dirs) const;
+          View_type<const Entity_ID,MemSpace_kind::HOST> &faceids,
+          View_type<const Direction_type,MemSpace_kind::HOST> * face_dirs) const;
 
  private:
   MPI_Comm mpicomm_;

--- a/src/mesh/mesh_simple/Mesh_simple.cc
+++ b/src/mesh/mesh_simple/Mesh_simple.cc
@@ -373,8 +373,8 @@ std::size_t Mesh_simple::getNumEntities(AmanziMesh::Entity_kind kind,
 // Connectivity: cell -> faces
 //---------------------------------------------------------
 void Mesh_simple::getCellFacesAndDirs(const Entity_ID cellid,
-        cEntity_ID_View& faceids,
-        cEntity_Direction_View *cfacedirs) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& faceids,
+        View_type<const Direction_type,MemSpace_kind::HOST> *cfacedirs) const
 {
   unsigned int offset = (unsigned int) 6*cellid;
   Entity_ID_View lfaceids("lfaceids",6); 
@@ -393,7 +393,7 @@ void Mesh_simple::getCellFacesAndDirs(const Entity_ID cellid,
 // Connectivity: face -> nodes
 //---------------------------------------------------------
 void Mesh_simple::getFaceNodes(Entity_ID face,
-        cEntity_ID_View& nodeids) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& nodeids) const
 {
   Entity_ID_View lnodeids("nodeids", 4); 
   unsigned int offset = (unsigned int) 4*face;
@@ -408,8 +408,8 @@ void Mesh_simple::getFaceNodes(Entity_ID face,
 // Connectivity: face -> edges
 //---------------------------------------------------------
 void Mesh_simple::getFaceEdgesAndDirs(const Entity_ID faceid,
-        cEntity_ID_View& edgeids,
-        cEntity_Direction_View *fedgedirs) const
+        View_type<const Entity_ID,MemSpace_kind::HOST>& edgeids,
+        View_type<const Direction_type,MemSpace_kind::HOST> *fedgedirs) const
 {
   unsigned int offset = (unsigned int) 4*faceid;
   Entity_ID_View ledgeids("ledgeids", 3); 
@@ -428,7 +428,7 @@ void Mesh_simple::getFaceEdgesAndDirs(const Entity_ID faceid,
 // Connectivity: edge -> nodes
 //---------------------------------------------------------
 void Mesh_simple::getEdgeNodes(
-  const Entity_ID edgeid, cEntity_ID_View& nodes) const
+  const Entity_ID edgeid, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const
 {
   Entity_ID_View lnodes("lnodes", 2); 
   unsigned int offset = (unsigned int) 2*edgeid;
@@ -471,7 +471,7 @@ void Mesh_simple::setNodeCoordinate(const AmanziMesh::Entity_ID local_node_id,
 //---------------------------------------------------------
 void Mesh_simple::getNodeFaces(const AmanziMesh::Entity_ID nodeid,
         const AmanziMesh::Parallel_kind ptype,
-        AmanziMesh::cEntity_ID_View& faceids) const
+        AmanziMesh::View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const
 {
   unsigned int offset = (unsigned int) 13*nodeid;
   unsigned int nfaces = node_to_face_[offset];
@@ -488,7 +488,7 @@ void Mesh_simple::getNodeFaces(const AmanziMesh::Entity_ID nodeid,
 //---------------------------------------------------------
 void Mesh_simple::getFaceCells(const AmanziMesh::Entity_ID faceid,
         const AmanziMesh::Parallel_kind ptype,
-        AmanziMesh::cEntity_ID_View& cellids) const
+        AmanziMesh::View_type<const Entity_ID,MemSpace_kind::HOST>& cellids) const
 {
   unsigned int offset = (unsigned int) 2*faceid;
   Entity_ID_View lcellids("lcellids", 2); 

--- a/src/mesh/mesh_simple/Mesh_simple.hh
+++ b/src/mesh/mesh_simple/Mesh_simple.hh
@@ -66,25 +66,25 @@ class Mesh_simple : public MeshFramework {
 
   virtual void getCellFacesAndDirs(
     const Entity_ID c,
-    cEntity_ID_View& faces,
-    cEntity_Direction_View * const dirs) const override;
+    View_type<const Entity_ID,MemSpace_kind::HOST>& faces,
+    View_type<const Direction_type,MemSpace_kind::HOST> * const dirs) const override;
 
   virtual void getFaceEdgesAndDirs(const Entity_ID f,
-          cEntity_ID_View& edges,
-          cEntity_Direction_View * const dirs=nullptr) const override;
+          View_type<const Entity_ID,MemSpace_kind::HOST>& edges,
+          View_type<const Direction_type,MemSpace_kind::HOST> * const dirs=nullptr) const override;
 
-  virtual void getFaceNodes(const Entity_ID f, cEntity_ID_View& nodes) const override;
+  virtual void getFaceNodes(const Entity_ID f, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const override;
 
-  virtual void getEdgeNodes(const Entity_ID e, cEntity_ID_View& nodes) const override;
+  virtual void getEdgeNodes(const Entity_ID e, View_type<const Entity_ID,MemSpace_kind::HOST>& nodes) const override;
 
 
   virtual void getFaceCells(const Entity_ID f,
                           const Parallel_kind ptype,
-                          cEntity_ID_View& cells) const override;
+                          View_type<const Entity_ID,MemSpace_kind::HOST>& cells) const override;
 
   virtual void getNodeFaces(const Entity_ID nodeid,
                             const Parallel_kind ptype,
-                            cEntity_ID_View& faceids) const override;
+                            View_type<const Entity_ID,MemSpace_kind::HOST>& faceids) const override;
 
  private:
   void CreateCache_();

--- a/src/utils/AmanziTypes.hh
+++ b/src/utils/AmanziTypes.hh
@@ -20,7 +20,7 @@
 
 #include <memory>
 #include "Teuchos_RCPDecl.hpp"
-
+#include "Kokkos_Core.hpp"
 
 #ifdef TRILINOS_TPETRA_STACK
 #  include "Teuchos_Comm.hpp"
@@ -58,6 +58,16 @@ typedef Epetra_SerialComm SerialComm_type;
 #endif
 
 typedef Teuchos::RCP<const Comm_type> Comm_ptr_type;
+
+
+enum class MemSpace_kind {
+  HOST,
+  DEVICE
+};
+
+template<MemSpace_kind MEM>
+using MemoryLocation = std::conditional_t<MEM==MemSpace_kind::DEVICE, Kokkos::DefaultExecutionSpace, Kokkos::HostSpace>;
+
 
 } // namespace Amanzi
 

--- a/src/utils/AmanziTypes.hh
+++ b/src/utils/AmanziTypes.hh
@@ -30,6 +30,8 @@
 
 #  include "Epetra_MpiComm.h"
 #  include "Epetra_SerialComm.h"
+#  include "Epetra_Map.h"
+#  include "Epetra_Import.h"
 #endif
 
 namespace Teuchos {
@@ -42,6 +44,17 @@ rcp(std::unique_ptr<T>&& in)
 } // namespace Teuchos
 
 namespace Amanzi {
+
+using DefaultExecutionSpace = Kokkos::DefaultExecutionSpace;
+using DefaultHostExecutionSpace = Kokkos::DefaultHostExecutionSpace;
+
+using DefaultMemorySpace = DefaultExecutionSpace::memory_space;
+using DefaultHostMemorySpace = DefaultHostExecutionSpace::memory_space;
+
+using HostSpace = Kokkos::HostSpace;
+using DefaultDevice = Kokkos::Device<DefaultExecutionSpace, DefaultMemorySpace>;
+using DefaultHost = Kokkos::Device<DefaultHostExecutionSpace, DefaultHostMemorySpace>;
+
 
 #ifdef TRILINOS_TPETRA_STACK
 typedef Teuchos::Comm<int> Comm_type;
@@ -58,6 +71,10 @@ typedef Epetra_SerialComm SerialComm_type;
 #endif
 
 typedef Teuchos::RCP<const Comm_type> Comm_ptr_type;
+using Map_type = Epetra_Map;
+using Map_ptr_type = Teuchos::RCP<Map_type>;
+using Import_type = Epetra_Import;
+using Import_ptr_type = Teuchos::RCP<Import_type>;
 
 
 enum class MemSpace_kind {

--- a/src/utils/Iterators.hh
+++ b/src/utils/Iterators.hh
@@ -13,12 +13,106 @@
   Helper classes which define const iterators that point to const.
 */
 
-#ifndef AMANZI_CONTAINER_HH_
-#define AMANZI_CONTAINER_HH_
+#pragma once
 
 #include "boost/iterator_adaptors.hpp"
 #include "Teuchos_RCP.hpp"
+#include "Kokkos_Core.hpp"
 
+//
+// Iterators on Kokkos views
+//
+// This simply allows ranged-based for loops on Kokkos Views that are on host.
+// We use this a lot...
+//
+namespace Kokkos {
+namespace Impl {
+
+template<typename View_type>
+struct View_iter {
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = typename View_type::value_type;
+  using difference_type = int;
+  using pointer = value_type*;
+  using reference = value_type&;
+
+  KOKKOS_INLINE_FUNCTION View_iter(const View_type& v) : View_iter(v,0) {}
+  KOKKOS_INLINE_FUNCTION View_iter(const View_type& v, int i) : v_(v), i_(i) {}
+
+  KOKKOS_INLINE_FUNCTION reference operator*() const { return v_(i_); }
+  KOKKOS_INLINE_FUNCTION pointer operator->() { return &v_(i_); }
+
+  // prefix
+  KOKKOS_INLINE_FUNCTION View_iter& operator++() { i_++; return *this; }
+  KOKKOS_INLINE_FUNCTION View_iter& operator--() { i_--; return *this; }
+  // postfix
+  KOKKOS_INLINE_FUNCTION View_iter operator++(int) { View_iter tmp(*this); ++(*this); return tmp; }
+
+  KOKKOS_INLINE_FUNCTION friend View_iter operator+(const View_iter& v, const int& d) {
+    View_iter tmp(v); tmp+=d; return tmp;
+  }
+  KOKKOS_INLINE_FUNCTION friend View_iter operator+(const int& d, const View_iter& v) {
+    return v + d;
+  }
+  KOKKOS_INLINE_FUNCTION friend int operator-(const View_iter& l, const View_iter& r){
+    return l.i_-r.i_;
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator==(const View_iter& a, const View_iter& b) {
+    return a.v_ == b.v_ && a.i_ == b.i_;
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator!=(const View_iter& a, const View_iter& b) {
+    return !(a == b);
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator<(const View_iter& l, const View_iter& r) {
+    return l.v_ == r.v_ && l.i_ < r.i_;
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator<=(const View_iter& l, const View_iter& r) {
+    return l.v_ == r.v_ && l.i_ <= r.i_;
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator>(const View_iter& l, const View_iter& r) {
+    return l.v_ == r.v_ && l.i_ > r.i_;
+  }
+  KOKKOS_INLINE_FUNCTION friend bool operator>=(const View_iter& l, const View_iter& r) {
+    return l.v_ == r.v_ && l.i_ >= r.i_;
+  }
+  KOKKOS_INLINE_FUNCTION View_iter& operator+=(const int& incr){
+    this->i_ += incr;
+    return *this;
+  }
+  KOKKOS_INLINE_FUNCTION View_iter& operator-=(const int& decr){
+    this->i_ -= decr;
+    return *this;
+  }
+  KOKKOS_INLINE_FUNCTION View_iter operator-(const int& decr){
+    this->i_ -= decr;
+    return *this;
+  }
+
+private:
+  int i_;
+  View_type v_;
+};
+
+} // namespace Impl
+
+template<typename View_type>
+Impl::View_iter<View_type>
+KOKKOS_INLINE_FUNCTION begin(const View_type& view) {
+  return Impl::View_iter<View_type>(view);
+}
+
+template<typename View_type>
+Impl::View_iter<View_type>
+KOKKOS_INLINE_FUNCTION end(const View_type& view) {
+  return Impl::View_iter<View_type>(view, view.size());
+}
+
+} // namespace Kokkos
+
+
+//
+// Iterators of const from const containers
+//
 namespace Amanzi {
 namespace Utils {
 
@@ -57,4 +151,4 @@ struct const_iterator : boost::iterator_adaptor<const_iterator<Container_t, Cont
 } // namespace Utils
 } // namespace Amanzi
 
-#endif
+

--- a/src/utils/MeshView.hh
+++ b/src/utils/MeshView.hh
@@ -1,0 +1,157 @@
+/*
+  Copyright 2010-201x held jointly by LANL, ORNL, LBNL, and PNNL.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Julien Loiseau (jloiseau@lanl.gov)
+*/
+
+#pragma once
+
+#include "Kokkos_Core.hpp"
+#include "Kokkos_DualView.hpp"
+
+#include "Iterators.hh"
+
+namespace Kokkos {
+
+template<class DataType, class... Properties>
+struct MeshView: public Kokkos::View<DataType, Properties...>{
+
+  using baseView = Kokkos::View<DataType, Properties...>;
+  using baseView::baseView;
+  using iterator = Impl::View_iter<MeshView<DataType, Properties...>>;
+  using traits = ViewTraits<DataType, Properties...>;
+
+  using const_type = MeshView<typename traits::const_data_type, typename traits::array_layout,
+            typename traits::device_type, typename traits::memory_traits>;
+  using const_iterator = Impl::View_iter<const_type>;
+
+  MeshView(const baseView& bv): baseView(bv) {}
+  MeshView(const MeshView& bv): baseView(bv) {}
+
+  KOKKOS_FUNCTION MeshView& operator=(const MeshView& other){
+    baseView::operator=(other);
+    return *this;
+  }
+
+  KOKKOS_FUNCTION MeshView& operator=(const MeshView&& other){
+    baseView::operator=(other);
+    return *this;
+  }
+
+  using HostMirror =
+    MeshView<typename traits::non_const_data_type, typename traits::array_layout,
+              Device<DefaultHostExecutionSpace,
+              typename traits::host_mirror_space::memory_space>>;
+
+  KOKKOS_INLINE_FUNCTION iterator begin() const {
+    return iterator(*this);
+  }
+
+  KOKKOS_INLINE_FUNCTION iterator end() const {
+    return iterator(*this, this->size());
+  }
+
+  KOKKOS_INLINE_FUNCTION const_iterator cbegin() const {
+    return const_iterator(*this);
+  }
+
+  KOKKOS_INLINE_FUNCTION const_iterator cend() const {
+    return const_iterator(*this, this->size());
+  }
+
+  void insert(iterator v0_e, iterator v1_b, iterator v1_e) {
+    //assert(v0_e - *this->end() != 0 && "Only insert at end supported for MeshViews");
+    std::size_t size = v1_e-v1_b;
+    std::size_t csize = this->size();
+    Kokkos::resize(*this, size+csize);
+    for(int i = csize; i < this->size(); ++i, ++v1_b) this->operator[](i) = *(v1_b);
+  }
+
+  template<typename MV>
+  KOKKOS_INLINE_FUNCTION void fromConst(const MV& cmv) {
+    Kokkos::resize(*this, cmv.size());
+    Kokkos::deep_copy(*this, cmv);
+  }
+
+};
+
+template<class SubDataType, class... SubProperties, class... Args>
+MeshView<SubDataType, SubProperties...> subview(Kokkos::MeshView<SubDataType, SubProperties...> v, Args... args){
+  MeshView ret(Kokkos::subview((typename Kokkos::MeshView<SubDataType, SubProperties...>::baseView)v, std::forward<Args>(args)...));
+  return ret;
+}
+
+template<class DataType, class Arg1Type = void, class Arg2Type = void, class Arg3Type = void>
+struct MeshDualView: public Kokkos::ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type>{
+
+  using traits = Kokkos::ViewTraits<DataType, Arg1Type, Arg2Type, Arg3Type>;
+  using host_mirror_space = typename traits::host_mirror_space;
+  using t_dev = MeshView<typename traits::data_type, Arg2Type, Arg2Type, Arg3Type>;
+  using t_host = typename t_dev::HostMirror;
+  using t_modified_flags = MeshView<unsigned int[2], LayoutLeft, Kokkos::HostSpace>;
+  t_modified_flags modified_flags;
+
+  KOKKOS_INLINE_FUNCTION t_host view_host() const {return h_view;}
+  KOKKOS_INLINE_FUNCTION t_dev view_device() const {return d_view;}
+
+  t_dev d_view;
+  t_host h_view;
+
+  MeshDualView() = default;
+  MeshDualView(const std::string& label,
+           const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+      : modified_flags(t_modified_flags("DualView::modified_flags")),
+        d_view(label, n0),
+        h_view(create_mirror_view(d_view))  // without UVM, host View mirrors
+  {}
+  MeshDualView(const MeshDualView& src): d_view(src.d_view), h_view(src.h_view), modified_flags(src.modified_flags){}
+  template <class SS, class LS, class DS, class MS>
+  MeshDualView(const MeshDualView<SS, LS, DS, MS>& src)
+      : modified_flags(src.modified_flags),
+        d_view(src.d_view),
+        h_view(src.h_view) {}
+
+  void resize(const size_t n0 = KOKKOS_IMPL_CTOR_DEFAULT_ARG) {
+    if (modified_flags.data() == nullptr) {
+      modified_flags = t_modified_flags("DualView::modified_flags");
+    }
+    if (modified_flags(1) >= modified_flags(0)) {
+      /* Resize on Device */
+      ::Kokkos::resize(d_view, n0);
+      h_view = create_mirror_view(d_view);
+
+      /* Mark Device copy as modified */
+      modified_flags(1) = modified_flags(1) + 1;
+
+    } else {
+      /* Realloc on Device */
+
+      ::Kokkos::realloc(d_view, n0);
+
+      const bool sizeMismatch = (h_view.extent(0) != n0) ;
+      if (sizeMismatch)
+        ::Kokkos::resize(h_view, n0);
+
+      t_host temp_view = create_mirror_view(d_view);
+
+      /* Remap on Host */
+      Kokkos::deep_copy(temp_view, h_view);
+
+      h_view = temp_view;
+
+      d_view = create_mirror_view(typename t_dev::execution_space(), h_view);
+
+      /* Mark Host copy as modified */
+      modified_flags(0) = modified_flags(0) + 1;
+    }
+  }
+
+};
+
+} // namespace Kokkos
+
+
+

--- a/src/utils/ViewUtils.hh
+++ b/src/utils/ViewUtils.hh
@@ -292,7 +292,7 @@ auto asRaggedArray_DualView(Func mesh_func, int count) {
   adj.rows.resize(count+1);
 
   // do a count first, setting rows
-  std::vector<Kokkos::MeshView<const T*, Kokkos::DefaultHostExecutionSpace>> ents(count);
+  std::vector<Kokkos::MeshView<const T*, Kokkos::HostSpace>> ents(count);
   int total = 0;
   for (int i=0; i!=count; ++i) {
     view<MemSpace_kind::HOST>(adj.rows)[i] = total;

--- a/src/utils/ViewUtils.hh
+++ b/src/utils/ViewUtils.hh
@@ -1,0 +1,342 @@
+/*
+  Copyright 2010-201x held jointly by LANL, ORNL, LBNL, and PNNL.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Julien Loiseau (jloiseau@lanl.gov)
+*/
+
+#pragma once
+#include <set>
+#include <vector>
+
+#include "AmanziTypes.hh"
+#include "MeshView.hh"
+
+//
+// Utility functions for Kokkos View operations
+//
+namespace Amanzi {
+
+//
+// Get the right view from a dual view
+//
+template<MemSpace_kind M, typename DualView>
+KOKKOS_INLINE_FUNCTION
+auto& // Kokkos::MeshView of the same type as DV, on M
+view(DualView& dv)
+{
+  if constexpr(M == MemSpace_kind::HOST) {
+    return dv.h_view;
+  } else {
+    return dv.d_view;
+  }
+}
+
+template<typename View, typename T>
+KOKKOS_INLINE_FUNCTION
+void initView(View& v,const T& t){
+  for(auto& vv: v) vv = t;
+}
+
+//
+// Conversion from view on host to vector
+//
+template<typename T, typename ...Args>
+std::vector<std::remove_cv_t<T>>
+asVector(const Kokkos::MeshView<T*, Args...> view)
+{
+  static_assert(Kokkos::SpaceAccessibility<typename Kokkos::MeshView<T*, Args...>::execution_space,
+                typename Kokkos::HostSpace>::accessible);
+  // currently no fix for this -- C++20 will use span
+  std::vector<std::remove_cv_t<T>> vec;
+  vec.reserve(view.size());
+  for (int i=0; i!=view.size(); ++i) vec.emplace_back(view[i]);
+  return vec;
+}
+
+
+//
+// Conversion from vector to non-owning view on host.
+//
+template<typename T>
+Kokkos::MeshView<const T*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
+toNonOwningView(const std::vector<T>& vec)
+{
+  using View_type = Kokkos::MeshView<const T*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
+  View_type my_view(vec.data(), vec.size());
+  return my_view;
+}
+
+template<typename V, typename T>
+void vectorToConstView(V& view, const std::vector<T> vec){
+  Kokkos::MeshView<T*> lview;
+  Kokkos::resize(lview,vec.size());
+  for(int i = 0; i < lview.size(); ++i)
+    lview[i] = vec[i];
+  view = lview;
+}
+
+template<typename V, typename T>
+void vectorToView(V& view, const std::vector<T> vec){
+  Kokkos::resize(view,vec.size());
+  for(int i = 0; i < view.size(); ++i)
+    view[i] = vec[i];
+}
+
+template<typename V, typename T>
+void setToView(V& view, const std::set<T> vec){
+  Kokkos::resize(view,vec.size());
+  int i = 0;
+  for(const auto& v: vec)
+    view[i++] = v;
+}
+
+//
+// Conversion between list and dual view through deep copy and sync.
+//
+// NOTE: change this to DefaultDevice!
+template<typename T, typename MemSpace = Kokkos::HostSpace>
+Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>
+asDualView(const std::vector<T>& in)
+{
+  using DV_type = Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>;
+  DV_type dv;
+  dv.resize(in.size());
+  Kokkos::deep_copy(dv.h_view, toNonOwningView(in));
+  Kokkos::deep_copy(dv.d_view,dv.h_view);
+  return dv;
+}
+
+template<typename T, typename MemSpace = Kokkos::HostSpace, typename ...Args>
+Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace>
+asDualView(const Kokkos::MeshView<T*, Args...>& in)
+{
+  Kokkos::MeshDualView<typename std::remove_const<T>::type*, MemSpace> dv;
+  dv.resize(in.size());
+  Kokkos::deep_copy(dv.h_view,in);
+  Kokkos::deep_copy(dv.d_view,dv.h_view);
+  return dv;
+}
+
+template<class ...> struct types {};
+template<class T> struct function_traits : function_traits<decltype(&T::operator())> {};
+template<class T,class C> struct function_traits<T C::*> : function_traits<T> {
+  using class_type=C;
+};
+template<class R,class ...PP> struct function_traits<R(PP...)> {
+  using return_type=R;
+  using parameter_types=std::tuple<PP...>;
+};
+template<class R,class ...PP> struct function_traits<R(PP...) const> : function_traits<R(PP...)> {};
+// In C++23, these can be merged into the above:
+template<class R,class ...PP> struct function_traits<R(PP...) noexcept> : function_traits<R(PP...)> {};
+template<class R,class ...PP> struct function_traits<R(PP...) const noexcept> : function_traits<R(PP...)> {};
+
+template<class V>
+using dual_view_t=Kokkos::MeshDualView<typename V::data_type,Kokkos::DefaultHostExecutionSpace>;
+
+namespace detail {
+  template<typename Func,typename F,typename ...PP>
+  auto asDualViews(Func &mesh_func,int count,std::tuple<F,PP...>*) {
+    std::tuple<dual_view_t<PP>...> dvs;
+    std::apply([count](auto &... dv) {(dv.resize(count),...);},dvs);
+    for(int i=0;i<count;++i)
+      std::apply([&](auto &...dv) {mesh_func(i,dv.h_view...);},dvs);
+    std::apply([](auto &...dv) {(Kokkos::deep_copy(dv.d_view,dv.h_view),...);},dvs);
+    return dvs;
+  }
+}
+
+template<typename Func>
+auto
+asDualView(Func &&mesh_func, int count)
+{
+  return detail::asDualViews(
+			     mesh_func,
+			     count,
+			     static_cast<typename function_traits<std::remove_reference_t<Func>>::parameter_types*>(nullptr));
+}
+
+
+// note, this template is left here despite not being used in case of future
+// refactoring for a more general struct.
+template<typename T>
+struct RaggedArray_DualView {
+
+  using View_type = Kokkos::MeshView<T*, Kokkos::DefaultHostExecutionSpace>;
+  using Entity_ID_View = View_type;
+
+  using type_t = T;
+
+  template<MemSpace_kind MEM>
+  using constview = Kokkos::MeshView<const T*, MemoryLocation<MEM>>;
+
+  Kokkos::MeshDualView<int*> rows;
+  Kokkos::MeshDualView<T*> entries;
+
+  using host_mirror_space = typename Kokkos::MeshDualView<T*>::host_mirror_space;
+  using execution_space = typename Kokkos::MeshDualView<T*>::execution_space;
+
+  RaggedArray_DualView() {}
+
+
+  RaggedArray_DualView(const std::vector<std::vector<T>>& vect){
+
+    rows.resize(vect.size()+1);
+    int count = 0;
+    view<MemSpace_kind::HOST>(rows)[0] = count;
+    for(int i = 1 ; i < vect.size()+1; ++i){
+      count += vect[i-1].size();
+      view<MemSpace_kind::HOST>(rows)[i] = count;
+    }
+
+    entries.resize(count);
+
+    int cur = 0;
+    for(int i = 0; i < vect.size(); ++i){
+      for(int j = 0 ; j < vect[i].size(); ++j){
+        view<MemSpace_kind::HOST>(entries)[cur++] = vect[i][j];
+      }
+    }
+    update<MemSpace_kind::DEVICE>();
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  auto
+  getRowUnmanaged(int row) {
+    const std::size_t size = view<MEM>(rows)[row+1] - view<MEM>(rows)[row];
+    const auto ptr = view<MEM>(entries).data()+view<MEM>(rows)[row];
+    return Kokkos::MeshView<T*, MemoryLocation<MEM>>(ptr, size);
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  auto
+  getRowUnmanaged(int row) const {
+    const std::size_t size = view<MEM>(rows)[row+1] - view<MEM>(rows)[row];
+    const auto ptr = view<MEM>(entries).data()+view<MEM>(rows)[row];
+    return Kokkos::MeshView<T*, MemoryLocation<MEM>>(ptr, size);
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  auto
+  getRow(int row) {
+    return Kokkos::subview(view<MEM>(entries), Kokkos::make_pair(view<MEM>(rows)[row], view<MEM>(rows)[row+1]));
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  auto
+  getRow(int row) const {
+    return Kokkos::subview(view<MEM>(entries), Kokkos::make_pair(view<MEM>(rows)[row], view<MEM>(rows)[row+1]));
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  T& get(int row, int i) {
+    return view<MEM>(entries)[view<MEM>(rows)[row]+i];
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  const T& get(int row, int i) const {
+    return view<MEM>(entries)[view<MEM>(rows)[row]+i];
+  }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  int size() const {return view<MEM>(rows).size()-1; }
+
+  template<MemSpace_kind MEM>
+  KOKKOS_INLINE_FUNCTION
+  int size(int row) const { return view<MEM>(rows)[row+1] - view<MEM>(rows)[row]; }
+
+  template<MemSpace_kind MEM>
+  void update(){
+    if constexpr (MEM == MemSpace_kind::HOST){
+      Kokkos::deep_copy(rows.view_host(),rows.view_device());
+      Kokkos::deep_copy(entries.view_host(),entries.view_device());
+    }else{
+      Kokkos::deep_copy(rows.view_device(),rows.view_host());
+      Kokkos::deep_copy(entries.view_device(),entries.view_host());
+    }
+  }
+
+  bool operator!=(const RaggedArray_DualView& oth){
+    return oth.rows.view_host().size() != rows.view_host().size()
+    && oth.entries.view_host().size() != entries.view_host().size();
+  }
+
+  void resize(int s1, int s2) {
+    rows.resize(s1+1);
+    entries.resize(s1*s2);
+    rows.h_view[0] = 0;
+    for(int i = 1 ; i < s1+1; ++i){
+      rows.h_view[i] = rows.h_view[i-1]+s2;
+    }
+    update<MemSpace_kind::DEVICE>();
+  }
+
+};
+
+//
+// Cache a RaggedArray from a callable, e.g. getCellFaces()
+//
+template<typename T, typename Func>
+auto asRaggedArray_DualView(Func mesh_func, int count) {
+  RaggedArray_DualView<T> adj;
+  adj.rows.resize(count+1);
+
+  // do a count first, setting rows
+  std::vector<Kokkos::MeshView<const T*, Kokkos::DefaultHostExecutionSpace>> ents(count);
+  int total = 0;
+  for (int i=0; i!=count; ++i) {
+    view<MemSpace_kind::HOST>(adj.rows)[i] = total;
+
+    mesh_func(i, ents[i]);
+    total += ents[i].size();
+  }
+  view<MemSpace_kind::HOST>(adj.rows)[count] = total;
+  adj.entries.resize(total);
+
+  for (int i=0; i!=count; ++i) {
+    auto row_view = adj.template getRowUnmanaged<MemSpace_kind::HOST>(i);
+    assert(row_view.extent(0) == ents[i].size());
+    Kokkos::deep_copy(row_view, ents[i]);
+  }
+  Kokkos::deep_copy(adj.rows.view_device(), adj.rows.view_host());
+  Kokkos::deep_copy(adj.entries.view_device(),adj.entries.view_host());
+  return adj;
+}
+
+template<typename T, typename List>
+KOKKOS_INLINE_FUNCTION
+bool is_present(const T& v, const List& l){
+  for(int i = 0 ; i < l.size(); ++i){
+    if(v == l[i])
+      return true;
+  }
+  return false;
+}
+
+// Find the right number of threads
+template<typename T>
+constexpr int ThreadsPerTeams(){
+  #ifdef KOKKOS_ENABLE_CUDA
+  if constexpr (std::is_same_v<T,Kokkos::Cuda>){
+    return 32;
+  }else // (std::is_same_v<T,Kokkos::Serial>){
+  #endif
+  {
+    return 1;
+  }
+}
+
+
+} // namespace Amanzi
+
+


### PR DESCRIPTION
This is mostly moving a few things around to make it easier to rebase in the future.  It also does a bit of pre-work for devices, e.g. moving using declarations for cEntity_ID_View and others into the MeshCache object so they can get the right space.