### PR TITLE
cleans up a few names in writing checkpoint/vis files; stops use of pk name in tag

### DIFF
--- a/src/time_integration/BDF1_TI.hh
+++ b/src/time_integration/BDF1_TI.hh
@@ -212,7 +212,7 @@ BDF1_TI<Vector, VectorSpace>::BDF1_TI(BDFFnBase<Vector>& fn,
 
   // timestep controller
   TimestepControllerFactory<Vector> fac;
-  ts_control_ = fac.Create(plist, udot_, udot_prev_, S);
+  ts_control_ = fac.Create(plist_, udot_, udot_prev_, S);
 
   // misc internal parameters
   tol_solver_ = solver_->tolerance();

--- a/src/time_integration/SolutionHistory.hh
+++ b/src/time_integration/SolutionHistory.hh
@@ -170,7 +170,7 @@ SolutionHistory<Vector>::Initialize_(int mvec, const Vector& initvec)
 
     // require time deltas
     for (int j = 0; j < mvec; j++) {
-      S_->Require<Vector>(initvec.Map(), name_, Tag(std::to_string(j)), name_);
+      S_->Require<Vector>(initvec.Map(), "solution_history_" + name_, Tag(std::to_string(j)), name_);
       S_->SetPtr<Vector>(name_, Tag(std::to_string(j)), name_, d_[j]);
       S_->GetRecordW(name_, Tag(std::to_string(j)), name_).set_initialized();
       S_->GetRecordW(name_, Tag(std::to_string(j)), name_).set_io_checkpoint();

--- a/src/time_integration/SolutionHistory.hh
+++ b/src/time_integration/SolutionHistory.hh
@@ -170,11 +170,12 @@ SolutionHistory<Vector>::Initialize_(int mvec, const Vector& initvec)
 
     // require time deltas
     for (int j = 0; j < mvec; j++) {
-      S_->Require<Vector>(initvec.Map(), "solution_history_" + name_, Tag(std::to_string(j)), name_);
-      S_->SetPtr<Vector>(name_, Tag(std::to_string(j)), name_, d_[j]);
-      S_->GetRecordW(name_, Tag(std::to_string(j)), name_).set_initialized();
-      S_->GetRecordW(name_, Tag(std::to_string(j)), name_).set_io_checkpoint();
-      S_->GetRecordW(name_, Tag(std::to_string(j)), name_).set_io_vis(false);
+      std::string sh_name = name_ + "_solution_history";
+      S_->Require<Vector>(initvec.Map(), sh_name, Tag(std::to_string(j)), name_);
+      S_->SetPtr<Vector>(sh_name, Tag(std::to_string(j)), name_, d_[j]);
+      S_->GetRecordW(sh_name, Tag(std::to_string(j)), name_).set_initialized();
+      S_->GetRecordW(sh_name, Tag(std::to_string(j)), name_).set_io_checkpoint();
+      S_->GetRecordW(sh_name, Tag(std::to_string(j)), name_).set_io_vis(false);
     }
   }
 }
@@ -317,9 +318,10 @@ template <class Vector>
 void
 SolutionHistory<Vector>::MoveToState()
 {
+  std::string sh_name = name_ + "_solution_history";
   if (S_ != Teuchos::null) {
     for (int j = 0; j != d_.size(); ++j) {
-      S_->SetPtr<Vector>(name_, Tag(std::to_string(j)), name_, d_[j]);
+      S_->SetPtr<Vector>(sh_name, Tag(std::to_string(j)), name_, d_[j]);
     }
   }
 }

--- a/src/time_integration/TimestepControllerFactory.hh
+++ b/src/time_integration/TimestepControllerFactory.hh
@@ -99,7 +99,7 @@ TimestepControllerFactory<Vector>::Create(const Teuchos::ParameterList& slist,
       std::string name = "TimestepControllerSmarter";
       if (slist.isSublist("verbose object")) {
         if (slist.sublist("verbose object").isParameter("name")) {
-          name = slist.sublist("verbose object").get<std::string>("name");
+          name = Keys::cleanPListName(slist.sublist("verbose object").get<std::string>("name"));
         }
       }
       Teuchos::ParameterList tslist = slist.sublist("timestep controller smarter parameters");

--- a/src/time_integration/TimestepControllerSmarter.cc
+++ b/src/time_integration/TimestepControllerSmarter.cc
@@ -25,7 +25,7 @@ TimestepControllerSmarter::TimestepControllerSmarter(const std::string& name,
                                                      const Teuchos::RCP<State>& S)
   : TimestepController(plist),
     plist_(plist),
-    name_(name),
+    name_(Keys::cleanName(name)),
     count_increased_before_increase_(0),
     S_(S),
     successive_increases_(0),

--- a/src/utils/Key.cc
+++ b/src/utils/Key.cc
@@ -400,9 +400,9 @@ cleanPListName(const std::string& name)
   if (pos == name.size()) {
     return "";
   } else if (pos == std::string::npos) {
-    return name;
+    return cleanName(name);
   } else {
-    return name.substr(pos + 2, std::string::npos);
+    return cleanName(name.substr(pos + 2, std::string::npos));
   }
 }
 

--- a/src/utils/Key.cc
+++ b/src/utils/Key.cc
@@ -400,9 +400,9 @@ cleanPListName(const std::string& name)
   if (pos == name.size()) {
     return "";
   } else if (pos == std::string::npos) {
-    return cleanName(name);
+    return name;
   } else {
-    return cleanName(name.substr(pos + 2, std::string::npos));
+    return name.substr(pos + 2, std::string::npos);
   }
 }
 


### PR DESCRIPTION
Removing spaces from some names for checkpoint/vis, removes use of PK name as a tag, which is inconsistent with how tags are used everywhere else.