### PR TITLE
work to optimize use of View in mesh construction/caching

### DIFF
--- a/src/mesh/MeshCache_impl.hh
+++ b/src/mesh/MeshCache_impl.hh
@@ -1083,13 +1083,11 @@ MeshCache<MEM>::setNodeCoordinates(const cEntity_ID_View& nodes, const cPoint_Vi
       nodes_on_host = nodes;
       coords_on_host = new_coords;
     } else {
-      View_type<Entity_ID, MemSpace_kind::HOST> nc_nodes_on_host;
-      View_type<AmanziGeometry::Point, MemSpace_kind::HOST> nc_coords_on_host;
-      Kokkos::resize(nc_nodes_on_host, nodes.size());
+      View_type<Entity_ID, MemSpace_kind::HOST> nc_nodes_on_host("", nodes.size());
       Kokkos::deep_copy(nc_nodes_on_host, nodes);
       nodes_on_host = nc_nodes_on_host;
 
-      Kokkos::resize(nc_coords_on_host, nodes.size());
+      View_type<AmanziGeometry::Point, MemSpace_kind::HOST> nc_coords_on_host("", nodes.size());
       Kokkos::deep_copy(nc_coords_on_host, new_coords);
       coords_on_host = nc_coords_on_host;
     }
@@ -1495,11 +1493,10 @@ MeshCache<MEM>::cacheFaceGeometry()
   //     space_dim != manifold_dim and ncells == 2
   auto lambda2 = [&, this](const Entity_ID& f,
                            View_type<const Direction_type, MemSpace_kind::HOST>& dirs) {
-    Direction_View ldirs;
     // This NEEDS to call the framework or be passed an host mesh to call the function on the host.
     View_type<const Entity_ID, MemSpace_kind::HOST> fcells;
     framework_mesh_->getFaceCells(f, fcells);
-    Kokkos::resize(ldirs, fcells.size());
+    Direction_View ldirs("", fcells.size());
     for (int i = 0; i != fcells.size(); ++i) {
       if ((getSpaceDimension() == getManifoldDimension()) || (fcells.size() != 2)) {
         ldirs(i) = Impl::getFaceDirectionInCell(*this, f, fcells(i));

--- a/src/mesh/MeshInternals_impl.hh
+++ b/src/mesh/MeshInternals_impl.hh
@@ -275,11 +275,10 @@ computeFaceGeometry(const Mesh_type& mesh, const Entity_ID f)
     typename Mesh_type::cEntity_ID_View fcells;
     mesh.getFaceCells(f, fcells);
     typename Mesh_type::Point_View normals("normals", fcells.size());
-    Kokkos::deep_copy(normals, normal);
 
     for (int i = 0; i != fcells.size(); ++i) {
       int dir = Impl::getFaceDirectionInCell(mesh, f, fcells[i]);
-      normals[i] = dir * normals[i];
+      normals[i] = dir * normal;
     }
     return std::make_tuple(area, centroid, normals);
 
@@ -298,10 +297,9 @@ computeFaceGeometry(const Mesh_type& mesh, const Entity_ID f)
       typename Mesh_type::cEntity_ID_View fcells;
       mesh.getFaceCells(f, fcells);
       typename Mesh_type::Point_View normals("normals", fcells.size());
-      Kokkos::deep_copy(normals, normal);
       for (int i = 0; i != fcells.size(); ++i) {
         int dir = Impl::getFaceDirectionInCell(mesh, f, fcells[i]);
-        normals[i] = dir * normals[i];
+        normals[i] = dir * normal;
       }
       return std::make_tuple(area, centroid, normals);
 

--- a/src/mesh/MeshSets.cc
+++ b/src/mesh/MeshSets.cc
@@ -73,7 +73,6 @@ resolveMeshSetVolumeFractions(const AmanziGeometry::Region& region,
                               View_type<double, MemSpace_kind::HOST>& vol_fracs,
                               const MeshCache<MemSpace_kind::HOST>& mesh)
 {
-  Kokkos::resize(vol_fracs, 0);
   MeshCache<MemSpace_kind::HOST>::cEntity_ID_View ret_ents;
   auto ents_cpt = 0;
   auto vol_fracs_cpt = 0;
@@ -85,8 +84,8 @@ resolveMeshSetVolumeFractions(const AmanziGeometry::Region& region,
 
     if (kind == Entity_kind::CELL) {
       auto ncells = mesh.getNumEntities(Entity_kind::CELL, ptype);
-      Kokkos::resize(vol_fracs, ncells);
-      Kokkos::resize(ents, ncells);
+      Kokkos::realloc(vol_fracs, ncells);
+      Kokkos::realloc(ents, ncells);
 
       for (int c = 0; c != ncells; ++c) {
         auto polytope_nodes = mesh.getCellCoordinates(c);
@@ -126,8 +125,8 @@ resolveMeshSetVolumeFractions(const AmanziGeometry::Region& region,
     } else {
       // ind == FACE
       int nfaces = mesh.getNumEntities(Entity_kind::FACE, ptype);
-      Kokkos::resize(vol_fracs, nfaces);
-      Kokkos::resize(ents, nfaces);
+      Kokkos::realloc(vol_fracs, nfaces);
+      Kokkos::realloc(ents, nfaces);
 
       for (int f = 0; f != nfaces; ++f) {
         auto polygon = mesh.getFaceCoordinates(f);

--- a/src/mesh/SingleFaceMesh.hh
+++ b/src/mesh/SingleFaceMesh.hh
@@ -84,7 +84,7 @@ class SingleFaceMesh : public AmanziMesh::Mesh {
 
 
     // single surface cell
-    Kokkos::resize(fedges, nnodes_owned);
+    Kokkos::realloc(fedges, nnodes_owned);
     for (int i = 0; i < nnodes_owned; ++i) fedges[i] = i;
 
     data_.cell_faces.resize(1, nnodes_owned);

--- a/src/mesh/mesh_extracted/MeshExtractedManifold.cc
+++ b/src/mesh/mesh_extracted/MeshExtractedManifold.cc
@@ -324,8 +324,8 @@ MeshExtractedManifold::InitParentMaps(const std::string& setname)
     { Entity_kind::FACE, Entity_kind::EDGE, Entity_kind::NODE });
 
   for (int i = 0; i < 3; ++i) {
-    auto kind_d = kinds_extracted[i];
-    auto kind_p = kinds_parent[i];
+    Entity_kind kind_d = kinds_extracted[i];
+    Entity_kind kind_p = kinds_parent[i];
 
     // build edge set from Exodus labeled face set
     Entity_ID_View setents;
@@ -333,34 +333,34 @@ MeshExtractedManifold::InitParentMaps(const std::string& setname)
     if (setents.size() == 0) {
       auto [lsetents, lvfs] =
         parent_mesh_->getSetEntitiesAndVolumeFractions(setname, kind_p, Parallel_kind::ALL);
-      Kokkos::resize(setents, lsetents.size());
-      Kokkos::deep_copy(setents, lsetents);
+      Kokkos::realloc(setents, lsetents.size());
+      for (size_t k = 0; k != lsetents.size(); ++k) setents(k) = lsetents(k);
     }
 
-    auto marked_ents = EnforceOneLayerOfGhosts_(setname, kind_p, &setents);
+    std::map<Entity_ID, int> marked_ents = EnforceOneLayerOfGhosts_(setname, kind_p, &setents);
 
     // extract owned ids
-    auto& ids_p = entid_to_parent_[kind_d];
-    int ids_p_s = std::distance(marked_ents.begin(), marked_ents.end());
-    Kokkos::resize(ids_p, ids_p_s);
-    ids_p_s = 0;
-    for (auto it = marked_ents.begin(); it != marked_ents.end(); ++it) {
-      if (it->second == MASTER) ids_p[ids_p_s++] = it->first;
+    Entity_ID_View ids_p(std::string("parent ids: ")+to_string(kind_d), marked_ents.size());
+
+    std::size_t ids_p_s = 0;
+    for (auto& it : marked_ents) {
+      if (it.second == MASTER) ids_p[ids_p_s++] = it.first;
     }
 
     nents_owned_[kind_d] = ids_p_s;
     nents_ghost_[kind_d] = marked_ents.size() - ids_p_s;
 
     // extract ghost ids
-    for (auto it = marked_ents.begin(); it != marked_ents.end(); ++it) {
-      if (it->second == GHOST) ids_p[ids_p_s++] = it->first;
+    for (auto& it : marked_ents) {
+      if (it.second == GHOST) ids_p[ids_p_s++] = it.first;
     }
 
-    Kokkos::resize(ids_p, ids_p_s);
+    entid_to_parent_[kind_d] = ids_p;
+
     // create reverse ordered map
-    auto& ids_d = parent_to_entid_[kind_d];
+    std::map<Entity_ID, Entity_ID>& ids_d = parent_to_entid_[kind_d];
     ids_d.clear();
-    for (int n = 0; n < ids_p.size(); ++n) { ids_d[ids_p[n]] = n; }
+    for (std::size_t n = 0; n != ids_p.size(); ++n) { ids_d[ids_p[n]] = n; }
   }
 }
 

--- a/src/mesh/mesh_logical/MeshLogical.cc
+++ b/src/mesh/mesh_logical/MeshLogical.cc
@@ -130,9 +130,9 @@ MeshLogical::MeshLogical(const Comm_ptr_type& comm,
   }
 
   // geometric info that must get set later
-  Kokkos::resize(cell_volumes_, num_cells);
+  Kokkos::realloc(cell_volumes_, num_cells);
   Kokkos::deep_copy(cell_volumes_, -1.);
-  Kokkos::resize(face_areas_, face_cell_ids_.size<MemSpace_kind::HOST>());
+  Kokkos::realloc(face_areas_, face_cell_ids_.size<MemSpace_kind::HOST>());
   Kokkos::deep_copy(face_areas_, -1.);
 
   std::vector<Entity_ID_List> cell_face_ids_v(num_cells);

--- a/src/mesh/mesh_mstk/Mesh_MSTK.cc
+++ b/src/mesh/mesh_mstk/Mesh_MSTK.cc
@@ -493,16 +493,16 @@ Mesh_MSTK::getCellFacesAndDirs_ordered_(
     Cell_kind celltype = getCellType(cellid);
     if (celltype == Cell_kind::TET || celltype == Cell_kind::PRISM ||
         celltype == Cell_kind::PYRAMID || celltype == Cell_kind::HEX) {
-      Entity_ID_View lfaceids;
-      Direction_View lface_dirs;
+
       int lid, nf;
       MEntity_ptr cell = cell_id_to_handle_[cellid];
 
       List_ptr rfaces = MR_Faces((MRegion_ptr)cell);
       nf = List_Num_Entries(rfaces);
 
-      Kokkos::resize(lfaceids, nf);
-      if (face_dirs) Kokkos::resize(lface_dirs, nf);
+      Entity_ID_View lfaceids("", nf);
+      Direction_View lface_dirs;
+      if (face_dirs) Kokkos::realloc(lface_dirs, nf);
 
       /* base face */
       MFace_ptr face0 = nullptr;
@@ -604,8 +604,8 @@ Mesh_MSTK::getCellFacesAndDirs_ordered_(
       MSTK_FreeMarker(mkid);
       List_Delete(rfaces);
 
-      faceids = lfaceids;
-      if (face_dirs) *face_dirs = lface_dirs;
+      faceids = std::move(lfaceids);
+      if (face_dirs) *face_dirs = std::move(lface_dirs);
 
     } else {
       getCellFacesAndDirs_unordered_(cellid, faceids, face_dirs);
@@ -631,7 +631,7 @@ Mesh_MSTK::getCellFacesAndDirs_unordered_(
     List_ptr rfaces;
     rfaces = MR_Faces((MRegion_ptr)cell);
     nrf = List_Num_Entries(rfaces);
-    Kokkos::resize(lfaceids, nrf);
+    Kokkos::realloc(lfaceids, nrf);
 
     for (int i = 0; i < nrf; ++i) {
       MFace_ptr face = List_Entry(rfaces, i);
@@ -654,12 +654,12 @@ Mesh_MSTK::getCellFacesAndDirs_unordered_(
     */
 
     if (face_dirs) {
-      Kokkos::resize(lface_dirs, nrf);
+      Kokkos::realloc(lface_dirs, nrf);
       for (int i = 0; i < nrf; ++i) {
         int lid = lfaceids[i];
         int fdir = 2 * MR_FaceDir_i((MRegion_ptr)cell, i) - 1;
         fdir = faceflip_[lid] ? -fdir : fdir;
-        (lface_dirs)[i] = fdir; // assign to next spot by dereferencing iterator
+        lface_dirs[i] = fdir;
       }
     }
 
@@ -669,11 +669,11 @@ Mesh_MSTK::getCellFacesAndDirs_unordered_(
     fedges = MF_Edges((MFace_ptr)cell, 1, 0);
     nfe = List_Num_Entries(fedges);
 
-    Kokkos::resize(lfaceids, nfe);
+    Kokkos::realloc(lfaceids, nfe);
     for (int i = 0; i < nfe; ++i) {
       MEdge_ptr edge = List_Entry(fedges, i);
       int lid = MEnt_ID(edge);
-      lfaceids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      lfaceids[i] = lid - 1;
     }
 
     List_Delete(fedges);
@@ -692,17 +692,17 @@ Mesh_MSTK::getCellFacesAndDirs_unordered_(
     */
 
     if (face_dirs) {
-      Kokkos::resize(lface_dirs, nfe);
+      Kokkos::realloc(lface_dirs, nfe);
       for (int i = 0; i < nfe; ++i) {
         int lid = lfaceids[i];
         int fdir = 2 * MF_EdgeDir_i((MFace_ptr)cell, i) - 1;
         fdir = faceflip_[lid] ? -fdir : fdir;
-        (lface_dirs)[i] = fdir; // assign to next spot by dereferencing iterator
+        lface_dirs[i] = fdir;
       }
     }
   }
-  faceids = lfaceids;
-  if (face_dirs) *face_dirs = lface_dirs;
+  faceids = std::move(lfaceids);
+  if (face_dirs) *face_dirs = std::move(lface_dirs);
 }
 
 
@@ -736,12 +736,12 @@ Mesh_MSTK::getCellEdges(const Entity_ID cellid,
 
     redges = MR_Edges((MRegion_ptr)cell);
     nre = List_Num_Entries(redges);
-    Kokkos::resize(ledgeids, nre);
+    Kokkos::realloc(ledgeids, nre);
 
     for (int i = 0; i < nre; ++i) {
       MEdge_ptr edge = List_Entry(redges, i);
       int lid = MEnt_ID(edge);
-      ledgeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      ledgeids[i] = lid - 1;
     }
 
     List_Delete(redges);
@@ -765,12 +765,12 @@ Mesh_MSTK::getCellEdges(const Entity_ID cellid,
     fedges = MF_Edges((MFace_ptr)cell, 1, 0);
     nfe = List_Num_Entries(fedges);
 
-    Kokkos::resize(ledgeids, nfe);
+    Kokkos::realloc(ledgeids, nfe);
 
     for (int i = 0; i < nfe; ++i) {
       MEdge_ptr edge = List_Entry(fedges, i);
       int lid = MEnt_ID(edge);
-      ledgeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      ledgeids[i] = lid - 1;
     }
 
     List_Delete(fedges);
@@ -788,7 +788,7 @@ Mesh_MSTK::getCellEdges(const Entity_ID cellid,
     }
     */
   }
-  edgeids = ledgeids;
+  edgeids = std::move(ledgeids);
 }
 
 
@@ -815,24 +815,24 @@ Mesh_MSTK::getCellNodes(const Entity_ID cellid,
     List_ptr rverts = MR_Vertices(cell);
 
     nn = List_Num_Entries(rverts);
-    Kokkos::resize(lnodeids, nn);
+    Kokkos::realloc(lnodeids, nn);
     for (int i = 0; i < nn; ++i) {
       lid = MEnt_ID(List_Entry(rverts, i));
-      lnodeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      lnodeids[i] = lid - 1;
     }
     List_Delete(rverts);
 
   } else { // Surface mesh
     List_ptr fverts = MF_Vertices(cell, 1, 0);
     nn = List_Num_Entries(fverts);
-    Kokkos::resize(lnodeids, nn);
+    Kokkos::realloc(lnodeids, nn);
     for (int i = 0; i < nn; ++i) {
       lid = MEnt_ID(List_Entry(fverts, i));
-      lnodeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      lnodeids[i] = lid - 1;
     }
     List_Delete(fverts);
   }
-  nodeids = lnodeids;
+  nodeids = std::move(lnodeids);
 }
 
 
@@ -855,12 +855,12 @@ Mesh_MSTK::getFaceEdgesAndDirs(
 
     fedges = MF_Edges((MFace_ptr)face, 1, 0);
     nfe = List_Num_Entries(fedges);
-    Kokkos::resize(ledgeids, nfe);
+    Kokkos::realloc(ledgeids, nfe);
 
     for (int i = 0; i < nfe; ++i) {
       MEdge_ptr edge = List_Entry(fedges, i);
       int lid = MEnt_ID(edge);
-      ledgeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      ledgeids[i] = lid - 1;
     }
 
     List_Delete(fedges);
@@ -878,13 +878,13 @@ Mesh_MSTK::getFaceEdgesAndDirs(
     */
 
     if (edge_dirs) {
-      Kokkos::resize(ledge_dirs, nfe);
+      Kokkos::realloc(ledge_dirs, nfe);
 
       for (int i = 0; i < nfe; ++i) {
         int lid = ledgeids[i];
         int edir = 2 * MF_EdgeDir_i((MFace_ptr)face, i) - 1;
         edir = edgeflip_[lid] ? -edir : edir;
-        (ledge_dirs)[i] = edir; // assign to next spot by dereferencing iterator
+        ledge_dirs[i] = edir;
       }
     }
 
@@ -893,16 +893,16 @@ Mesh_MSTK::getFaceEdgesAndDirs(
     // direction of 1
     MEdge_ptr edge = (MEdge_ptr)face;
 
-    Kokkos::resize(ledgeids, 1);
+    Kokkos::realloc(ledgeids, 1);
     ledgeids[0] = MEnt_ID(edge) - 1;
 
     if (edge_dirs) {
-      Kokkos::resize(ledge_dirs, 1);
+      Kokkos::realloc(ledge_dirs, 1);
       (ledge_dirs)[0] = 1;
     }
   }
-  edgeids = ledgeids;
-  if (edge_dirs) *edge_dirs = ledge_dirs;
+  edgeids = std::move(ledgeids);
+  if (edge_dirs) *edge_dirs = std::move(ledge_dirs);
 }
 
 
@@ -930,17 +930,17 @@ Mesh_MSTK::getFaceNodes(const Entity_ID faceid,
     AMANZI_ASSERT(fverts != nullptr);
 
     nn = List_Num_Entries(fverts);
-    Kokkos::resize(lnodeids, nn);
+    Kokkos::realloc(lnodeids, nn);
 
     for (int i = 0; i < nn; ++i) {
       lid = MEnt_ID(List_Entry(fverts, i));
-      lnodeids[i] = lid - 1; // assign to next spot by dereferencing iterator
+      lnodeids[i] = lid - 1;
     }
 
     List_Delete(fverts);
 
   } else { // Surface mesh or 2D mesh
-    Kokkos::resize(lnodeids, 2);
+    Kokkos::realloc(lnodeids, 2);
     if (faceflip_[faceid]) {
       lnodeids[0] = MEnt_ID(ME_Vertex(genface, 1)) - 1;
       lnodeids[1] = MEnt_ID(ME_Vertex(genface, 0)) - 1;
@@ -949,7 +949,7 @@ Mesh_MSTK::getFaceNodes(const Entity_ID faceid,
       lnodeids[1] = MEnt_ID(ME_Vertex(genface, 1)) - 1;
     }
   }
-  nodeids = lnodeids;
+  nodeids = std::move(lnodeids);
 }
 
 
@@ -960,10 +960,10 @@ void
 Mesh_MSTK::getEdgeNodes(const Entity_ID edgeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& nodes) const
 {
-  Entity_ID_View lnodes;
+  Entity_ID_View lnodes("", 2);
   AMANZI_ASSERT(edges_initialized_);
   MEdge_ptr edge = (MEdge_ptr)edge_id_to_handle_[edgeid];
-  Kokkos::resize(lnodes, 2);
+
   if (edgeflip_[edgeid]) {
     lnodes[0] = MEnt_ID(ME_Vertex(edge, 1)) - 1;
     lnodes[1] = MEnt_ID(ME_Vertex(edge, 0)) - 1;
@@ -984,7 +984,6 @@ void
 Mesh_MSTK::getNodeCells(const Entity_ID nodeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& cellids) const
 {
-  Entity_ID_View lcellids;
   int idx, lid, nc;
   List_ptr cell_list;
   MEntity_ptr ment;
@@ -1029,7 +1028,8 @@ Mesh_MSTK::getNodeCells(const Entity_ID nodeid,
     cell_list = MV_Faces(mv);
 
   nc = List_Num_Entries(cell_list);
-  Kokkos::resize(lcellids, nc); // resize to maximum size possible
+
+  Entity_ID_View lcellids("", nc);
 
   int n = 0;
   idx = 0;
@@ -1042,9 +1042,8 @@ Mesh_MSTK::getNodeCells(const Entity_ID nodeid,
       lcellids[n++] = lid - 1;
     }
   }
-  Kokkos::resize(lcellids, n); // resize to the actual number of cells being returned
   List_Delete(cell_list);
-  cellids = lcellids;
+  cellids = Kokkos::subview(lcellids, Kokkos::pair{0,n});
 }
 
 
@@ -1057,7 +1056,6 @@ void
 Mesh_MSTK::getNodeFaces(const Entity_ID nodeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& faceids) const
 {
-  Entity_ID_View lfaceids;
   int idx, lid, n;
   List_ptr face_list;
   MEntity_ptr ment;
@@ -1103,7 +1101,7 @@ Mesh_MSTK::getNodeFaces(const Entity_ID nodeid,
     face_list = MV_Edges(mv);
 
   int nf = List_Num_Entries(face_list);
-  Kokkos::resize(lfaceids, nf); // resize to the maximum
+  Entity_ID_View lfaceids("", nf); // size to the maximum
   idx = 0;
   n = 0;
   while ((ment = List_Next_Entry(face_list, &idx))) {
@@ -1115,8 +1113,7 @@ Mesh_MSTK::getNodeFaces(const Entity_ID nodeid,
       lfaceids[n++] = lid - 1;
     }
   }
-  Kokkos::resize(lfaceids, n); // resize to the actual number of faces being returned
-  faceids = lfaceids;
+  faceids = Kokkos::subview(lfaceids, Kokkos::pair{0,n});
   List_Delete(face_list);
 }
 
@@ -1128,7 +1125,6 @@ void
 Mesh_MSTK::getNodeEdges(const Entity_ID nodeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& edgeids) const
 {
-  Entity_ID_View ledgeids;
   int idx, lid, nc;
   List_ptr edge_list;
   MEntity_ptr ment;
@@ -1141,7 +1137,7 @@ Mesh_MSTK::getNodeEdges(const Entity_ID nodeid,
   edge_list = MV_Edges(mv);
   nc = List_Num_Entries(edge_list);
 
-  Kokkos::resize(ledgeids, nc); // resize to maximum size possible
+  Entity_ID_View ledgeids("", nc);
 
   int n = 0;
   idx = 0;
@@ -1154,8 +1150,7 @@ Mesh_MSTK::getNodeEdges(const Entity_ID nodeid,
       ledgeids[n++] = lid - 1;
     }
   }
-  Kokkos::resize(ledgeids, n); // resize to the actual number of cells being returned
-  edgeids = ledgeids;
+  edgeids = Kokkos::subview(ledgeids, Kokkos::pair{0,n});
   List_Delete(edge_list);
 }
 
@@ -1167,7 +1162,6 @@ void
 Mesh_MSTK::getEdgeFaces(const Entity_ID edgeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& faceids) const
 {
-  Entity_ID_View lfaceids;
   int idx, lid, nc;
   List_ptr face_list;
   MEntity_ptr ment;
@@ -1178,7 +1172,7 @@ Mesh_MSTK::getEdgeFaces(const Entity_ID edgeid,
   face_list = ME_Faces(me);
 
   nc = List_Num_Entries(face_list);
-  Kokkos::resize(lfaceids, nc); // resize to maximum size possible
+  Entity_ID_View lfaceids("", nc);
 
   int n = 0;
   idx = 0;
@@ -1191,8 +1185,7 @@ Mesh_MSTK::getEdgeFaces(const Entity_ID edgeid,
       lfaceids[n++] = lid - 1;
     }
   }
-  Kokkos::resize(lfaceids, n); // resize to the actual number of cells being returned
-  faceids = lfaceids;
+  faceids = Kokkos::subview(lfaceids, Kokkos::pair{0,n});
   List_Delete(face_list);
 }
 
@@ -1206,7 +1199,6 @@ void
 Mesh_MSTK::getEdgeCells(const Entity_ID edgeid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& cellids) const
 {
-  Entity_ID_View lcellids;
   MEdge_ptr me = (MEdge_ptr)edge_id_to_handle_[edgeid];
 
   // mesh edge on a processor boundary may be connected to owned
@@ -1219,7 +1211,7 @@ Mesh_MSTK::getEdgeCells(const Entity_ID edgeid,
     cell_list = ME_Faces(me);
 
   int nc = List_Num_Entries(cell_list);
-  Kokkos::resize(lcellids, nc); // resize to maximum size possible
+  Entity_ID_View lcellids("", nc);
 
   int n = 0;
   int idx = 0;
@@ -1233,8 +1225,7 @@ Mesh_MSTK::getEdgeCells(const Entity_ID edgeid,
       lcellids[n++] = lid - 1;
     }
   }
-  Kokkos::resize(lcellids, n); // resize to the actual number of cells being returned
-  cellids = lcellids;
+  cellids = Kokkos::subview(lcellids, Kokkos::pair{0,n});
   List_Delete(cell_list);
 }
 
@@ -1247,27 +1238,34 @@ Mesh_MSTK::getFaceCells(const Entity_ID faceid,
                         View_type<const Entity_ID, MemSpace_kind::HOST>& cellids) const
 {
   AMANZI_ASSERT(faces_initialized_);
-  Entity_ID_List vcellids;
+  View_type<Entity_ID, MemSpace_kind::HOST> lcellids;
+
 
   if (getManifoldDimension() == 3) {
     MFace_ptr mf = (MFace_ptr)face_id_to_handle_[faceid];
 
     List_ptr fregs = MF_Regions(mf);
+    Kokkos::realloc(lcellids, List_Num_Entries(fregs));
+
     MRegion_ptr mr;
     int idx = 0;
-    while ((mr = List_Next_Entry(fregs, &idx))) vcellids.push_back(MR_ID(mr) - 1);
+    int n = 0;
+    while ((mr = List_Next_Entry(fregs, &idx))) lcellids[n++] = MR_ID(mr) - 1;
     List_Delete(fregs);
 
   } else {
     MEdge_ptr me = (MEdge_ptr)face_id_to_handle_[faceid];
 
     List_ptr efaces = ME_Faces(me);
+    Kokkos::realloc(lcellids, List_Num_Entries(efaces));
+
     MFace_ptr mf;
     int idx = 0;
-    while ((mf = List_Next_Entry(efaces, &idx))) vcellids.push_back(MF_ID(mf) - 1);
+    int n = 0;
+    while ((mf = List_Next_Entry(efaces, &idx))) lcellids[n++] = MF_ID(mf) - 1;
     List_Delete(efaces);
   }
-  vectorToConstView(cellids, vcellids);
+  cellids = std::move(lcellids);
 }
 
 
@@ -1958,7 +1956,6 @@ Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
                           const Parallel_kind ptype,
                           View_type<const Entity_ID, MemSpace_kind::HOST>& entids) const
 {
-  Entity_ID_View lentids;
   if (kind > createEntityKind(region.entity_str())) {
     Errors::Message msg;
     msg << "Inconsistent request of labeled set for region \"" << region.get_name()
@@ -2019,7 +2016,7 @@ Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
     }
 
     int nent_loc = MSet_Num_Entries(mset);
-    Kokkos::resize(lentids, nent_loc);
+    Entity_ID_View lentids("", nent_loc);
 
     if (nent_loc) {
       nent_loc = 0; // reset and count to get the real number
@@ -2034,6 +2031,7 @@ Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
             ++nent_loc;
           }
         }
+        Kokkos::resize(lentids, nent_loc);
         break;
       case Parallel_kind::GHOST:
         idx = 0;
@@ -2043,6 +2041,7 @@ Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
             ++nent_loc;
           }
         }
+        Kokkos::resize(lentids, nent_loc);
         break;
       case Parallel_kind::ALL:
         idx = 0;
@@ -2051,13 +2050,11 @@ Mesh_MSTK::getSetEntities(const AmanziGeometry::RegionLabeledSet& region,
           ++nent_loc;
         }
         break;
-      default: {
+      default: {}
       }
-      }
-      Kokkos::resize(lentids, nent_loc);
     }
+    entids = std::move(lentids);
   }
-  entids = lentids;
 }
 
 

--- a/src/operators/PDE_DiffusionFVonManifolds.hh
+++ b/src/operators/PDE_DiffusionFVonManifolds.hh
@@ -36,12 +36,14 @@ namespace Operators {
 
 class BCs;
 
-class PDE_DiffusionFVonManifolds : public virtual PDE_Diffusion, public PDE_DiffusionWithGravity {
+class PDE_DiffusionFVonManifolds : public PDE_DiffusionWithGravity {
  public:
   PDE_DiffusionFVonManifolds(Teuchos::ParameterList& plist,
                              const Teuchos::RCP<Operator>& global_op,
                              bool flag)
-    : PDE_Diffusion(global_op), PDE_DiffusionWithGravity(global_op), beta_initialized_(false)
+    : PDE_DiffusionWithGravity(global_op),
+      PDE_Diffusion(global_op),
+      beta_initialized_(false)
   {
     pde_type_ = PDE_DIFFUSION_FV_MANIFOLDS;
     Init_(plist);
@@ -49,7 +51,9 @@ class PDE_DiffusionFVonManifolds : public virtual PDE_Diffusion, public PDE_Diff
 
   PDE_DiffusionFVonManifolds(Teuchos::ParameterList& plist,
                              const Teuchos::RCP<const AmanziMesh::Mesh>& mesh)
-    : PDE_Diffusion(mesh), PDE_DiffusionWithGravity(mesh), beta_initialized_(false)
+    : PDE_DiffusionWithGravity(mesh),
+      PDE_Diffusion(mesh),
+      beta_initialized_(false)
   {
     pde_type_ = PDE_DIFFUSION_FV_MANIFOLDS;
     Init_(plist);

--- a/src/operators/test/operator_diffusion_dfn_fv.cc
+++ b/src/operators/test/operator_diffusion_dfn_fv.cc
@@ -149,6 +149,8 @@ RunTest(int icase, double gravity, int nx = 10, double tol = 1e-12)
       (*K)[c](0,0) = ana->ScalarDiffusivity(xc, 0.0);
     }
     op->SetTensorCoefficient(K);
+    op->SetDensity(0.);
+    op->SetGravity(gvec);
   } else if (icase == 3) {
     auto k = Teuchos::rcp(new CompositeVector(*cvs2));
     auto& k_f = *k->ViewComponent("face");
@@ -162,6 +164,8 @@ RunTest(int icase, double gravity, int nx = 10, double tol = 1e-12)
       for (int i = 0; i < ndofs; ++i) k_f[0][g + i] = ana->ScalarDiffusivity(xf, 0.0);
     }
     op->SetScalarCoefficient(k, Teuchos::null);
+    op->SetDensity(0.);
+    op->SetGravity(gvec);
   }
 
   // create optional source term

--- a/src/pks/PK_DomainFunctionSubgridReturn.hh
+++ b/src/pks/PK_DomainFunctionSubgridReturn.hh
@@ -178,7 +178,6 @@ PK_DomainFunctionSubgridReturn<FunctionBase>::Compute(double t0, double t1)
         val[k] *= ws_[0][*c] * phi_[0][*c] * mol_dens_[0][*c] / ncells_sg;
       }
       value_[*c] = val;
-      if (*c == 0) std::cout << "Computed return src term with val = " << val[0] << std::endl;
     }
   }
 }


### PR DESCRIPTION
- removes many Kokkos::resize() in favor of Kokkos::realloc(), which is significantly faster if you don't need to keep the old data
- avoids deep_copyies on host when a loop would suffice
- avoids deep_copies when subviews would suffice
- tries to take advantage of move semantics in View::operator=.  Not sure if this is significant, but since a move operator= is defined, we should use it where possible.