### PR TITLE
adds ability to read a Tag via readKey()

### DIFF
--- a/src/utils/Key.cc
+++ b/src/utils/Key.cc
@@ -514,6 +514,20 @@ readKey(Teuchos::ParameterList& list,
   }
 }
 
+
+KeyTag
+readKeyTag(Teuchos::ParameterList& list,
+           const Key& domain,
+           const Key& basename,
+           const Key& default_name,
+           const Tag& tag)
+{
+  Key key = readKey(list, domain, basename, default_name);
+  Tag tag_out(list.get<std::string>(basename+" tag", tag.get()));
+  return KeyTag{key, tag_out};
+}
+
+
 Teuchos::Array<Key>
 readKeys(Teuchos::ParameterList& list,
          const Key& domain,

--- a/src/utils/Key.hh
+++ b/src/utils/Key.hh
@@ -300,6 +300,13 @@ readKey(Teuchos::ParameterList& list,
         const Key& basename,
         const Key& default_name = "");
 
+KeyTag
+readKeyTag(Teuchos::ParameterList& list,
+           const Key& domain,
+           const Key& basename,
+           const Key& default_name = "",
+           const Tag& tag_default = Tag(""));
+
 // Convenience function for requesting a list of names of Keys from an input
 // spec.
 Teuchos::Array<Key>

--- a/src/utils/VerboseObject.cc
+++ b/src/utils/VerboseObject.cc
@@ -151,7 +151,7 @@ VerboseObject::getVerbLevelString() const
     level_str = "extreme";
     break;
   case Teuchos::VERB_DEFAULT:
-    level_str = "high";
+    level_str = "default";
     break;
   }
   return level_str;


### PR DESCRIPTION
Minor tweak, shouldn't break anything, but allows Evaluators to read Tags of their dependencies as well as the variable name.


For an example usage, we would like to explicitly lag the dependency of water density as a function of salinity concentration in a coupled flow and transport run.  Density at the new time (Tag::NEXT) is a function of TCC at the old time (Tag::CURRENT) in this situation.  This is currently not possible because the density eos_evaluator hard-codes that my_key_'s Tag is the same as all dependency Tags.  This allows the evaluator to read the parameter list to change that tag from the default.  Note that the required change to the input file is to write the tag in the input file of the EOS evaluator -- ideally an MPC would do this automatically.