### PR TITLE
added natural_id to alquimia routine argument list

### DIFF
--- a/src/common/alquimia/ChemistryEngine.cc
+++ b/src/common/alquimia/ChemistryEngine.cc
@@ -558,7 +558,7 @@ ChemistryEngine::Advance(const double delta_time,
                          AlquimiaState& chem_state,
                          AlquimiaAuxiliaryData& aux_data,
                          AlquimiaAuxiliaryOutputData& aux_output,
-                         int& num_iterations)
+                         int& num_iterations, int natural_id)
 {
 #ifdef AMANZI_USE_FENV
   // Disable divide-by-zero floating point exceptions.
@@ -571,6 +571,7 @@ ChemistryEngine::Advance(const double delta_time,
                                   &(const_cast<AlquimiaProperties&>(mat_props)),
                                   &chem_state,
                                   &aux_data,
+                                  natural_id,
                                   &chem_status_);
 
 #ifdef AMANZI_USE_FENV

--- a/src/common/alquimia/ChemistryEngine.hh
+++ b/src/common/alquimia/ChemistryEngine.hh
@@ -138,7 +138,7 @@ class ChemistryEngine {
                AlquimiaState& chem_state,
                AlquimiaAuxiliaryData& aux_data,
                AlquimiaAuxiliaryOutputData& aux_output,
-               int& num_iterations);
+               int& num_iterations, int natural_id);
 
  private:
   // Alquimia data structures.

--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -838,7 +838,7 @@ Alquimia_PK::AdvanceSingleCell(double dt,
   int num_iterations = 0;
   if (alq_mat_props_.saturation > saturation_tolerance_) {
     bool success = chem_engine_->Advance(
-      dt, alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_, num_iterations);
+      dt, alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_, num_iterations, mesh_->cell_map(false).GID(cell));
     if (not success) {
       if (vo_->os_OK(Teuchos::VERB_MEDIUM)) {
         Teuchos::OSTab tab = vo_->getOSTab();


### PR DESCRIPTION
This PR adds "natural_id" as an argument for calls to Alquimia, making Amanzi compatible with the Nov 23 xSDK versions of PFLOTRAN and Alquimia. natural_id was added for debugging purposes. 