### PR TITLE
Update Dockerfile-TPLs to manually compile mpich

### DIFF
--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -15,7 +15,7 @@ RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONT
 
 RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   apt-utils \
-  cmake \
+#  cmake \
   curl \
   libcurl4-openssl-dev \
   emacs \
@@ -85,16 +85,16 @@ WORKDIR /home/amanzi_user
 #     http_proxy=proxyout.lanl.gov:8080
 
 # Clone the amanzi git repo.
-RUN git clone --branch $amanzi_branch --depth 1 --no-single-branch https://github.com/amanzi/amanzi.git
+RUN git clone https://github.com/amanzi/amanzi.git
 
 # Set the current working directory to the git repo
 # and switch branches if requested.
 WORKDIR /home/amanzi_user/amanzi
-#RUN if [ "$amanzi_branch" != "master" ]; then \
-#       git checkout $amanzi_branch; \
-#    fi; \
-#    echo "Amanzi branch = $amanzi_branch"; \
-#    git branch --list 
+RUN if [ "$amanzi_branch" != "master" ]; then \
+       git checkout $amanzi_branch; \
+    fi; \
+    echo "Amanzi branch = $amanzi_branch"; \
+    git branch --list 
 
 # Build and install the TPLs using bootstrap.sh, and remove
 # the source, objects, etc. after installation to save space.

--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -8,7 +8,7 @@ LABEL Description="This image contains all of the third-party libraries needed b
 
 # MPI flavor (mpich|openmpi)
 ARG mpi_flavor=mpich 
-ARG mpi_version=4.1.2
+ARG mpi_version=3.3.2
 
 # Set timezone:
 RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
@@ -49,7 +49,7 @@ RUN if [ "$mpi_flavor" = "mpich" ]; then cd / \
   && wget https://www.mpich.org/static/downloads/${mpi_version}/mpich-${mpi_version}.tar.gz \
   && tar xvf mpich-${mpi_version}.tar.gz \
   && cd mpich-${mpi_version} \
-  && ./configure --enable-shared --with-device=ch3:sock --prefix=/usr \ 
+  && ./configure --enable-shared --with-device=ch3:sock --enable-fast=all,O3 --prefix=/usr \ 
   && make \ 
   && make install \
   && cd ../ \

--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -7,7 +7,8 @@ FROM ubuntu:focal
 LABEL Description="This image contains all of the third-party libraries needed by Amanzi (based on the specified branch, default branch is master)."
 
 # MPI flavor (mpich|openmpi)
-ARG mpi_flavor=mpich
+ARG mpi_flavor=mpich 
+ARG mpi_version=4.1.2
 
 # Set timezone:
 RUN ln -snf /usr/share/zoneinfo/$CONTAINER_TIMEZONE /etc/localtime && echo $CONTAINER_TIMEZONE > /etc/timezone
@@ -25,7 +26,7 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   libblas-dev \
   liblapacke-dev \
   liblapack-dev \
-  lib${mpi_flavor}-dev \
+#  lib${mpi_flavor}-dev \
   libssl-dev \
   m4 \
   make \
@@ -42,6 +43,19 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
 # Note this installs numpy as well
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir install h5py
+
+# install mpich:
+RUN if [ "$mpi_flavor" = "mpich" ]; then cd / \
+  && wget https://www.mpich.org/static/downloads/${mpi_version}/mpich-${mpi_version}.tar.gz \
+  && tar xvf mpich-${mpi_version}.tar.gz \
+  && cd mpich-${mpi_version} \
+  && ./configure --enable-shared --with-device=ch3:sock --prefix=/usr \ 
+  && make \ 
+  && make install \
+  && cd ../ \
+  && rm -r mpich-${mpi_version}/ \
+  && rm mpich-${mpi_version}.tar.gz ; \
+  else apt-get install -y lib${mpi_flavor}-dev ; fi
 
 # Versions change and we cannot set environment variables from command output.
 ARG petsc_ver
@@ -71,16 +85,16 @@ WORKDIR /home/amanzi_user
 #     http_proxy=proxyout.lanl.gov:8080
 
 # Clone the amanzi git repo.
-RUN git clone https://github.com/amanzi/amanzi.git
+RUN git clone --branch $amanzi_branch --depth 1 --no-single-branch https://github.com/amanzi/amanzi.git
 
 # Set the current working directory to the git repo
 # and switch branches if requested.
 WORKDIR /home/amanzi_user/amanzi
-RUN if [ "$amanzi_branch" != "master" ]; then \
-       git checkout $amanzi_branch; \
-    fi; \
-    echo "Amanzi branch = $amanzi_branch"; \
-    git branch --list 
+#RUN if [ "$amanzi_branch" != "master" ]; then \
+#       git checkout $amanzi_branch; \
+#    fi; \
+#    echo "Amanzi branch = $amanzi_branch"; \
+#    git branch --list 
 
 # Build and install the TPLs using bootstrap.sh, and remove
 # the source, objects, etc. after installation to save space.
@@ -96,7 +110,8 @@ RUN ./bootstrap.sh --prefix=${AMANZI_PREFIX} \
   --with-mpi=/usr \
   --with-python=/usr/bin/python \
   && git checkout master \
-  && rm -r /home/amanzi_user/amanzi_builddir
+  && rm -r /home/amanzi_user/amanzi_builddir \
+  && rm -r /home/amanzi_user/amanzi/build/tools/
 
 # Set the LD_LIBRARY_PATH for Amanzi builds in the next stage
 ENV LD_LIBRARY_PATH=${AMANZI_TPLS_DIR}/lib:${AMANZI_PETSC_LIBS}:${AMANZI_TRILINOS_LIBS}:${AMANZI_SEACAS_LIBS}

--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -44,7 +44,7 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir install h5py
 
-# install mpich:
+# install MPI - if mpich, custom compile; if openmpi, install precompiled binary 
 RUN if [ "$mpi_flavor" = "mpich" ]; then cd / \
   && wget https://www.mpich.org/static/downloads/${mpi_version}/mpich-${mpi_version}.tar.gz \
   && tar xvf mpich-${mpi_version}.tar.gz \

--- a/Docker/deploy-tpls-docker.sh
+++ b/Docker/deploy-tpls-docker.sh
@@ -4,12 +4,12 @@
 # Options: openmpi, mpich
 MPI_DISTRO=mpich
 
-PETSC_VER=3.13
-TRILINOS_VER=13-0-afc4e525
+PETSC_VER=3.16
+TRILINOS_VER=14-2-fc55b9cd
 
 AMANZI_BRANCH=master
 AMANZI_SOURCE_DIR=/ascem/amanzi/repos/amanzi-master
-AMANZI_TPLS_VER=0.98.4
+AMANZI_TPLS_VER=0.98.7
 
 LANL_PROXY="--build-arg http_proxy=proxyout.lanl.gov:8080 --build-arg https_proxy=proxyout.lanl.gov:8080"
 

--- a/config/SuperBuild/templates/ccse-arm64.patch
+++ b/config/SuperBuild/templates/ccse-arm64.patch
@@ -1,39 +1,39 @@
-diff -ruNbB BoxLib-17.05.1/Src/C_BaseLib/FPC.cpp ccse-17.05.1-source/Src/C_BaseLib/FPC.cpp
---- BoxLib-17.05.1/Src/C_BaseLib/FPC.cpp	2017-07-27 10:50:29.000000000 -0600
-+++ ccse-17.05.1-source/Src/C_BaseLib/FPC.cpp	2022-09-14 18:31:04.000000000 -0600
-@@ -29,6 +29,7 @@
+diff -Naur ccse-17.05.1-old/Src/C_BaseLib/FPC.cpp ccse-17.05.1-new/Src/C_BaseLib/FPC.cpp
+--- ccse-17.05.1-old/Src/C_BaseLib/FPC.cpp	2017-07-27 16:50:29.000000000 +0000
++++ ccse-17.05.1-new/Src/C_BaseLib/FPC.cpp	2023-07-19 16:23:32.519424010 +0000
+@@ -29,6 +29,8 @@
      defined(__i386__) || \
      defined(__x86_64) || \
      defined(__amd64__) || \
-+    defined(__arm64) || \
++    defined(__arm64__) || \
++    defined(__aarch64__) || \
      defined(powerpc)
      static const IntDescriptor nld(sizeof(long), IntDescriptor::ReverseOrder);
  #endif
-@@ -55,7 +56,8 @@
+@@ -55,6 +57,8 @@
      defined(i386) || \
      defined(__i386__) || \
      defined(__amd64__) || \
--    defined(__x86_64)
-+    defined(__x86_64) || \
-+    defined(__arm64)
++    defined(__arm64__) || \
++    defined(__aarch64__) || \
+     defined(__x86_64)
  #ifdef BL_USE_FLOAT
      static const RealDescriptor nrd(ieee_float, reverse_float_order, 4);
- #else
-@@ -90,7 +92,8 @@
+@@ -90,6 +94,8 @@
      defined(i386) || \
      defined(__i386__) || \
      defined(__amd64__) || \
--    defined(__x86_64)
-+    defined(__x86_64) || \
-+    defined(__arm64)
++    defined(__arm64__) || \
++    defined(__aarch64__) || \
+     defined(__x86_64)
      static const RealDescriptor n32rd(ieee_float, reverse_float_order, 4);
  #endif
- 
-@@ -135,6 +138,7 @@
+@@ -134,6 +140,8 @@
+       defined(__ppc64__) || \
        defined(__i386__) || \
        defined(__amd64__) || \
++      defined(__arm64__) || \
++      defined(__aarch64__) || \
        defined(__x86_64) || \
-+      defined(__arm64) || \
        defined(__hpux)   || \
        defined(powerpc)  || \
-       defined(_MSC_VER) || \


### PR DESCRIPTION
Updates dockerfile for TPLs to automatically build mpich from source with custom options that dramatically speeds running of tests on github actions when test oversubscribes runners. Refs #773.

Benefits to CI require that a new TPL image with newly compiled mpich is pushed to dockerhub and picked up by future CI runs.