### PR TITLE
Work around a failing block in the preconditioner for multiphase PK

### DIFF
--- a/src/mpc/test/mpc_multiphase_fractures.cc
+++ b/src/mpc/test/mpc_multiphase_fractures.cc
@@ -51,8 +51,9 @@ TEST(MPC_DRIVER_MULTIPHASE_FRACTURES)
   mesh_list->set<bool>("request faces", true);
   MeshFactory factory(comm, gm, mesh_list);
   factory.set_preference(Preference({ Framework::MSTK }));
+  // auto mesh3D = factory.create(0.0, 0.0, 0.0, 200.0, 12.0, 60.0, 50, 1, 20);
   auto mesh3D = factory.create(0.0, 0.0, 0.0, 200.0, 12.0, 12.0, 50, 12, 12);
-  // auto mesh3D = factory.create(0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 4, 4, 4, true, true);
+
 
   std::vector<std::string> names;
   names.push_back("fractures");
@@ -63,6 +64,11 @@ TEST(MPC_DRIVER_MULTIPHASE_FRACTURES)
   Teuchos::ParameterList state_plist = plist->sublist("state");
   Teuchos::RCP<Amanzi::State> S = Teuchos::rcp(new Amanzi::State(state_plist));
   S->RegisterMesh("domain", mesh);
+
+  // work-around
+  // Key key("mass_density_gas");
+  // S->Require<CompositeVector, CompositeVectorSpace>(key, Tags::DEFAULT, key)
+  //   .SetMesh(mesh)->SetGhosted(true)->AddComponent("cell", AmanziMesh::CELL, 1);
 
   {
     Amanzi::CycleDriver cycle_driver(plist, S, comm, obs_data);

--- a/src/operators/PDE_AdvectionUpwindDFN.cc
+++ b/src/operators/PDE_AdvectionUpwindDFN.cc
@@ -87,7 +87,7 @@ PDE_AdvectionUpwindDFN::UpdateMatrices(const Teuchos::Ptr<const CompositeVector>
 
       for (int m = 0; m < nupwind; m++) {
         double v = upwind_flux_dfn_[f][m];
-        for (int j = 0; j < cells.size(); j++) {
+        for (int j = 0; j < ncells; j++) {
           if (cells[j] == c) {
             Aface(j, upwind_loc[m]) = (u / flux_in) * v;
             break;
@@ -95,6 +95,7 @@ PDE_AdvectionUpwindDFN::UpdateMatrices(const Teuchos::Ptr<const CompositeVector>
         }
       }
     }
+
     matrix[f] = Aface;
   }
 }
@@ -286,7 +287,7 @@ PDE_AdvectionUpwindDFN::IdentifyUpwindCells_(const CompositeVector& u)
       int ndofs = map->ElementSize(f);
       if (ndofs > 1) g += Operators::UniqueIndexFaceToCells(*mesh_, f, c);
 
-      double flux = u_f[0][g] * dirs[i]; // exterior flux
+      double flux = u_f[0][g] * dirs[i]; // exterior flux. Note that dirs could be negative
       if (flux >= 0.0) {
         upwind_cells_dfn_[f].push_back(c);
         upwind_flux_dfn_[f].push_back(flux);

--- a/src/operators/PDE_DiffusionFVonManifolds.cc
+++ b/src/operators/PDE_DiffusionFVonManifolds.cc
@@ -312,7 +312,7 @@ PDE_DiffusionFVonManifolds::UpdateFlux(const Teuchos::Ptr<const CompositeVector>
       if (sum > 0.0) pf /= sum;
 
       for (int i = 0; i < ndofs; ++i) {
-        const auto& normal = mesh_->getFaceNormal(f, cells[i], &dir);
+        mesh_->getFaceNormal(f, cells[i], &dir);
         flux[0][g + i] = -ti(i) * (pf - pi(i)) * dir;
       }
     }

--- a/src/operators/UpwindFluxManifolds.cc
+++ b/src/operators/UpwindFluxManifolds.cc
@@ -19,7 +19,6 @@
 #include "Teuchos_RCP.hpp"
 
 // Operators
-#include "UniqueLocalIndex.hh"
 #include "UpwindFluxManifolds.hh"
 
 namespace Amanzi {
@@ -74,28 +73,37 @@ UpwindFluxManifolds::Compute(const CompositeVector& flux,
     // volume-weigthed average over downwind cells
     if (ncells > 1) {
       int dir;
-      double utvol(0.0), umean(0.0), dtvol(0.0), dmean(0.0), vol;
+      double uvol(0.0), umean(0.0), tvol(0.0), tmean(0.0), vol;
 
       for (int i = 0; i < ncells; ++i) {
         int c = cells[i];
         mesh_->getFaceNormal(f, c, &dir);
         vol = mesh_->getCellVolume(c);
 
-        if (flux_f[0][g + i] * dir > tol) {
-          utvol += vol;
+        tvol += vol;
+        tmean += vol * field_c[0][c];
+
+        if (flux_f[0][g + i] * dir >= tol) {
+          uvol += vol;
           umean += vol * field_c[0][c];
-        } else {
-          dtvol += vol;
-          dmean += vol * field_c[0][c];
         }
       }
 
-      if (utvol > 0.0) {
-        umean /= utvol;
-        for (int i = 0; i < ncells; ++i) field_f[0][g + i] = umean;
+      // average upwind cell values and use them for all downwind faces
+      if (uvol > 0.0) {
+        umean /= uvol;
+        for (int i = 0; i < ncells; ++i) {
+          int c = cells[i];
+          mesh_->getFaceNormal(f, c, &dir);
+          if (flux_f[0][g + i] * dir >= tol) 
+            field_f[0][g + i] = field_c[0][c];
+          else
+            field_f[0][g + i] = umean;
+        }
+      // flow is negligent, use average all cell values
       } else {
-        dmean /= dtvol;
-        for (int i = 0; i < ncells; ++i) field_f[0][g + i] = dmean;
+        tmean /= tvol;
+        for (int i = 0; i < ncells; ++i) field_f[0][g + i] = tmean;
       }
 
       // upwind only on inflow Dirichlet faces

--- a/src/pks/multiphase/Multiphase_PK.cc
+++ b/src/pks/multiphase/Multiphase_PK.cc
@@ -85,6 +85,8 @@ Multiphase_PK::Multiphase_PK(Teuchos::ParameterList& pk_tree,
   num_ns_itrs_ = 0;
   num_ls_itrs_ = 0;
 
+  special_pc_term_ = mp_list_->template get<bool>("special pc term", true);
+
   Teuchos::ParameterList vlist;
   vlist.sublist("verbose object") = mp_list_->sublist("verbose object");
   std::string ioname = "MultiphasePK" + ((domain_ != "domain") ? "-" + domain_ : "");

--- a/src/pks/multiphase/Multiphase_PK.hh
+++ b/src/pks/multiphase/Multiphase_PK.hh
@@ -297,6 +297,7 @@ class Multiphase_PK : public PK_PhysicalBDF {
   // miscaleneous
   AmanziGeometry::Point gravity_;
   double g_;
+  bool special_pc_term_;
 
  private:
   static RegisteredPKFactory<Multiphase_PK> reg_;

--- a/src/pks/multiphase/Multiphase_TI.cc
+++ b/src/pks/multiphase/Multiphase_TI.cc
@@ -412,13 +412,15 @@ Multiphase_PK::UpdatePreconditioner(double tp, Teuchos::RCP<const TreeVector> u,
 
         // populate advection operator. Note that upwind direction is based on
         // the Darcy flux, but flux value is based on derivatives of coefficients
-        auto pde1 = fac_adv_->Create(global_op);
-        const auto& flux = S_->Get<CompositeVector>(flux_names_[phase]);
-        pde1->Setup(flux);
+        if (special_pc_term_) {
+          auto pde1 = fac_adv_->Create(global_op);
+          const auto& flux = S_->Get<CompositeVector>(flux_names_[phase]);
+          pde1->Setup(flux);
 
-        pde1->SetBCs(op_bcs_[keyr], op_bcs_[keyr]);
-        pde1->UpdateMatrices(flux_acc.ptr(), [](double x) { return x; });
-        pde1->ApplyBCs(false, false, false);
+          pde1->SetBCs(op_bcs_[keyr], op_bcs_[keyr]);
+          pde1->UpdateMatrices(flux_acc.ptr(), [](double x) { return x; });
+          pde1->ApplyBCs(false, false, false);
+        }
       }
 
       // storage term


### PR DESCRIPTION
Added a temporary parameter to turn off the failing block. The default behavior is to use this block