### PR TITLE
Split ctest suite across multiple runners

### DIFF
--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -49,7 +49,7 @@ jobs:
         docker push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest
   sw_tests:
     runs-on: ubuntu-latest
-    name: run shallow water tests separately.
+    name: shallow_water_* tests 
     needs: build
     steps:
     - name: Check out the Amanzi repo
@@ -67,9 +67,9 @@ jobs:
       working-directory: Docker
       run:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R ^shallow_water"
-  non_sw_tests:
+  trans_tests:
     runs-on: ubuntu-latest
-    name: run all other tests.
+    name: transport_* tests 
     needs: build
     steps:
     - name: Check out the Amanzi repo
@@ -86,4 +86,24 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E ^shallow_water"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R ^transport"
+  non_sw_tests:
+    runs-on: ubuntu-latest
+    name: Tests other than shallow_water_* or transport_*
+    needs: build
+    steps:
+    - name: Check out the Amanzi repo
+      uses: actions/checkout@v4
+    - name: Extract the branch name
+      id: branch
+      run:
+        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+    - name: Filter the branch name to generate a tag for Docker
+      id: tag
+      run:
+        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
+    - name: Run tests
+      id: tests
+      working-directory: Docker
+      run:
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E '^shallow_water|^transport'"

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -47,9 +47,9 @@ jobs:
       working-directory: Docker
       run:
         docker push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest
-  sw_tests:
+  serial-tests:
     runs-on: ubuntu-latest
-    name: shallow_water_* tests 
+    name: serial tests 
     needs: build
     steps:
     - name: Check out the Amanzi repo
@@ -66,10 +66,10 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R ^shallow_water"
-  trans_tests:
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL"
+  parallel-tests:
     runs-on: ubuntu-latest
-    name: transport_* tests 
+    name: parallel tests 
     needs: build
     steps:
     - name: Check out the Amanzi repo
@@ -86,24 +86,5 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R ^transport"
-  non_sw_tests:
-    runs-on: ubuntu-latest
-    name: Tests other than shallow_water_* or transport_*
-    needs: build
-    steps:
-    - name: Check out the Amanzi repo
-      uses: actions/checkout@v4
-    - name: Extract the branch name
-      id: branch
-      run:
-        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
-    - name: Filter the branch name to generate a tag for Docker
-      id: tag
-      run:
-        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
-    - name: Run tests
-      id: tests
-      working-directory: Docker
-      run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E '^shallow_water|^transport'"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL"
+  

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -8,12 +8,12 @@ on:
       - amanzi-*
 
 jobs:
-  build_test:
+  build:
     runs-on: ubuntu-latest
     name: Build and test with Docker
     steps:
     - name: Check out the Amanzi repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Extract the branch name
       id: branch
       run:
@@ -47,8 +47,43 @@ jobs:
       working-directory: Docker
       run:
         docker push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest
+  sw_tests:
+    runs-on: ubuntu-latest
+    name: run shallow water tests separately.
+    needs: build
+    steps:
+    - name: Check out the Amanzi repo
+      uses: actions/checkout@v4
+    - name: Extract the branch name
+      id: branch
+      run:
+        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+    - name: Filter the branch name to generate a tag for Docker
+      id: tag
+      run:
+        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
     - name: Run tests
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R shallow_water"
+  non_sw_tests:
+    runs-on: ubuntu-latest
+    name: run all other tests.
+    needs: build
+    steps:
+    - name: Check out the Amanzi repo
+      uses: actions/checkout@v4
+    - name: Extract the branch name
+      id: branch
+      run:
+        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
+    - name: Filter the branch name to generate a tag for Docker
+      id: tag
+      run:
+        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
+    - name: Run tests
+      id: tests
+      working-directory: Docker
+      run:
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E shallow_water"

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -66,7 +66,7 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R shallow_water"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -R ^shallow_water"
   non_sw_tests:
     runs-on: ubuntu-latest
     name: run all other tests.
@@ -86,4 +86,4 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E shallow_water"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -E ^shallow_water"

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -57,9 +57,10 @@ jobs:
     - name: Run tests
       id: tests
       working-directory: Docker
-      run:
-        # set environment variables again:
+      run: |
+        # set environment variables again as they are not available to new runner:
         echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
+        # run tests:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL"
   parallel-tests:
     runs-on: ubuntu-latest
@@ -71,8 +72,9 @@ jobs:
     - name: Run tests
       id: tests
       working-directory: Docker
-      run:
-        # set environment variables again:
+      run: |
+        # set environment variables again as they are not available to new runner:
         echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
+        # run tests:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL"
   

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -54,13 +54,13 @@ jobs:
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
+    - name: Set environment variables
+      run:
+        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
     - name: Run tests
       id: tests
       working-directory: Docker
-      run: |
-        # set environment variables again as they are not available to new runner:
-        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
-        # run tests:
+      run: 
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL"
   parallel-tests:
     runs-on: ubuntu-latest
@@ -69,12 +69,12 @@ jobs:
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
+    - name: Set environment variables
+      run:
+        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
     - name: Run tests
       id: tests
       working-directory: Docker
-      run: |
-        # set environment variables again as they are not available to new runner:
-        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
-        # run tests:
+      run: 
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL"
   

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build and test with Docker
+    name: Build Docker container
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -54,18 +54,12 @@ jobs:
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
-    - name: Extract the branch name
-      id: branch
-      run:
-        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
-    - name: Filter the branch name to generate a tag for Docker
-      id: tag
-      run:
-        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
     - name: Run tests
       id: tests
       working-directory: Docker
       run:
+        # set environment variables again:
+        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL"
   parallel-tests:
     runs-on: ubuntu-latest
@@ -74,17 +68,11 @@ jobs:
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
-    - name: Extract the branch name
-      id: branch
-      run:
-        echo "AMANZI_BRANCH=$GITHUB_REF_NAME" >> $GITHUB_ENV
-    - name: Filter the branch name to generate a tag for Docker
-      id: tag
-      run:
-        echo "AMANZI_BRANCH_TAG=$(echo ${{env.AMANZI_BRANCH}} | sed -e 's/\//--/g')" >> $GITHUB_ENV
     - name: Run tests
       id: tests
       working-directory: Docker
       run:
+        # set environment variables again:
+        echo "AMANZI_BRANCH_TAG=$(echo $GITHUB_REF_NAME | sed -e 's/\//--/g')" >> $GITHUB_ENV
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL"
   

--- a/Docker/Dockerfile-Amanzi-build
+++ b/Docker/Dockerfile-Amanzi-build
@@ -36,7 +36,7 @@ RUN ./bootstrap.sh --prefix=${AMANZI_PREFIX} \
    --amanzi-build-dir=/home/amanzi_user/amanzi_builddir/amanzi \
    --tpl-config-file=${AMANZI_TPLS_DIR}/share/cmake/amanzi-tpl-config.cmake \
    --parallel=4 --opt \
-   --disable-structured \
+   --enable-structured \
    --disable-build_user_guide \
    --enable-alquimia --enable-pflotran --enable-crunchtope \
    --with-mpi=/usr \

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -335,7 +335,7 @@ Configuration:
                           option is selected, '"$0"' will NOT build the TPLs.
 
   --opt                   build optimized TPLs and Amanzi binaries. This the default
-                          configuration.
+                          configuration. Produces no debug info.
 
   --relwithdebinfo        build optimized TPLs and Amanzi binaries with debug info
                           (for profiling)
@@ -1530,7 +1530,7 @@ function check_tools
     ( version_compare "$ver_string" "$cmake_version" )
     result=$?
     if [ ${result} -eq 2 ]; then
-      status_message "CMake version is less than required version. Will build CMake version 3.11.4"
+      status_message "CMake version is less than required version. Will build CMake version ≥ ${cmake_version}"
       build_cmake ${tools_build_dir} ${tools_install_prefix} ${tools_download_dir} 
     fi
   fi

--- a/tools/cmake/CCSEOptions.cmake
+++ b/tools/cmake/CCSEOptions.cmake
@@ -62,11 +62,6 @@ if(defs)
   list(APPEND BL_DEFINES ${defs})
 endif()
 
-
-if(CMAKE_COMPILER_IS_GNUCXX)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wno-deprecated")
-endif(CMAKE_COMPILER_IS_GNUCXX)
-
 list(APPEND BL_DEFINES "AMANZI")
 
 if (ENABLE_PETSC)


### PR DESCRIPTION
Splits ctest suite across three runners to reduce CI run times. Most recent CI run for this reduced time from ~2h7m to 1h7m, but compile time was unusually fast and so times closer to 1h30m should more often be expected.

Refs #773 