### PR TITLE
fixes bug in Mesh_MSTK w.r.t. enumerated set regions

### DIFF
--- a/src/mesh/mesh_mstk/Mesh_MSTK.cc
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.cc
@@ -2398,7 +2398,7 @@ Mesh_MSTK::build_set(const Teuchos::RCP<const AmanziGeometry::Region>& region,
       int ncell = num_entities(CELL, Parallel_type::ALL);
 
       for (int icell = 0; icell < ncell; icell++) {
-        Entity_ID gid = MEnt_GlobalID(cell_id_to_handle[icell]);
+        Entity_ID gid = MEnt_GlobalID(cell_id_to_handle[icell]) - 1;
         for (const auto& jset : rgn->entities()) {
           if (jset == gid) {
             MSet_Add(mset, cell_id_to_handle[icell]);


### PR DESCRIPTION
fixes bug in Mesh_MSTK where enumerated GIDs were not incremented prior to comparison to MSTK GIDs, which are 1-based.

Note this requires an ATS PR as well, which fixes the test that checked this capability.