### PR TITLE
adds option for providing a form to bilinear-and-time function

### DIFF
--- a/src/functions/Function.hh
+++ b/src/functions/Function.hh
@@ -34,6 +34,8 @@ Note, this does not follow the `"typed`" format for legacy reasons.
 
 namespace Amanzi {
 
+enum class Form_kind { LINEAR, CONSTANT, FUNCTION };
+
 class Function {
  public:
   virtual ~Function() {}

--- a/src/functions/FunctionBilinearAndTime.cc
+++ b/src/functions/FunctionBilinearAndTime.cc
@@ -76,7 +76,8 @@ FunctionBilinearAndTime::operator()(const std::vector<double>& x) const
   // get the interval of the current time
   int interval = std::lower_bound(times_.begin(), times_.end(), x[0]) - times_.begin() - 1;
 
-  if ((interval < times_.size() - 1) && (x[0] + 1.e-6 > times_[interval + 1]) && form_ == Form_kind::CONSTANT) {
+  if ((interval < times_.size() - 1) && (x[0] + 1.e-6 > times_[interval + 1]) &&
+      form_ == Form_kind::CONSTANT) {
     // basicaly on the right-side endpoint -- need to deal with roundoff error
     // as this is a discontinuous case.  Note 1e-6 is chosen so that dt in
     // seconds is bigger than machine precision of a double on 100 years in

--- a/src/functions/FunctionBilinearAndTime.hh
+++ b/src/functions/FunctionBilinearAndTime.hh
@@ -29,6 +29,10 @@ bounds.
 * `"column header`" ``[string]`` **y** name of the column dataset, the :math:`y_i`
 * `"column coordinate`" ``[string]`` **y** one of `"x`",`"y`",`"z`"
 * `"value header`" ``[string]`` name of the values dataset, the :math:`u_{{i,j}}`
+* `"forms`" ``[string]`` **linear** Describes the temporal interpolant, one
+  of `"linear`" or `"constant`", where `"linear`" is therefore trilinear
+  interpolation (2x space and time) and `"constant`" indicates that the value
+  on an interval is provided by the left point's (earlier in time) value.
 
 Example1:
 
@@ -73,7 +77,8 @@ class FunctionBilinearAndTime : public Function {
                           const std::string& row_coordinate,
                           const std::string& column_header,
                           const std::string& column_coordinate,
-                          const std::string& val_header);
+                          const std::string& val_header,
+                          Form_kind form);
 
   FunctionBilinearAndTime(const FunctionBilinearAndTime& other);
 
@@ -93,6 +98,8 @@ class FunctionBilinearAndTime : public Function {
   int row_index_, col_index_;
   std::vector<double> times_;
   std::string filename_;
+  Form_kind form_;
+
   mutable double t_before_;
   mutable double t_after_;
   mutable int current_interval_;

--- a/src/functions/FunctionFactory.cc
+++ b/src/functions/FunctionFactory.cc
@@ -687,8 +687,14 @@ FunctionFactory::create_bilinear_and_time(Teuchos::ParameterList& params) const
       << form_string << "\" -- valid are \"linear\" and \"constant\"";
     Exceptions::amanzi_throw(m);
   }
-  return std::make_unique<FunctionBilinearAndTime>(
-    filename, time_header, row_header, row_coordinate, col_header, col_coordinate, value_header, form);
+  return std::make_unique<FunctionBilinearAndTime>(filename,
+                                                   time_header,
+                                                   row_header,
+                                                   row_coordinate,
+                                                   col_header,
+                                                   col_coordinate,
+                                                   value_header,
+                                                   form);
 }
 
 

--- a/src/functions/FunctionTabular.cc
+++ b/src/functions/FunctionTabular.cc
@@ -17,14 +17,14 @@ FunctionTabular::FunctionTabular(const std::vector<double>& x,
                                  const int xi)
   : x_(x), y_(y), xi_(xi)
 {
-  form_.assign(x.size() - 1, LINEAR);
+  form_.assign(x.size() - 1, Form_kind::LINEAR);
   check_args(x, y, form_);
 }
 
 FunctionTabular::FunctionTabular(const std::vector<double>& x,
                                  const std::vector<double>& y,
                                  const int xi,
-                                 const std::vector<Form>& form)
+                                 const std::vector<Form_kind>& form)
   : x_(x), y_(y), xi_(xi), form_(form)
 {
   check_args(x, y, form);
@@ -33,7 +33,7 @@ FunctionTabular::FunctionTabular(const std::vector<double>& x,
 FunctionTabular::FunctionTabular(const std::vector<double>& x,
                                  const std::vector<double>& y,
                                  const int xi,
-                                 const std::vector<Form>& form,
+                                 const std::vector<Form_kind>& form,
                                  std::vector<std::unique_ptr<Function>> func)
   : x_(x), y_(y), xi_(xi), form_(form), func_(std::move(func))
 {
@@ -51,7 +51,7 @@ FunctionTabular::FunctionTabular(const FunctionTabular& other)
 void
 FunctionTabular::check_args(const std::vector<double>& x,
                             const std::vector<double>& y,
-                            const std::vector<Form>& form) const
+                            const std::vector<Form_kind>& form) const
 {
   if (x.size() != y.size()) {
     Errors::Message m;
@@ -102,14 +102,14 @@ FunctionTabular::operator()(const std::vector<double>& x) const
     // Now have x_[j1] <= xv < x_[j2], if right continuous
     // or x_[j1] < xv <= x_[j2], if left continuous
     switch (form_[j1]) {
-    case LINEAR:
+    case Form_kind::LINEAR:
       // Linear interpolation between x[j1] and x[j2]
       y = y_[j1] + ((y_[j2] - y_[j1]) / (x_[j2] - x_[j1])) * (xv - x_[j1]);
       break;
-    case CONSTANT:
+    case Form_kind::CONSTANT:
       y = y_[j1];
       break;
-    case FUNCTION:
+    case Form_kind::FUNCTION:
       y = (*func_[j1])(x);
     }
   }

--- a/src/functions/FunctionTabular.hh
+++ b/src/functions/FunctionTabular.hh
@@ -116,18 +116,15 @@ namespace Amanzi {
 
 class FunctionTabular : public Function {
  public:
-  enum Form { LINEAR, CONSTANT, FUNCTION };
-
- public:
   FunctionTabular(const std::vector<double>& x, const std::vector<double>& y, const int xi);
   FunctionTabular(const std::vector<double>& x,
                   const std::vector<double>& y,
                   const int xi,
-                  const std::vector<Form>& form);
+                  const std::vector<Form_kind>& form);
   FunctionTabular(const std::vector<double>& x,
                   const std::vector<double>& y,
                   const int xi,
-                  const std::vector<Form>& form,
+                  const std::vector<Form_kind>& form,
                   std::vector<std::unique_ptr<Function>> func);
   FunctionTabular(const FunctionTabular& other);
   ~FunctionTabular(){};
@@ -138,13 +135,13 @@ class FunctionTabular : public Function {
  private:
   std::vector<double> x_, y_;
   int xi_;
-  std::vector<Form> form_;
+  std::vector<Form_kind> form_;
   std::vector<std::unique_ptr<Function>> func_;
 
  private: // helper functions
   void check_args(const std::vector<double>&,
                   const std::vector<double>&,
-                  const std::vector<Form>&) const;
+                  const std::vector<Form_kind>&) const;
 };
 
 } // namespace Amanzi

--- a/src/functions/test/AllFunctionTest.cc
+++ b/src/functions/test/AllFunctionTest.cc
@@ -127,9 +127,7 @@ TEST(tabular_test)
   CHECK_EQUAL((*g)(z), 2.0);
 
   // Now try with optional form argument
-  Form_kind form[3] = { Form_kind::CONSTANT,
-                        Form_kind::LINEAR,
-                        Form_kind::CONSTANT };
+  Form_kind form[3] = { Form_kind::CONSTANT, Form_kind::LINEAR, Form_kind::CONSTANT };
   std::vector<Form_kind> formvec(form, form + 3);
   f = new FunctionTabular(xvec, yvec, xi, formvec);
   z[0] = -1.0;
@@ -540,162 +538,163 @@ TEST(bilinear_and_time_test)
   //        [ 6 8 ]
   //        [ 7 9 ]
   {
-  FunctionBilinearAndTime f("test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::LINEAR);
-  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(3., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(3., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+    FunctionBilinearAndTime f(
+      "test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::LINEAR);
+    CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(3., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(3., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
-  CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, -1. }), 1.e-7);
-  CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., -1. }), 1.e-7);
-  CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, -1. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, -1. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
+    CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, -1. }), 1.e-7);
+    CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., -1. }), 1.e-7);
+    CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, -1. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, -1. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, -1. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, 0. }), 1.e-7);
-  CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., 0. }), 1.e-7);
-  CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, 0. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, 0. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, 0. }), 1.e-7);
+    CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., 0. }), 1.e-7);
+    CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, 0. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, 0. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, 0. }), 1.e-7);
 
-  CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, -1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 2.0, 0.1, 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.55, f(std::vector<double>{ 2.0, 1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 1.9, 0.1 }), 1.e-7);
-  CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 2, 0.1 }), 1.e-7);
-  CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 2.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, -1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 2.0, 0.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.55, f(std::vector<double>{ 2.0, 1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 1.9, 0.1 }), 1.e-7);
+    CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 2, 0.1 }), 1.e-7);
+    CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 2.1, 0.1 }), 1.e-7);
 
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, -1., 2.0 }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 0., 2.0 }), 1.e-7);
-  CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 0.1, 2.0 }), 1.e-7);
-  CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 1., 2.0 }), 1.e-7);
-  CHECK_CLOSE(5.95, f(std::vector<double>{ 2.0, 1.9, 2.0 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 2, 2.0 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 2.1, 2.0 }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, -1., 2.0 }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 0., 2.0 }), 1.e-7);
+    CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 0.1, 2.0 }), 1.e-7);
+    CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 1., 2.0 }), 1.e-7);
+    CHECK_CLOSE(5.95, f(std::vector<double>{ 2.0, 1.9, 2.0 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 2, 2.0 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 2.1, 2.0 }), 1.e-7);
 
-  CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, -1., 2.1 }), 1.e-7);
-  CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 0., 2.1 }), 1.e-7);
-  CHECK_CLOSE(5.1, f(std::vector<double>{ 2.0, 0.1, 2.1 }), 1.e-7);
-  CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 1., 2.1 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1.9, 2.1 }), 1.e-7);
-  CHECK_CLOSE(6.05, f(std::vector<double>{ 2.0, 2, 2.1 }), 1.e-7);
-  CHECK_CLOSE(6.05, f(std::vector<double>{ 2.0, 2.1, 2.1 }), 1.e-7);
+    CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, -1., 2.1 }), 1.e-7);
+    CHECK_CLOSE(5.05, f(std::vector<double>{ 2.0, 0., 2.1 }), 1.e-7);
+    CHECK_CLOSE(5.1, f(std::vector<double>{ 2.0, 0.1, 2.1 }), 1.e-7);
+    CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 1., 2.1 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1.9, 2.1 }), 1.e-7);
+    CHECK_CLOSE(6.05, f(std::vector<double>{ 2.0, 2, 2.1 }), 1.e-7);
+    CHECK_CLOSE(6.05, f(std::vector<double>{ 2.0, 2.1, 2.1 }), 1.e-7);
 
-  CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, -1., 3.0 }), 1.e-7);
-  CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 0., 3.0 }), 1.e-7);
-  CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 0.1, 3.0 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1., 3.0 }), 1.e-7);
-  CHECK_CLOSE(6.45, f(std::vector<double>{ 2.0, 1.9, 3.0 }), 1.e-7);
-  CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2, 3.0 }), 1.e-7);
-  CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2.1, 3.0 }), 1.e-7);
+    CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, -1., 3.0 }), 1.e-7);
+    CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 0., 3.0 }), 1.e-7);
+    CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 0.1, 3.0 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1., 3.0 }), 1.e-7);
+    CHECK_CLOSE(6.45, f(std::vector<double>{ 2.0, 1.9, 3.0 }), 1.e-7);
+    CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2, 3.0 }), 1.e-7);
+    CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2.1, 3.0 }), 1.e-7);
 
-  CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, -1., 4.0 }), 1.e-7);
-  CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 0., 4.0 }), 1.e-7);
-  CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 0.1, 4.0 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1., 4.0 }), 1.e-7);
-  CHECK_CLOSE(6.45, f(std::vector<double>{ 2.0, 1.9, 4.0 }), 1.e-7);
-  CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2, 4.0 }), 1.e-7);
-  CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2.1, 4.0 }), 1.e-7);
+    CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, -1., 4.0 }), 1.e-7);
+    CHECK_CLOSE(5.5, f(std::vector<double>{ 2.0, 0., 4.0 }), 1.e-7);
+    CHECK_CLOSE(5.55, f(std::vector<double>{ 2.0, 0.1, 4.0 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 2.0, 1., 4.0 }), 1.e-7);
+    CHECK_CLOSE(6.45, f(std::vector<double>{ 2.0, 1.9, 4.0 }), 1.e-7);
+    CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2, 4.0 }), 1.e-7);
+    CHECK_CLOSE(6.5, f(std::vector<double>{ 2.0, 2.1, 4.0 }), 1.e-7);
 
-  // check again (can we go out of order in time)
-  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(1., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(3., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(3., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+    // check again (can we go out of order in time)
+    CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(1., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(3., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(3., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
-  CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, -1. }), 1.e-7);
-  CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., -1. }), 1.e-7);
-  CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, -1. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, -1. }), 1.e-7);
-  CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
+    CHECK_CLOSE(4.05, f(std::vector<double>{ 2.0, 0.1, -1. }), 1.e-7);
+    CHECK_CLOSE(4.5, f(std::vector<double>{ 2.0, 1., -1. }), 1.e-7);
+    CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, -1. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, -1. }), 1.e-7);
+    CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, -1. }), 1.e-7);
   }
   {
-  FunctionBilinearAndTime f("test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::CONSTANT);
-  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+    FunctionBilinearAndTime f(
+      "test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::CONSTANT);
+    CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2., 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2., 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 3.0, -1., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 3.0, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, 0. }), 1.e-7);
-  CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., 0. }), 1.e-7);
-  CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, 0. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, 0. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 3.0, -1., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 3.0, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, 0. }), 1.e-7);
+    CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., 0. }), 1.e-7);
+    CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, 0. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, 0. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, 0. }), 1.e-7);
 
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, -1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.2, f(std::vector<double>{ 3.0, 0.1, 0.1 }), 1.e-7);
-  CHECK_CLOSE(5.1, f(std::vector<double>{ 3.0, 1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 1.9, 0.1 }), 1.e-7);
-  CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2, 0.1 }), 1.e-7);
-  CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, -1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.2, f(std::vector<double>{ 3.0, 0.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(5.1, f(std::vector<double>{ 3.0, 1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 1.9, 0.1 }), 1.e-7);
+    CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2, 0.1 }), 1.e-7);
+    CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2.1, 0.1 }), 1.e-7);
 
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, -1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0., 0.1 }), 1.e-7);
-  CHECK_CLOSE(4.2, f(std::vector<double>{ 4.0, 0.1, 0.1 }), 1.e-7);
-  CHECK_CLOSE(5.1, f(std::vector<double>{ 4.0, 1., 0.1 }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 1.9, 0.1 }), 1.e-7);
-  CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2, 0.1 }), 1.e-7);
-  CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, -1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0., 0.1 }), 1.e-7);
+    CHECK_CLOSE(4.2, f(std::vector<double>{ 4.0, 0.1, 0.1 }), 1.e-7);
+    CHECK_CLOSE(5.1, f(std::vector<double>{ 4.0, 1., 0.1 }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 1.9, 0.1 }), 1.e-7);
+    CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2, 0.1 }), 1.e-7);
+    CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2.1, 0.1 }), 1.e-7);
 
 
-  // check again (can we go out of order in time)
-  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
-  CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+    // check again (can we go out of order in time)
+    CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+    CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, -1. }), 1.e-7);
-  CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., -1. }), 1.e-7);
-  CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, -1. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, -1. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, -1. }), 1.e-7);
+    CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., -1. }), 1.e-7);
+    CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, -1. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, -1. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, -1. }), 1.e-7);
 
-  CHECK_CLOSE(4., f(std::vector<double>{ 4.0, -1., -1. }), 1.e-7);
-  CHECK_CLOSE(4., f(std::vector<double>{ 4.0, 0., -1. }), 1.e-7);
-  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0.1, -1. }), 1.e-7);
-  CHECK_CLOSE(5, f(std::vector<double>{ 4.0, 1., -1. }), 1.e-7);
-  CHECK_CLOSE(5.9, f(std::vector<double>{ 4.0, 1.9, -1. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2, -1. }), 1.e-7);
-  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2.1, -1. }), 1.e-7);
-
+    CHECK_CLOSE(4., f(std::vector<double>{ 4.0, -1., -1. }), 1.e-7);
+    CHECK_CLOSE(4., f(std::vector<double>{ 4.0, 0., -1. }), 1.e-7);
+    CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0.1, -1. }), 1.e-7);
+    CHECK_CLOSE(5, f(std::vector<double>{ 4.0, 1., -1. }), 1.e-7);
+    CHECK_CLOSE(5.9, f(std::vector<double>{ 4.0, 1.9, -1. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2, -1. }), 1.e-7);
+    CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2.1, -1. }), 1.e-7);
   }
 }

--- a/src/functions/test/AllFunctionTest.cc
+++ b/src/functions/test/AllFunctionTest.cc
@@ -127,10 +127,10 @@ TEST(tabular_test)
   CHECK_EQUAL((*g)(z), 2.0);
 
   // Now try with optional form argument
-  FunctionTabular::Form form[3] = { FunctionTabular::CONSTANT,
-                                    FunctionTabular::LINEAR,
-                                    FunctionTabular::CONSTANT };
-  std::vector<FunctionTabular::Form> formvec(form, form + 3);
+  Form_kind form[3] = { Form_kind::CONSTANT,
+                        Form_kind::LINEAR,
+                        Form_kind::CONSTANT };
+  std::vector<Form_kind> formvec(form, form + 3);
   f = new FunctionTabular(xvec, yvec, xi, formvec);
   z[0] = -1.0;
   CHECK_EQUAL((*f)(z), 1.0);
@@ -539,8 +539,8 @@ TEST(bilinear_and_time_test)
   // v(3) = [ 4 6 ]
   //        [ 6 8 ]
   //        [ 7 9 ]
-
-  FunctionBilinearAndTime f("test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values");
+  {
+  FunctionBilinearAndTime f("test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::LINEAR);
   CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
   CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
   CHECK_CLOSE(1., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
@@ -625,4 +625,77 @@ TEST(bilinear_and_time_test)
   CHECK_CLOSE(4.95, f(std::vector<double>{ 2.0, 1.9, -1. }), 1.e-7);
   CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2, -1. }), 1.e-7);
   CHECK_CLOSE(5., f(std::vector<double>{ 2.0, 2.1, -1. }), 1.e-7);
+  }
+  {
+  FunctionBilinearAndTime f("test/bilinear_and_time.h5", "time", "x", "x", "y", "y", "values", Form_kind::CONSTANT);
+  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 2., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 2., 3., 3. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 2.9, 3., 3. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 3.0, -1., 0. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 3.0, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, 0. }), 1.e-7);
+  CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., 0. }), 1.e-7);
+  CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, 0. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, 0. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, 0. }), 1.e-7);
+
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, -1., 0.1 }), 1.e-7);
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0., 0.1 }), 1.e-7);
+  CHECK_CLOSE(4.2, f(std::vector<double>{ 3.0, 0.1, 0.1 }), 1.e-7);
+  CHECK_CLOSE(5.1, f(std::vector<double>{ 3.0, 1., 0.1 }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 1.9, 0.1 }), 1.e-7);
+  CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2, 0.1 }), 1.e-7);
+  CHECK_CLOSE(6.1, f(std::vector<double>{ 3.0, 2.1, 0.1 }), 1.e-7);
+
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, -1., 0.1 }), 1.e-7);
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0., 0.1 }), 1.e-7);
+  CHECK_CLOSE(4.2, f(std::vector<double>{ 4.0, 0.1, 0.1 }), 1.e-7);
+  CHECK_CLOSE(5.1, f(std::vector<double>{ 4.0, 1., 0.1 }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 1.9, 0.1 }), 1.e-7);
+  CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2, 0.1 }), 1.e-7);
+  CHECK_CLOSE(6.1, f(std::vector<double>{ 4.0, 2.1, 0.1 }), 1.e-7);
+
+
+  // check again (can we go out of order in time)
+  CHECK_CLOSE(0., f(std::vector<double>{ -1., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ 0., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, -1., -1. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .25, 3., 3. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .75, 0., 0. }), 1.e-7);
+  CHECK_CLOSE(0., f(std::vector<double>{ .75, 3., 3. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 1., 0., 0. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 1., 3., 3. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, -1., -1. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 2.0, 0., -1. }), 1.e-7);
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 3.0, 0.1, -1. }), 1.e-7);
+  CHECK_CLOSE(5, f(std::vector<double>{ 3.0, 1., -1. }), 1.e-7);
+  CHECK_CLOSE(5.9, f(std::vector<double>{ 3.0, 1.9, -1. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2, -1. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 3.0, 2.1, -1. }), 1.e-7);
+
+  CHECK_CLOSE(4., f(std::vector<double>{ 4.0, -1., -1. }), 1.e-7);
+  CHECK_CLOSE(4., f(std::vector<double>{ 4.0, 0., -1. }), 1.e-7);
+  CHECK_CLOSE(4.1, f(std::vector<double>{ 4.0, 0.1, -1. }), 1.e-7);
+  CHECK_CLOSE(5, f(std::vector<double>{ 4.0, 1., -1. }), 1.e-7);
+  CHECK_CLOSE(5.9, f(std::vector<double>{ 4.0, 1.9, -1. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2, -1. }), 1.e-7);
+  CHECK_CLOSE(6., f(std::vector<double>{ 4.0, 2.1, -1. }), 1.e-7);
+
+  }
 }


### PR DESCRIPTION
This allows the time part to be piecewise constant, instead of just linear, and matches the concepts in fuction-tabular.  Like function-tabular, values on the interval match the left endpoint of the interval.

Note only a single "forms" string is allowed -- forms may not be prescribed by interval, since this would require reading strings from the file.

Tests added to test the capability.