### PR TITLE
Changes UniqueMeshFunction to instantiate only on OWNED entities

### DIFF
--- a/src/mesh_functions/BoundaryFunction.hh
+++ b/src/mesh_functions/BoundaryFunction.hh
@@ -36,7 +36,8 @@ namespace Functions {
 class BoundaryFunction : public UniqueMeshFunction {
  public:
   BoundaryFunction(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh)
-    : UniqueMeshFunction(mesh), finalized_(false){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::ALL),
+      finalized_(false) {};
 
   void Define(const std::vector<std::string>& regions, const Teuchos::RCP<const MultiFunction>& f);
 

--- a/src/mesh_functions/UniqueMeshFunction.cc
+++ b/src/mesh_functions/UniqueMeshFunction.cc
@@ -37,7 +37,7 @@ UniqueMeshFunction::AddSpec(const Teuchos::RCP<Spec>& spec)
   for (auto region = domain->first.begin(); region != domain->first.end(); ++region) {
     // Get all region IDs by the region name and entity kind.
     if (mesh_->isValidSetName(*region, kind)) {
-      auto id_list = mesh_->getSetEntities(*region, kind, AmanziMesh::Parallel_kind::ALL);
+      auto id_list = mesh_->getSetEntities(*region, kind, AmanziMesh::Parallel_kind::OWNED);
       this_spec_ids->insert(id_list.begin(), id_list.end());
     } else {
       std::stringstream m;

--- a/src/mesh_functions/UniqueMeshFunction.cc
+++ b/src/mesh_functions/UniqueMeshFunction.cc
@@ -37,7 +37,7 @@ UniqueMeshFunction::AddSpec(const Teuchos::RCP<Spec>& spec)
   for (auto region = domain->first.begin(); region != domain->first.end(); ++region) {
     // Get all region IDs by the region name and entity kind.
     if (mesh_->isValidSetName(*region, kind)) {
-      auto id_list = mesh_->getSetEntities(*region, kind, AmanziMesh::Parallel_kind::OWNED);
+      auto id_list = mesh_->getSetEntities(*region, kind, parallel_kind_);
       this_spec_ids->insert(id_list.begin(), id_list.end());
     } else {
       std::stringstream m;

--- a/src/mesh_functions/UniqueMeshFunction.hh
+++ b/src/mesh_functions/UniqueMeshFunction.hh
@@ -31,7 +31,10 @@ namespace Functions {
 class UniqueMeshFunction : public MeshFunction {
  public:
   // Constructor
-  UniqueMeshFunction(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh) : MeshFunction(mesh){};
+  UniqueMeshFunction(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
+                     AmanziMesh::Parallel_kind parallel_kind)
+    : MeshFunction(mesh),
+      parallel_kind_(parallel_kind) {}
 
   // Overload the AddSpec method to check uniqueness.
   virtual void AddSpec(const Teuchos::RCP<Spec>& spec);
@@ -42,6 +45,7 @@ class UniqueMeshFunction : public MeshFunction {
   typedef std::vector<Teuchos::RCP<UniqueSpec>> UniqueSpecList;
 
   std::map<AmanziMesh::Entity_kind, Teuchos::RCP<UniqueSpecList>> unique_specs_;
+  AmanziMesh::Parallel_kind parallel_kind_;
 };
 
 } //namespace Functions

--- a/src/pks/PK_DomainFunctionFactory.hh
+++ b/src/pks/PK_DomainFunctionFactory.hh
@@ -43,15 +43,17 @@ class PK_DomainFunctionFactory : public FunctionBase {
   ~PK_DomainFunctionFactory(){};
 
   Teuchos::RCP<FunctionBase> Create(Teuchos::ParameterList& plist,
-                                    AmanziMesh::Entity_kind kind,
-                                    Teuchos::RCP<const Epetra_MultiVector> weight,
-                                    const Tag& tag = Tags::DEFAULT);
+          AmanziMesh::Entity_kind kind,
+          Teuchos::RCP<const Epetra_MultiVector> weight,
+          const Tag& tag = Tags::DEFAULT,
+          bool ghosted = false);
 
   Teuchos::RCP<FunctionBase> Create(Teuchos::ParameterList& plist,
-                                    const std::string& keyword,
-                                    AmanziMesh::Entity_kind kind,
-                                    Teuchos::RCP<const Epetra_MultiVector> weight,
-                                    const Tag& tag = Tags::DEFAULT);
+          const std::string& keyword,
+          AmanziMesh::Entity_kind kind,
+          Teuchos::RCP<const Epetra_MultiVector> weight,
+          const Tag& tag = Tags::DEFAULT,
+          bool ghosted = false);
 
 
  protected:
@@ -63,10 +65,11 @@ class PK_DomainFunctionFactory : public FunctionBase {
 template <class FunctionBase>
 Teuchos::RCP<FunctionBase>
 PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
-                                               const std::string& keyword,
-                                               AmanziMesh::Entity_kind kind,
-                                               Teuchos::RCP<const Epetra_MultiVector> weight,
-                                               const Tag& tag)
+        const std::string& keyword,
+        AmanziMesh::Entity_kind kind,
+        Teuchos::RCP<const Epetra_MultiVector> weight,
+        const Tag& tag,
+        bool ghosted)
 {
   // verify completeness of the list
   Errors::Message msg;
@@ -152,7 +155,7 @@ PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
     return func;
   } else {
     Teuchos::RCP<PK_DomainFunctionSimple<FunctionBase>> func =
-      Teuchos::rcp(new PK_DomainFunctionSimple<FunctionBase>(mesh_, plist, kind));
+      Teuchos::rcp(new PK_DomainFunctionSimple<FunctionBase>(mesh_, plist, kind, ghosted));
     func->Init(plist, keyword);
     return func;
   }
@@ -164,9 +167,10 @@ PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
 template <class FunctionBase>
 Teuchos::RCP<FunctionBase>
 PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
-                                               AmanziMesh::Entity_kind kind,
-                                               Teuchos::RCP<const Epetra_MultiVector> weight,
-                                               const Tag& tag)
+        AmanziMesh::Entity_kind kind,
+        Teuchos::RCP<const Epetra_MultiVector> weight,
+        const Tag& tag,
+        bool ghosted)
 {
   int n(0);
   std::string keyword;
@@ -182,7 +186,7 @@ PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
     Exceptions::amanzi_throw(msg);
   }
 
-  return Create(plist, keyword, kind, weight, tag);
+  return Create(plist, keyword, kind, weight, tag, ghosted);
 }
 
 } // namespace Amanzi

--- a/src/pks/PK_DomainFunctionField.hh
+++ b/src/pks/PK_DomainFunctionField.hh
@@ -36,7 +36,6 @@ the domain function.
 
 #include "CommonDefs.hh"
 #include "Mesh.hh"
-#include "UniqueMeshFunction.hh"
 #include "Evaluator.hh"
 
 #include "PK_Utils.hh"

--- a/src/pks/PK_DomainFunctionFirstOrderExchange.hh
+++ b/src/pks/PK_DomainFunctionFirstOrderExchange.hh
@@ -38,7 +38,9 @@ class PK_DomainFunctionFirstOrderExchange : public FunctionBase,
   PK_DomainFunctionFirstOrderExchange(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                                       const Teuchos::ParameterList& plist,
                                       AmanziMesh::Entity_kind kind)
-    : FunctionBase(plist), UniqueMeshFunction(mesh), kind_(kind){};
+    : FunctionBase(plist),
+      UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED),
+      kind_(kind) {};
   virtual ~PK_DomainFunctionFirstOrderExchange() = default;
 
   // member functions

--- a/src/pks/PK_DomainFunctionSimple.hh
+++ b/src/pks/PK_DomainFunctionSimple.hh
@@ -35,16 +35,18 @@ template <class FunctionBase>
 class PK_DomainFunctionSimple : public FunctionBase, public Functions::UniqueMeshFunction {
  public:
   PK_DomainFunctionSimple(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
-                          AmanziMesh::Entity_kind kind)
-    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED),
-      kind_(kind) {};
+                          AmanziMesh::Entity_kind entity_kind,
+                          bool ghosted)
+    : UniqueMeshFunction(mesh, ghosted ? AmanziMesh::Parallel_kind::ALL : AmanziMesh::Parallel_kind::OWNED),
+      kind_(entity_kind) {};
 
   PK_DomainFunctionSimple(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           const Teuchos::ParameterList& plist,
-                          AmanziMesh::Entity_kind kind)
+                          AmanziMesh::Entity_kind entity_kind,
+                          bool ghosted)
     : FunctionBase(plist),
-      UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED),
-      kind_(kind) {};
+      UniqueMeshFunction(mesh, ghosted ? AmanziMesh::Parallel_kind::ALL : AmanziMesh::Parallel_kind::OWNED),
+      kind_(entity_kind) {};
 
   ~PK_DomainFunctionSimple(){};
 

--- a/src/pks/PK_DomainFunctionSimple.hh
+++ b/src/pks/PK_DomainFunctionSimple.hh
@@ -36,12 +36,15 @@ class PK_DomainFunctionSimple : public FunctionBase, public Functions::UniqueMes
  public:
   PK_DomainFunctionSimple(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           AmanziMesh::Entity_kind kind)
-    : UniqueMeshFunction(mesh), kind_(kind){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED),
+      kind_(kind) {};
 
   PK_DomainFunctionSimple(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           const Teuchos::ParameterList& plist,
                           AmanziMesh::Entity_kind kind)
-    : FunctionBase(plist), UniqueMeshFunction(mesh), kind_(kind){};
+    : FunctionBase(plist),
+      UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED),
+      kind_(kind) {};
 
   ~PK_DomainFunctionSimple(){};
 

--- a/src/pks/PK_DomainFunctionSimpleWell.hh
+++ b/src/pks/PK_DomainFunctionSimpleWell.hh
@@ -31,11 +31,11 @@ template <class FunctionBase>
 class PK_DomainFunctionSimpleWell : public FunctionBase, public Functions::UniqueMeshFunction {
  public:
   PK_DomainFunctionSimpleWell(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh)
-    : UniqueMeshFunction(mesh){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED){};
 
   PK_DomainFunctionSimpleWell(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                               const Teuchos::ParameterList& plist)
-    : UniqueMeshFunction(mesh){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED){};
 
   ~PK_DomainFunctionSimpleWell(){};
 

--- a/src/pks/PK_DomainFunctionSubgridReturn.hh
+++ b/src/pks/PK_DomainFunctionSubgridReturn.hh
@@ -35,7 +35,7 @@ class PK_DomainFunctionSubgridReturn : public FunctionBase, public Functions::Un
  public:
   PK_DomainFunctionSubgridReturn(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                                  const Teuchos::ParameterList& plist)
-    : FunctionBase(plist), UniqueMeshFunction(mesh){};
+    : FunctionBase(plist), UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED) {};
   virtual ~PK_DomainFunctionSubgridReturn() = default;
 
   // member functions

--- a/src/pks/PK_DomainFunctionVolume.hh
+++ b/src/pks/PK_DomainFunctionVolume.hh
@@ -34,12 +34,12 @@ class PK_DomainFunctionVolume : public FunctionBase, public Functions::UniqueMes
  public:
   PK_DomainFunctionVolume(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           AmanziMesh::Entity_kind kind)
-    : UniqueMeshFunction(mesh), kind_(kind){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED), kind_(kind){};
 
   PK_DomainFunctionVolume(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           const Teuchos::ParameterList& plist,
                           AmanziMesh::Entity_kind kind)
-    : UniqueMeshFunction(mesh), kind_(kind){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED), kind_(kind){};
 
   ~PK_DomainFunctionVolume(){};
 

--- a/src/pks/PK_DomainFunctionWeight.hh
+++ b/src/pks/PK_DomainFunctionWeight.hh
@@ -37,7 +37,7 @@ class PK_DomainFunctionWeight : public FunctionBase, public Functions::UniqueMes
  public:
   PK_DomainFunctionWeight(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                           AmanziMesh::Entity_kind kind)
-    : UniqueMeshFunction(mesh), kind_(kind){};
+    : UniqueMeshFunction(mesh, AmanziMesh::Parallel_kind::OWNED), kind_(kind){};
   ~PK_DomainFunctionWeight(){};
 
   // member functions

--- a/src/pks/energy/Energy_PK.cc
+++ b/src/pks/energy/Energy_PK.cc
@@ -308,7 +308,7 @@ Energy_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc_temperature_.push_back(bc_factory.Create(
-          spec, "boundary temperature", AmanziMesh::Entity_kind::FACE, Teuchos::null));
+          spec, "boundary temperature", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true));
       }
     }
   }
@@ -323,7 +323,7 @@ Energy_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc_flux_.push_back(bc_factory.Create(
-          spec, "outward energy flux", AmanziMesh::Entity_kind::FACE, Teuchos::null));
+          spec, "outward energy flux", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true));
       }
     }
   }

--- a/src/pks/flow/Flow_PK.cc
+++ b/src/pks/flow/Flow_PK.cc
@@ -420,7 +420,7 @@ Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc = bc_factory.Create(
-          spec, "boundary pressure", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "boundary pressure", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("pressure");
         bcs_.push_back(bc);
       }
@@ -436,7 +436,7 @@ Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
       std::string name = it->first;
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
-        bc = bc_factory.Create(spec, "static head", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+        bc = bc_factory.Create(spec, "static head", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("head");
         bcs_.push_back(bc);
       }
@@ -452,7 +452,7 @@ Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
       if (it->second.isList()) {
         Teuchos::ParameterList spec = Teuchos::getValue<Teuchos::ParameterList>(it->second);
         bc = bc_factory.Create(
-          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("flux");
         bcs_.push_back(bc);
       }
@@ -469,7 +469,7 @@ Flow_PK::InitializeBCsSources_(Teuchos::ParameterList& plist)
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc = bc_factory.Create(
-          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("seepage");
         bcs_.push_back(bc);
       }

--- a/src/pks/mechanics/MechanicsElasticity_PK.cc
+++ b/src/pks/mechanics/MechanicsElasticity_PK.cc
@@ -231,14 +231,14 @@ MechanicsElasticity_PK::Initialize()
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
         // nodal dofs
-        auto bc = bc_factory.Create(spec, "no slip", AmanziMesh::NODE, Teuchos::null);
+        auto bc = bc_factory.Create(spec, "no slip", AmanziMesh::NODE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("no slip");
         bc->set_type(WhetStone::DOF_Type::POINT);
         bc->set_kind(AmanziMesh::NODE);
         bcs_.push_back(bc);
 
         // bubble dofs
-        auto bc2 = bc_factory.Create(spec, "no slip", AmanziMesh::FACE, Teuchos::null);
+        auto bc2 = bc_factory.Create(spec, "no slip", AmanziMesh::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc2->set_bc_name("no slip");
         bc2->set_type(WhetStone::DOF_Type::POINT);
         bc2->set_kind(AmanziMesh::FACE);
@@ -256,7 +256,7 @@ MechanicsElasticity_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
-        auto bc = bc_factory.Create(spec, "kinematic", AmanziMesh::FACE, Teuchos::null);
+        auto bc = bc_factory.Create(spec, "kinematic", AmanziMesh::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("kinematic");
         bc->set_type(WhetStone::DOF_Type::NORMAL_COMPONENT);
         bc->set_kind(AmanziMesh::FACE);
@@ -274,7 +274,7 @@ MechanicsElasticity_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
-        auto bc = bc_factory.Create(spec, "traction", AmanziMesh::FACE, Teuchos::null);
+        auto bc = bc_factory.Create(spec, "traction", AmanziMesh::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("traction");
         bc->set_type(WhetStone::DOF_Type::POINT);
         bc->set_kind(AmanziMesh::FACE);
@@ -292,7 +292,7 @@ MechanicsElasticity_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
-        auto bc = bc_factory.Create(spec, "normal traction", AmanziMesh::FACE, Teuchos::null);
+        auto bc = bc_factory.Create(spec, "normal traction", AmanziMesh::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("normal traction");
         bc->set_type(WhetStone::DOF_Type::NORMAL_COMPONENT);
         bc->set_kind(AmanziMesh::FACE);

--- a/src/pks/multiphase/Multiphase_PK.cc
+++ b/src/pks/multiphase/Multiphase_PK.cc
@@ -684,7 +684,7 @@ Multiphase_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc = bc_factory.Create(
-          spec, "boundary pressure", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "boundary pressure", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("pressure");
         bcs_.push_back(bc);
       }
@@ -700,7 +700,7 @@ Multiphase_PK::Initialize()
       if (it->second.isList()) {
         Teuchos::ParameterList spec = Teuchos::getValue<Teuchos::ParameterList>(it->second);
         bc = bc_factory.Create(
-          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "outward mass flux", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("flux");
         bc->SetComponentId(component_names_);
         bcs_.push_back(bc);
@@ -718,7 +718,7 @@ Multiphase_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc = bc_factory.Create(
-          spec, "boundary saturation", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "boundary saturation", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("saturation");
         bcs_.push_back(bc);
       }
@@ -735,7 +735,7 @@ Multiphase_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
         bc = bc_factory.Create(
-          spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+          spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("concentration");
         bc->SetComponentId(component_names_);
         bcs_.push_back(bc);

--- a/src/pks/navier_stokes/NavierStokes_PK.cc
+++ b/src/pks/navier_stokes/NavierStokes_PK.cc
@@ -258,7 +258,7 @@ NavierStokes_PK::Initialize()
           WhetStone::DOF_Type type;
           std::tie(kind, type, std::ignore) = *jt;
 
-          bc = bc_factory.Create(spec, "no slip", kind, Teuchos::null);
+          bc = bc_factory.Create(spec, "no slip", kind, Teuchos::null, Tags::DEFAULT, true);
           bc->set_bc_name("no slip");
           bc->set_type(type);
           bcs_.push_back(bc);

--- a/src/pks/shallow_water/ShallowWater_PK.cc
+++ b/src/pks/shallow_water/ShallowWater_PK.cc
@@ -216,7 +216,7 @@ ShallowWater_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
-        bc = bc_factory.Create(spec, "velocity", AmanziMesh::Entity_kind::FACE, Teuchos::null);
+        bc = bc_factory.Create(spec, "velocity", AmanziMesh::Entity_kind::FACE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("velocity");
         bc->set_type(WhetStone::DOF_Type::VECTOR);
         bcs_.push_back(bc);
@@ -234,7 +234,7 @@ ShallowWater_PK::Initialize()
       if (tmp_list.isSublist(name)) {
         Teuchos::ParameterList& spec = tmp_list.sublist(name);
 
-        bc = bc_factory.Create(spec, "ponded depth", AmanziMesh::Entity_kind::NODE, Teuchos::null);
+        bc = bc_factory.Create(spec, "ponded depth", AmanziMesh::Entity_kind::NODE, Teuchos::null, Tags::DEFAULT, true);
         bc->set_bc_name("ponded depth");
         bc->set_type(WhetStone::DOF_Type::SCALAR);
         bcs_.push_back(bc);

--- a/src/pks/transport/Transport_PK.cc
+++ b/src/pks/transport/Transport_PK.cc
@@ -469,7 +469,7 @@ Transport_PK::Initialize()
         std::string specname = it1->first;
         Teuchos::ParameterList& spec = bc_list.sublist(specname);
         Teuchos::RCP<TransportDomainFunction> bc =
-          factory.Create(spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Kxy);
+          factory.Create(spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Kxy, Tags::DEFAULT, true);
 
         for (int i = 0; i < component_names_.size(); i++) {
           bc->tcc_names().push_back(component_names_[i]);
@@ -485,7 +485,7 @@ Transport_PK::Initialize()
             std::string specname = it1->first;
             Teuchos::ParameterList& spec = bc_list.sublist(specname);
             Teuchos::RCP<TransportDomainFunction> bc =
-              factory.Create(spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Kxy);
+              factory.Create(spec, "boundary concentration", AmanziMesh::Entity_kind::FACE, Kxy, Tags::DEFAULT, true);
 
             bc->tcc_names().push_back(name);
             bc->tcc_index().push_back(FindComponentNumber(name));
@@ -507,7 +507,7 @@ Transport_PK::Initialize()
         spec.set<Teuchos::RCP<AmanziChemistry::Chemistry_PK>>("chemical pk", chem_pk_);
 
         Teuchos::RCP<TransportBoundaryFunction_Chemistry> bc =
-          factory2.Create(spec, "boundary constraints", AmanziMesh::Entity_kind::FACE, Kxy);
+          factory2.Create(spec, "boundary constraints", AmanziMesh::Entity_kind::FACE, Kxy, Tags::DEFAULT, true);
 
         for (int i = 0; i < component_names_.size(); i++) {
           bc->tcc_names().push_back(component_names_[i]);


### PR DESCRIPTION
This is required because UniqueMeshFunction is used on source terms, and those source terms are only well posed on OWNED entities when they are derived from subgrid meshes that are only instantiated on OWNED entities.

This may break some things -- run tests and confirm please CI.  If it doesn't break things, check with @lipnikov as to whether he is ok with this change.

