### PR TITLE
better definition of IsDifferentiableWRT

### DIFF
--- a/Docker/Dockerfile-ATS-build
+++ b/Docker/Dockerfile-ATS-build
@@ -35,12 +35,14 @@ RUN git checkout $amanzi_branch
 RUN git pull
 RUN git rev-parse --short HEAD
 
-# Checkout/update the submodules
-RUN git submodule update --init --recursive
+# Checkout ATS at the right branch
+RUN git submodule update --init
 WORKDIR /home/amanzi_user/amanzi/src/physics/ats
-RUN git checkout $ats_branch
-RUN git pull
+RUN if [[ -n "$ats_branch" ]] ; then git checkout $ats_branch; git pull; fi
 RUN git rev-parse --short HEAD
+
+# Checkout ats-regression-tests at the right branch
+RUN git submodule update --init 
 WORKDIR /home/amanzi_user/amanzi/src/physics/ats/testing/ats-regression-tests
 RUN if [[ -n "$ats_tests_branch" ]] ; then git checkout $ats_tests_branch; git pull; fi
 RUN git rev-parse --short HEAD

--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -271,9 +271,9 @@ CompositeVector::operator=(const CompositeVector& other)
 // Ghosted views are simply the vector itself, while non-ghosted views are
 // lazily generated.
 Teuchos::RCP<const Epetra_MultiVector>
-CompositeVector::ViewComponent(std::string name, bool ghosted) const
+CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
-  if (name == std::string("boundary_face")) {
+  if (name == "boundary_face") {
     if (!mastervec_->HasComponent("boundary_face") && mastervec_->HasComponent("face")) {
       ApplyVandelay_();
       return vandelay_vector_;
@@ -289,9 +289,9 @@ CompositeVector::ViewComponent(std::string name, bool ghosted) const
 
 
 Teuchos::RCP<Epetra_MultiVector>
-CompositeVector::ViewComponent(std::string name, bool ghosted)
+CompositeVector::ViewComponent(const std::string& name, bool ghosted)
 {
-  if (name == std::string("boundary_face")) {
+  if (name == "boundary_face") {
     if (!mastervec_->HasComponent("boundary_face") && mastervec_->HasComponent("face")) {
       ApplyVandelay_();
       ChangedValue("face");
@@ -310,7 +310,7 @@ CompositeVector::ViewComponent(std::string name, bool ghosted)
 
 // Set data by pointer if possible, otherwise by copy.
 void
-CompositeVector::SetComponent(std::string name, const Teuchos::RCP<Epetra_MultiVector>& data)
+CompositeVector::SetComponent(const std::string& name, const Teuchos::RCP<Epetra_MultiVector>& data)
 {
   ChangedValue(name);
 
@@ -347,7 +347,7 @@ CompositeVector::ScatterMasterToGhosted(bool force) const
 
 
 void
-CompositeVector::ScatterMasterToGhosted(std::string name, bool force) const
+CompositeVector::ScatterMasterToGhosted(const std::string& name, bool force) const
 {
   // NOTE: allowing const is a hack to allow non-owning PKs to nonetheless
   // update ghost cells, which may be necessary for their discretization
@@ -399,7 +399,7 @@ CompositeVector::ScatterMasterToGhosted(Epetra_CombineMode mode) const
 //
 // This Scatter() is not managed, and is always done.  Tags changed.
 void
-CompositeVector::ScatterMasterToGhosted(std::string name, Epetra_CombineMode mode) const
+CompositeVector::ScatterMasterToGhosted(const std::string& name, Epetra_CombineMode mode) const
 {
   ChangedValue(name);
 
@@ -428,7 +428,7 @@ CompositeVector::GatherGhostedToMaster(Epetra_CombineMode mode)
 
 
 void
-CompositeVector::GatherGhostedToMaster(std::string name, Epetra_CombineMode mode)
+CompositeVector::GatherGhostedToMaster(const std::string& name, Epetra_CombineMode mode)
 {
   ChangedValue(name);
 #ifdef HAVE_MPI
@@ -476,7 +476,7 @@ CompositeVector::ApplyVandelay_() const
 
 // return non-empty importer
 const Epetra_Import&
-CompositeVector::importer(std::string name) const
+CompositeVector::importer(const std::string& name) const
 {
   return Mesh()->importer(Location(name));
 }

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -189,7 +189,8 @@ class CompositeVector {
   }
 
   // Access the VectorSpace for each component.
-  Teuchos::RCP<const Epetra_BlockMap> ComponentMap(const std::string& name, bool ghosted = false) const
+  Teuchos::RCP<const Epetra_BlockMap>
+  ComponentMap(const std::string& name, bool ghosted = false) const
   {
     return ghosted ? ghostvec_->ComponentMap(name) : mastervec_->ComponentMap(name);
   }
@@ -205,7 +206,10 @@ class CompositeVector {
   // View entries in the vectors
   //
   // Return-by-value, this does not tag as changed.
-  double operator()(const std::string& name, int i, int j) const { return (*ghostvec_)(name, i, j); }
+  double operator()(const std::string& name, int i, int j) const
+  {
+    return (*ghostvec_)(name, i, j);
+  }
   double operator()(const std::string& name, int j) const { return (*ghostvec_)(name, 0, j); }
 
   // -- Set data. --
@@ -395,10 +399,7 @@ class CompositeVector {
   void InitData_(const CompositeVector& other, InitMode mode);
   void CreateData_();
 
-  int Index_(const std::string& name) const
-  {
-    return indexmap_.at(name);
-  }
+  int Index_(const std::string& name) const { return indexmap_.at(name); }
 
   // The Vandelay is an Importer/Exporter which allows face unknowns
   // to be spoofed as boundary face unknowns.

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -176,20 +176,20 @@ class CompositeVector {
   Teuchos::RCP<const AmanziMesh::Mesh> Mesh() const { return map_->Mesh(); }
   bool HasComponent(const std::string& name) const { return map_->HasComponent(name); }
   int NumComponents() const { return size(); }
-  AmanziMesh::Entity_kind Location(std::string name) const { return map_->Location(name); }
+  AmanziMesh::Entity_kind Location(const std::string& name) const { return map_->Location(name); }
 
   int NumVectors(const std::string& name) const { return map_->NumVectors(name); }
   int GlobalLength() const { return mastervec_->GlobalLength(); }
   long int GetLocalElementCount() const { return mastervec_->GetLocalElementCount(); }
 
   // Provides the size of each component's vector, either ghosted or non-ghosted.
-  unsigned int size(std::string name, bool ghosted = false) const
+  unsigned int size(const std::string& name, bool ghosted = false) const
   {
     return ghosted ? ghostvec_->size(name) : mastervec_->size(name);
   }
 
   // Access the VectorSpace for each component.
-  Teuchos::RCP<const Epetra_BlockMap> ComponentMap(std::string name, bool ghosted = false) const
+  Teuchos::RCP<const Epetra_BlockMap> ComponentMap(const std::string& name, bool ghosted = false) const
   {
     return ghosted ? ghostvec_->ComponentMap(name) : mastervec_->ComponentMap(name);
   }
@@ -200,20 +200,20 @@ class CompositeVector {
   //
   // Const access -- this does not tag as changed.
   Teuchos::RCP<const Epetra_MultiVector>
-  ViewComponent(std::string name, bool ghosted = false) const;
+  ViewComponent(const std::string& name, bool ghosted = false) const;
 
   // View entries in the vectors
   //
   // Return-by-value, this does not tag as changed.
-  double operator()(std::string name, int i, int j) const { return (*ghostvec_)(name, i, j); }
-  double operator()(std::string name, int j) const { return (*ghostvec_)(name, 0, j); }
+  double operator()(const std::string& name, int i, int j) const { return (*ghostvec_)(name, i, j); }
+  double operator()(const std::string& name, int j) const { return (*ghostvec_)(name, 0, j); }
 
   // -- Set data. --
 
   // Access a view of a single component's data.
   //
   // Non-const access -- tags changed.
-  Teuchos::RCP<Epetra_MultiVector> ViewComponent(std::string name, bool ghosted = false);
+  Teuchos::RCP<Epetra_MultiVector> ViewComponent(const std::string& name, bool ghosted = false);
 
 #if CV_ENABLE_SET_FROM_OPERATOR
   // Set entries in the vectors.
@@ -241,7 +241,7 @@ class CompositeVector {
 
 
   // Set block by pointer if possible, copy if not?????? FIX ME --etc
-  void SetComponent(std::string name, const Teuchos::RCP<Epetra_MultiVector>& data);
+  void SetComponent(const std::string& name, const Teuchos::RCP<Epetra_MultiVector>& data);
 
   // -- Communicate data and communication management. --
 
@@ -249,7 +249,7 @@ class CompositeVector {
   void ChangedValue() const;
 
   // Mark a single component as changed.
-  void ChangedValue(std::string name) const;
+  void ChangedValue(const std::string& name) const;
 
   // Scatter master values to ghosted values, on all components (INSERT mode).
   //
@@ -270,11 +270,7 @@ class CompositeVector {
   // non-owning PK to communicate a non-owned vector.
   //
   // Note that the scatter is ifneeded, unless force=true.
-  void ScatterMasterToGhosted(std::string name, bool force = false) const;
-  void ScatterMasterToGhosted(const char* name, bool force = false) const
-  {
-    ScatterMasterToGhosted(std::string(name), force);
-  }
+  void ScatterMasterToGhosted(const std::string& name, bool force = false) const;
 
   // Scatter master values to ghosted values, on all components, in a mode.
   //
@@ -298,7 +294,7 @@ class CompositeVector {
   // non-owning PK to communicate a non-owned vector.
   //
   // This Scatter() is not managed, and is always done.  Tags changed.
-  void ScatterMasterToGhosted(std::string name, Epetra_CombineMode mode) const;
+  void ScatterMasterToGhosted(const std::string& name, Epetra_CombineMode mode) const;
 
   // Combine ghosted values back to master values.
   //
@@ -307,10 +303,10 @@ class CompositeVector {
   //
   // This Scatter() is not managed, and is always done.  Tags changed.
   void GatherGhostedToMaster(Epetra_CombineMode mode = Add);
-  void GatherGhostedToMaster(std::string name, Epetra_CombineMode mode = Add);
+  void GatherGhostedToMaster(const std::string& name, Epetra_CombineMode mode = Add);
 
   // returns non-empty importer
-  const Epetra_Import& importer(std::string name) const;
+  const Epetra_Import& importer(const std::string& name) const;
 
   // -- Assorted vector operations, this implements a Vec --
 
@@ -326,10 +322,10 @@ class CompositeVector {
   int PutScalarGhosted(double scalar);
 
   // v(name,:,:) = scalar
-  int PutScalar(std::string name, double scalar);
+  int PutScalar(const std::string& name, double scalar);
 
   // v(name,i,:) = scalar[i]
-  int PutScalar(std::string name, std::vector<double> scalar);
+  int PutScalar(const std::string& name, std::vector<double> scalar);
 
   // this <- scalar*this
   int Scale(double scalar);
@@ -339,13 +335,13 @@ class CompositeVector {
   int Abs(const CompositeVector& other);
 
   // this(name,:,:) <- scalar*this(name,:,:)
-  int Scale(std::string name, double scalar);
+  int Scale(const std::string& name, double scalar);
 
   // this <- this + scalar
   int Shift(double scalar);
 
   // this(name,:,:) <- scalar + this(name,:,:)
-  int Shift(std::string name, double scalar);
+  int Shift(const std::string& name, double scalar);
 
   // this <- element wise reciprocal(this)
   int Reciprocal(const CompositeVector& other);
@@ -399,13 +395,10 @@ class CompositeVector {
   void InitData_(const CompositeVector& other, InitMode mode);
   void CreateData_();
 
-  int Index_(std::string name) const
+  int Index_(const std::string& name) const
   {
-    std::map<std::string, int>::const_iterator item = indexmap_.find(name);
-    AMANZI_ASSERT(item != indexmap_.end());
-    return item->second;
+    return indexmap_.at(name);
   }
-
 
   // The Vandelay is an Importer/Exporter which allows face unknowns
   // to be spoofed as boundary face unknowns.
@@ -442,7 +435,7 @@ CompositeVector::ChangedValue() const
 }
 
 inline void
-CompositeVector::ChangedValue(std::string name) const
+CompositeVector::ChangedValue(const std::string& name) const
 {
   ghost_are_current_[Index_(name)] = false;
 }
@@ -483,14 +476,14 @@ CompositeVector::PutScalarGhosted(double scalar)
 }
 
 inline int
-CompositeVector::PutScalar(std::string name, double scalar)
+CompositeVector::PutScalar(const std::string& name, double scalar)
 {
   ChangedValue(name);
   return mastervec_->PutScalar(name, scalar);
 }
 
 inline int
-CompositeVector::PutScalar(std::string name, std::vector<double> scalar)
+CompositeVector::PutScalar(const std::string& name, std::vector<double> scalar)
 {
   ChangedValue(name);
   return mastervec_->PutScalar(name, scalar);
@@ -518,7 +511,7 @@ CompositeVector::ScaleMasterAndGhosted(double scalar)
 }
 
 inline int
-CompositeVector::Scale(std::string name, double scalar)
+CompositeVector::Scale(const std::string& name, double scalar)
 {
   ChangedValue(name);
   return mastervec_->Scale(name, scalar);
@@ -532,7 +525,7 @@ CompositeVector::Shift(double scalar)
 }
 
 inline int
-CompositeVector::Shift(std::string name, double scalar)
+CompositeVector::Shift(const std::string& name, double scalar)
 {
   ChangedValue(name);
   return mastervec_->Shift(name, scalar);

--- a/src/functions/Function.hh
+++ b/src/functions/Function.hh
@@ -7,22 +7,23 @@
   Authors:
 */
 
-//! Function: base class for all functions of space and time.
+//! A base class for all functions of space and time.
 /*!
+
 Analytic, algabraic functions of space and time are used for a variety of
 purposes, including boundary conditions, initial conditions, and independent
 variables.
 
 For initial conditions, functions are prescribed of space only, i.e.
 
-:math:`u = f(x,y,z)`
+.. math::
+   u = f(x,y,z)
 
 For boundary conditions and independent variables, functions are also a
 function of time:
 
-:math:`u = f(t,x,y,z)`
-
-Note, this does not follow the `"typed`" format for legacy reasons.
+.. math::
+   u = f(t,x,y,z)
 
 */
 

--- a/src/functions/FunctionStandardMath.hh
+++ b/src/functions/FunctionStandardMath.hh
@@ -7,8 +7,9 @@
   Authors: Ethan Coon (ecoon@lanl.gov)
 */
 
-//! FunctionStandardMath: provides access to many common mathematical functions.
+//! Provides access to many common mathematical functions.
 /*!
+
 These functions allow to set up non-trivial time-dependent boundary conditions
 which increases a set of analytic solutions that can be used in convergence
 analysis tests.

--- a/src/mesh_functions/ColumnMeshFunction.hh
+++ b/src/mesh_functions/ColumnMeshFunction.hh
@@ -23,8 +23,8 @@ Function values u:
 
   /f[:] = (f_0(z_0), f_1(z_1), ..., f_n(z_n))
 
-.. _constants-composite-vector-spec:
-.. admonition:: constants-composite-vector-spec
+.. _column-initialization-spec
+.. admonition:: column-initialization-spec
 
    * `"file`" ``[string]`` HDF5 filename
    * `"z header`" ``[string]`` name of the z-coordinate data: `z` above.  Depth

--- a/src/operators/Operator.hh
+++ b/src/operators/Operator.hh
@@ -54,7 +54,8 @@ The list includes reconstruction and limiting algorithms.
 
 
 Schema
-......
+------
+
 The operators use notion of schema to describe operator's abstract structure.
 Old operators use a simple schema which is simply the list of geometric objects where
 scalar degrees of freedom are defined.

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -28,6 +28,9 @@ include_directories(${DATA_STRUCTURES_SOURCE_DIR})
 include_directories(${MESH_SOURCE_DIR})
 include_directories(${OUTPUT_SOURCE_DIR})
 include_directories(${GEOMETRY_SOURCE_DIR})
+include_directories(${MFUNCS_SOURCE_DIR})
+include_directories(${STATE_SOURCE_DIR})
+include_directories(${STATE_SOURCE_DIR}/data)
 
 # External (TPL) include directories
 include_directories(${Teuchos_INCLUDE_DIRS})
@@ -65,13 +68,14 @@ set(solvers_link_libs data_structures
 		      geometry
 		      error_handling
 		      whetstone
-		      atk)
+		      atk
+                      state
+                      mesh_functions)
 
 add_amanzi_library(solvers
                    SOURCE ${solvers_source_files} 
                    HEADERS ${solvers_inc_files}
-		   LINK_LIBS data_structures output whetstone atk
-                             ${solver_depends} ${solvers_tpl_libs} ${Epetra_LIBRARIES})
+		   LINK_LIBS ${solvers_link_libs} ${solvers_tpl_libs})
 
 if (BUILD_TESTS)
     set(solvers_test_link_libs solvers ${solvers_link_libs})

--- a/src/solvers/IterativeMethodBelos.hh
+++ b/src/solvers/IterativeMethodBelos.hh
@@ -10,7 +10,8 @@
 
 //! Trilinos/Belos implementations of iterative methods.
 /*!
-Includes GMRES
+
+Includes GMRES and other Belos methods.
 
 .. warning:: undocumented
 

--- a/src/solvers/PreconditionerIfpack.hh
+++ b/src/solvers/PreconditionerIfpack.hh
@@ -31,9 +31,9 @@ Valid methods include:
 Note that all of these can be used without Additive Schwarz by appending
 "stand-alone".
 
-The full list of relevant parameters is somewhat method-dependent, and is documented extensively at
-
-.. url:: https://docs.trilinos.org/dev/packages/ifpack/doc/html/index.html
+The full list of relevant parameters is somewhat method-dependent, and is
+documented extensively in the `Trilinos Documentation
+<https://docs.trilinos.org/dev/packages/ifpack/doc/html/index.html>`_.
 
 Here we document a subset of the most frequently used parameters -- advanced
 users should read the Ifpack User Guide above to see all options.

--- a/src/solvers/ResidualDebugger.cc
+++ b/src/solvers/ResidualDebugger.cc
@@ -33,14 +33,12 @@ namespace AmanziSolvers {
 // -----------------------------------------------------------------------------
 template <>
 void
-ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt,
-                                                  const TreeVectorSpace& space)
+ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt, const TreeVectorSpace& space)
 {
   int cycle = -1;
   double time = 0;
   if (S_.get()) {
-    if (S_->HasRecord("cycle", tag_))
-      cycle = S_->Get<int>("cycle", tag_);
+    if (S_->HasRecord("cycle", tag_)) cycle = S_->Get<int>("cycle", tag_);
     time = S_->Get<double>("time", tag_);
   }
   on_ = DumpRequested(cycle, time);
@@ -101,7 +99,8 @@ ResidualDebugger::WriteVector<TreeVector>(int iter,
           auto mesh = r_leaves[i]->Data()->Mesh();
           for (const std::string& additional_var : additional_vars_) {
             if (S_->GetMesh(Keys::getDomain(additional_var)) == mesh) {
-              const auto& vec = *S_->Get<CompositeVector>(additional_var, tag_).ViewComponent("cell", false);
+              const auto& vec =
+                *S_->Get<CompositeVector>(additional_var, tag_).ViewComponent("cell", false);
               for (int j = 0; j != vec.NumVectors(); ++j) {
                 std::stringstream my_name;
                 my_name << additional_var << ".cell." << j;

--- a/src/solvers/ResidualDebugger.cc
+++ b/src/solvers/ResidualDebugger.cc
@@ -36,8 +36,14 @@ void
 ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt,
                                                   const TreeVectorSpace& space)
 {
-  int cycle = S_->Get<int>("cycle", tag_);
-  on_ = DumpRequested(cycle, S_->Get<double>("time", tag_));
+  int cycle = -1;
+  double time = 0;
+  if (S_.get()) {
+    if (S_->HasRecord("cycle", tag_))
+      cycle = S_->Get<int>("cycle", tag_);
+    time = S_->Get<double>("time", tag_);
+  }
+  on_ = DumpRequested(cycle, time);
   if (on_) {
     // iterate through the TreeVector finding leaf nodes and write them
     std::vector<Teuchos::RCP<const TreeVectorSpace>> leaves = collectTreeVectorLeaves_const(space);

--- a/src/solvers/ResidualDebugger.cc
+++ b/src/solvers/ResidualDebugger.cc
@@ -33,13 +33,11 @@ namespace AmanziSolvers {
 // -----------------------------------------------------------------------------
 template <>
 void
-ResidualDebugger::StartIteration<TreeVectorSpace>(double time,
-                                                  int cycle,
-                                                  int attempt,
+ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt,
                                                   const TreeVectorSpace& space)
 {
-  on_ = DumpRequested(cycle, time);
-  time_ = time;
+  int cycle = S_->Get<int>("cycle", tag_);
+  on_ = DumpRequested(cycle, S_->Get<double>("time", tag_));
   if (on_) {
     // iterate through the TreeVector finding leaf nodes and write them
     std::vector<Teuchos::RCP<const TreeVectorSpace>> leaves = collectTreeVectorLeaves_const(space);
@@ -73,10 +71,11 @@ ResidualDebugger::WriteVector<TreeVector>(int iter,
     // open files
     for (std::vector<Teuchos::RCP<HDF5_MPI>>::iterator it = vis_.begin(); it != vis_.end(); ++it) {
       if (it->get()) {
-        (*it)->writeMesh(time_, iter);
-        (*it)->createTimestep(time_, iter, "");
+        (*it)->writeMesh(S_->Get<double>("time", tag_), iter);
+        (*it)->createTimestep(S_->Get<double>("time", tag_), iter, "");
         (*it)->open_h5file();
         (*it)->writeAttrReal(S_->Get<double>("dt", tag_), "dt");
+        (*it)->writeAttrInt(S_->Get<int>("cycle", tag_), "dt");
       }
     }
 

--- a/src/solvers/ResidualDebugger.hh
+++ b/src/solvers/ResidualDebugger.hh
@@ -61,7 +61,7 @@ class ResidualDebugger : public IOEvent {
       tag_(tag)
   {
     filebasename_ = plist_.get<std::string>("file name base", "amanzi_dbg");
-    additional_vars_ = plist_.get<Teuchos::Array<std::string>>("additional variables");
+    additional_vars_ = plist_.get<Teuchos::Array<std::string>>("additional variables", {});
   }
 
   template <class VectorSpace>

--- a/src/solvers/ResidualDebugger.hh
+++ b/src/solvers/ResidualDebugger.hh
@@ -65,8 +65,7 @@ class ResidualDebugger : public IOEvent {
   }
 
   template <class VectorSpace>
-  void StartIteration(double time, int cycle, int attempt, const VectorSpace& space)
-  {}
+  void StartIteration(int attempt, const VectorSpace& space) {}
 
   template <class Vector>
   void WriteVector(int iter,
@@ -79,7 +78,6 @@ class ResidualDebugger : public IOEvent {
  protected:
   std::string filebasename_;
   bool on_;
-  double time_;
   std::vector<Teuchos::RCP<HDF5_MPI>> vis_;
 
   Teuchos::RCP<State> S_;
@@ -90,9 +88,7 @@ class ResidualDebugger : public IOEvent {
 
 template <>
 void
-ResidualDebugger::StartIteration<TreeVectorSpace>(double time,
-                                                  int cycle,
-                                                  int attempt,
+ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt,
                                                   const TreeVectorSpace& space);
 template <>
 void

--- a/src/solvers/ResidualDebugger.hh
+++ b/src/solvers/ResidualDebugger.hh
@@ -56,16 +56,15 @@ class ResidualDebugger : public IOEvent {
   ResidualDebugger(Teuchos::ParameterList& plist,
                    const Teuchos::RCP<State>& S = Teuchos::null,
                    const Tag& tag = Tags::DEFAULT)
-    : IOEvent(plist),
-      S_(S),
-      tag_(tag)
+    : IOEvent(plist), S_(S), tag_(tag)
   {
     filebasename_ = plist_.get<std::string>("file name base", "amanzi_dbg");
     additional_vars_ = plist_.get<Teuchos::Array<std::string>>("additional variables", {});
   }
 
   template <class VectorSpace>
-  void StartIteration(int attempt, const VectorSpace& space) {}
+  void StartIteration(int attempt, const VectorSpace& space)
+  {}
 
   template <class Vector>
   void WriteVector(int iter,
@@ -88,8 +87,7 @@ class ResidualDebugger : public IOEvent {
 
 template <>
 void
-ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt,
-                                                  const TreeVectorSpace& space);
+ResidualDebugger::StartIteration<TreeVectorSpace>(int attempt, const TreeVectorSpace& space);
 template <>
 void
 ResidualDebugger::WriteVector<TreeVector>(int iter,

--- a/src/solvers/ResidualDebugger.hh
+++ b/src/solvers/ResidualDebugger.hh
@@ -36,21 +36,32 @@ process for use with vis tools.
 #include "Teuchos_Ptr.hpp"
 #include "Teuchos_ParameterList.hpp"
 
+#include "Tag.hh"
 #include "VerboseObject.hh"
 #include "IOEvent.hh"
 #include "TreeVector.hh"
 #include "TreeVector_Utils.hh"
 #include "HDF5_MPI.hh"
+#include "StateDefs.hh"
 
 namespace Amanzi {
+
+class State;
+
 namespace AmanziSolvers {
 
 class ResidualDebugger : public IOEvent {
  public:
   // Constructor
-  ResidualDebugger(Teuchos::ParameterList& plist) : IOEvent(plist)
+  ResidualDebugger(Teuchos::ParameterList& plist,
+                   const Teuchos::RCP<State>& S = Teuchos::null,
+                   const Tag& tag = Tags::DEFAULT)
+    : IOEvent(plist),
+      S_(S),
+      tag_(tag)
   {
     filebasename_ = plist_.get<std::string>("file name base", "amanzi_dbg");
+    additional_vars_ = plist_.get<Teuchos::Array<std::string>>("additional variables");
   }
 
   template <class VectorSpace>
@@ -70,6 +81,10 @@ class ResidualDebugger : public IOEvent {
   bool on_;
   double time_;
   std::vector<Teuchos::RCP<HDF5_MPI>> vis_;
+
+  Teuchos::RCP<State> S_;
+  Teuchos::Array<std::string> additional_vars_;
+  Tag tag_;
 };
 
 

--- a/src/state/IO.cc
+++ b/src/state/IO.cc
@@ -41,7 +41,7 @@ namespace Amanzi {
 // Non-member function for visualization.
 // -----------------------------------------------------------------------------
 void
-WriteVis(Visualization& vis, const State& S)
+WriteVis(Visualization& vis, State& S)
 {
   if (!vis.is_disabled()) {
     // Create the new time step
@@ -69,6 +69,9 @@ WriteVis(Visualization& vis, const State& S)
           // -- same time
           Tag tag;
           if (r->second->HasRecord(tag)) {
+            if (S.HasEvaluator(r->first, tag)) {
+              S.GetEvaluator(r->first, tag).Update(S, "vis");
+            }
             r->second->WriteVis(vis, &tag);
           } else {
             // try to find a record at the same time
@@ -76,6 +79,9 @@ WriteVis(Visualization& vis, const State& S)
             for (const auto& time_record : S.GetRecordSet("time")) {
               if (r->second->HasRecord(time_record.first) &&
                   S.get_time(time_record.first) == time) {
+                if (S.HasEvaluator(r->first, time_record.first)) {
+                  S.GetEvaluator(r->first, time_record.first).Update(S, "vis");
+                }
                 r->second->WriteVis(vis, &time_record.first);
                 break;
               }

--- a/src/state/IO.cc
+++ b/src/state/IO.cc
@@ -69,9 +69,7 @@ WriteVis(Visualization& vis, State& S)
           // -- same time
           Tag tag;
           if (r->second->HasRecord(tag)) {
-            if (S.HasEvaluator(r->first, tag)) {
-              S.GetEvaluator(r->first, tag).Update(S, "vis");
-            }
+            if (S.HasEvaluator(r->first, tag)) { S.GetEvaluator(r->first, tag).Update(S, "vis"); }
             r->second->WriteVis(vis, &tag);
           } else {
             // try to find a record at the same time

--- a/src/state/IO.hh
+++ b/src/state/IO.hh
@@ -28,7 +28,7 @@ namespace Amanzi {
 
 // Visualization
 void
-WriteVis(Visualization& vis, const State& S);
+WriteVis(Visualization& vis, State& S);
 
 // Checkpointing
 void

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -394,7 +394,7 @@ State::RequireEvaluator(const Key& key, const Tag& tag)
 
 
 bool
-State::HasEvaluator(const Key& key, const Tag& tag)
+State::HasEvaluator(const Key& key, const Tag& tag) const
 {
   if (Keys::hasKey(evaluators_, key)) {
     return Keys::hasKey(evaluators_.at(key), tag);
@@ -913,7 +913,7 @@ State::GetEvaluatorList(const Key& key)
 
 
 bool
-State::HasEvaluatorList(const Key& key)
+State::HasEvaluatorList(const Key& key) const
 {
   if (FEList().isSublist(key)) return true;
   // check for domain set

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -57,6 +57,10 @@ State::State()
 State::State(Teuchos::ParameterList& state_plist) : state_plist_(state_plist)
 {
   vo_ = Teuchos::rcp(new VerboseObject("State", state_plist_));
+
+  // touch the "evaluators" list to make sure it exists, even in tests that
+  // don't use it, to make sure that const calls to FEList() can work.
+  state_plist_.sublist("evaluators");
 };
 
 

--- a/src/state/State.hh
+++ b/src/state/State.hh
@@ -485,8 +485,9 @@ class State {
   //
   // -- allows PKs to add to this list to custom evaluators
   Teuchos::ParameterList& FEList() { return state_plist_.sublist("evaluators"); }
+  const Teuchos::ParameterList& FEList() const { return state_plist_.sublist("evaluators"); }
   Teuchos::ParameterList& GetEvaluatorList(const Key& key);
-  bool HasEvaluatorList(const Key& key);
+  bool HasEvaluatorList(const Key& key) const;
 
   // -- allows PKs to add to this list to initial conditions
   Teuchos::ParameterList& ICList() { return state_plist_.sublist("initial conditions"); }
@@ -504,7 +505,7 @@ class State {
   const Evaluator& GetEvaluator(const Key& key, const Tag& tag) const;
 #endif
 
-  bool HasEvaluator(const Key& key, const Tag& tag);
+  bool HasEvaluator(const Key& key, const Tag& tag) const;
   void SetEvaluator(const Key& key, const Tag& tag, const Teuchos::RCP<Evaluator>& evaluator);
   Teuchos::RCP<Evaluator> GetEvaluatorPtr(const Key& key, const Tag& tag);
 

--- a/src/state/evaluators/EvaluatorSecondary.cc
+++ b/src/state/evaluators/EvaluatorSecondary.cc
@@ -319,8 +319,7 @@ EvaluatorSecondary::UpdateDerivative(State& S,
 bool
 EvaluatorSecondary::IsDependency(const State& S, const Key& key, const Tag& tag) const
 {
-  if (std::find(dependencies_.begin(), dependencies_.end(), std::make_pair(key, tag)) !=
-      dependencies_.end()) {
+  if (IsDirectDependency(key, tag)) {
     return true;
   } else {
     for (auto& dep : dependencies_) {
@@ -330,6 +329,17 @@ EvaluatorSecondary::IsDependency(const State& S, const Key& key, const Tag& tag)
   return false;
 }
 
+bool
+EvaluatorSecondary::IsDirectDependency(const Key& key, const Tag& tag) const
+{
+  if (std::find(dependencies_.begin(), dependencies_.end(), std::make_pair(key, tag)) !=
+      dependencies_.end()) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 
 bool
 EvaluatorSecondary::ProvidesKey(const Key& key, const Tag& tag) const
@@ -337,6 +347,22 @@ EvaluatorSecondary::ProvidesKey(const Key& key, const Tag& tag) const
   std::pair<Key, Tag> my_key = std::make_pair(key, tag);
   return std::find(my_keys_.begin(), my_keys_.end(), my_key) != my_keys_.end();
 }
+
+
+bool
+EvaluatorSecondary::IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const
+{
+  // note, provides key means the value is 1, and there may be times we have to use this value...
+  if (ProvidesKey(wrt_key, wrt_tag)) return true;
+  if (IsDirectDependency(wrt_key, wrt_tag)) return true;
+  for (auto& dep : dependencies_) {
+    if (S.GetEvaluator(dep.first, dep.second).IsDifferentiableWRT(S, wrt_key, wrt_tag)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 
 
 std::string

--- a/src/state/evaluators/EvaluatorSecondary.cc
+++ b/src/state/evaluators/EvaluatorSecondary.cc
@@ -350,7 +350,9 @@ EvaluatorSecondary::ProvidesKey(const Key& key, const Tag& tag) const
 
 
 bool
-EvaluatorSecondary::IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const
+EvaluatorSecondary::IsDifferentiableWRT(const State& S,
+                                        const Key& wrt_key,
+                                        const Tag& wrt_tag) const
 {
   // note, provides key means the value is 1, and there may be times we have to use this value...
   if (ProvidesKey(wrt_key, wrt_tag)) return true;
@@ -362,7 +364,6 @@ EvaluatorSecondary::IsDifferentiableWRT(const State& S, const Key& wrt_key, cons
   }
   return false;
 }
-
 
 
 std::string

--- a/src/state/evaluators/EvaluatorSecondary.hh
+++ b/src/state/evaluators/EvaluatorSecondary.hh
@@ -60,14 +60,10 @@ class EvaluatorSecondary : public Evaluator {
   virtual bool
   UpdateDerivative(State& S, const Key& request, const Key& wrt_key, const Tag& wrt_tag) override;
 
+  virtual bool IsDirectDependency(const Key& key, const Tag& tag) const;
   virtual bool IsDependency(const State& S, const Key& key, const Tag& tag) const override;
   virtual bool ProvidesKey(const Key& key, const Tag& tag) const override;
-  virtual bool
-  IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override
-  {
-    // note, provides key means the value is 1, and there may be times we have to use this value...
-    return ProvidesKey(wrt_key, wrt_tag) || IsDependency(S, wrt_key, wrt_tag);
-  }
+  virtual bool IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override;
 
   virtual std::string WriteToString() const override;
 

--- a/src/state/evaluators/EvaluatorSecondary.hh
+++ b/src/state/evaluators/EvaluatorSecondary.hh
@@ -63,7 +63,8 @@ class EvaluatorSecondary : public Evaluator {
   virtual bool IsDirectDependency(const Key& key, const Tag& tag) const;
   virtual bool IsDependency(const State& S, const Key& key, const Tag& tag) const override;
   virtual bool ProvidesKey(const Key& key, const Tag& tag) const override;
-  virtual bool IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override;
+  virtual bool
+  IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override;
 
   virtual std::string WriteToString() const override;
 

--- a/src/state/evaluators/EvaluatorSecondaryMonotypeFromFunction.cc
+++ b/src/state/evaluators/EvaluatorSecondaryMonotypeFromFunction.cc
@@ -54,7 +54,8 @@ EvaluatorSecondaryMonotypeFromFunction::EvaluatorSecondaryMonotypeFromFunction(
 {
   if (dependencies_.size() == 0) {
     Errors::Message message;
-    message << "EvaluatorSecondaryMonotypeFromFunction: for " << my_keys_[0].first << " was provided no dependencies";
+    message << "EvaluatorSecondaryMonotypeFromFunction: for " << my_keys_[0].first
+            << " was provided no dependencies";
     throw(message);
   }
 

--- a/src/state/evaluators/EvaluatorSecondaryMonotypeFromFunction.cc
+++ b/src/state/evaluators/EvaluatorSecondaryMonotypeFromFunction.cc
@@ -26,9 +26,9 @@ as:
 Example:
 ..xml:
     <ParameterList name="VARNAME">
-      <Parameter name="field evaluator type" type="string" value="secondary
-variable from function"/> <Parameter name="evaluator dependencies"
-type="Array{string}" value="{DEP1, DEP2}"/> <ParameterList name="function">
+      <Parameter name="field evaluator type" type="string" value="secondary variable from function"/>
+      <Parameter name="evaluator dependencies" type="Array{string}" value="{DEP1, DEP2}"/>
+      <ParameterList name="function">
         <ParameterList name="function-linear">
           <Parameter name="x0" type="Array(double)" value="{0.0,0.0}" />
           <Parameter name="y0" type="double" value="3." />
@@ -52,6 +52,12 @@ EvaluatorSecondaryMonotypeFromFunction::EvaluatorSecondaryMonotypeFromFunction(
   Teuchos::ParameterList& plist)
   : EvaluatorSecondaryMonotype<CompositeVector, CompositeVectorSpace>(plist)
 {
+  if (dependencies_.size() == 0) {
+    Errors::Message message;
+    message << "EvaluatorSecondaryMonotypeFromFunction: for " << my_keys_[0].first << " was provided no dependencies";
+    throw(message);
+  }
+
   FunctionFactory fac;
   if (plist.isSublist("functions")) {
     auto& flist = plist.sublist("functions");

--- a/src/time_integration/BDF1_TI.hh
+++ b/src/time_integration/BDF1_TI.hh
@@ -190,7 +190,7 @@ BDF1_TI<Vector, VectorSpace>::BDF1_TI(BDFFnBase<Vector>& fn,
 
   // update the verbose options
   vo_ = Teuchos::rcp(new VerboseObject(initvector->Comm(), "TI::BDF1", plist_));
-  db_ = Teuchos::rcp(new AmanziSolvers::ResidualDebugger(plist_.sublist("residual debugger")));
+  db_ = Teuchos::rcp(new AmanziSolvers::ResidualDebugger(plist_.sublist("residual debugger"), S));
 
   // Create the state.
   state_ = Teuchos::rcp(new BDF1_State<Vector>());

--- a/src/time_integration/BDF1_TI.hh
+++ b/src/time_integration/BDF1_TI.hh
@@ -328,7 +328,7 @@ BDF1_TI<Vector, VectorSpace>::TimeStep(double dt,
   }
 
   // Update the debugger
-  db_->StartIteration<VectorSpace>(tlast, state_->seq, state_->failed_current, u->Map());
+  db_->StartIteration<VectorSpace>(state_->failed_current, u->Map());
 
   // Overwrite preconditioner control
   if (state_->freeze_pc) solver_->set_pc_lag(1000000000);

--- a/src/utils/VerboseObject.hh
+++ b/src/utils/VerboseObject.hh
@@ -105,6 +105,9 @@ class VerboseObject : public Teuchos::VerboseObject<VerboseObject> {
   // Is process 0 and verbosity is included?
   inline bool os_OK(Teuchos::EVerbosityLevel verbosity) const;
 
+  // is the verbosity included?
+  inline bool includesVerbLevel(Teuchos::EVerbosityLevel verbosity) const;
+
   // Get the stream (errors if !os_OK()).
   inline Teuchos::RCP<Teuchos::FancyOStream> os() const;
 
@@ -142,8 +145,14 @@ class VerboseObject : public Teuchos::VerboseObject<VerboseObject> {
 bool
 VerboseObject::os_OK(Teuchos::EVerbosityLevel verbosity) const
 {
-  return getOStream().get() && includesVerbLevel(getVerbLevel(), verbosity, true);
+  return getOStream().get() && includesVerbLevel(verbosity);
 };
+
+bool
+VerboseObject::includesVerbLevel(Teuchos::EVerbosityLevel verbosity) const
+{
+  return Teuchos::includesVerbLevel(getVerbLevel(), verbosity, true);
+}
 
 
 Teuchos::RCP<Teuchos::FancyOStream>

--- a/tools/amanzi_xml/amanzi_xml/common/parameter.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter.py
@@ -176,6 +176,13 @@ class Parameter(base.TeuchosBaseXML):
         assert retval is not None
         return retval
 
+    def __copy__(self):
+        return Parameter(self.getName(), self.getType(), self.getValue())
+
+    def __deepcopy__(self, memo):
+        cp = self.__copy__()
+        memo[id(self)] = cp
+        return cp
 
 from amanzi_xml.utils import parser
 def make_class(typename, array=False):

--- a/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
@@ -1,4 +1,6 @@
 import warnings
+import copy
+
 from . import base
 from . import parameter
 from amanzi_xml.utils import parser
@@ -200,6 +202,19 @@ class ParameterList(base.TeuchosBaseXML):
 
     def pop(self, name):
         return search.remove_element(self, name, False, True)
+
+    def __copy__(self):
+        cp = self.__class__(self.getName())
+        for child in self:
+            cp.append(child)
+        return cp
+
+    def __deepcopy__(self, memo):
+        cp = self.__class__(self.getName())
+        memo[id(self)] = cp
+        for child in self:
+            cp.append(copy.deepcopy(child, memo))
+        return cp
     
 # register
 parser.objects['ParameterList'] = ParameterList


### PR DESCRIPTION
This change of IsDifferentiableWRT allows evaluators to have the key as a dependency, but NOT be differentiable with respect to that dependency.  This allows other evaluators to overload this method and turn derivatives off if they are not implemented, rather than set the derivative to zero (which results in the same answer but at the cost of doing work and then multiplying it by zero).