### PR TITLE
fixes bug in how we download Trilinos -- use release not git

### DIFF
--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -512,7 +512,8 @@ set(Trilinos_VERSION ${Trilinos_VERSION_MAJOR}-${Trilinos_VERSION_MINOR}-${Trili
 set(Trilinos_URL_STRING     "https://github.com/trilinos/Trilinos/archive")
 set(Trilinos_ARCHIVE_FILE   trilinos-release-${Trilinos_VERSION}.tar.gz)
 set(Trilinos_SAVEAS_FILE    ${Trilinos_ARCHIVE_FILE})
-set(Trilinos_GIT_REPOSITORY "https://github.com/trilinos/Trilinos")
+set(Trilinos_MD5_SUM       79237697af4fc42eaaf70f23104a8e12)
+#set(Trilinos_GIT_REPOSITORY "https://github.com/trilinos/Trilinos")
 
 
 #

--- a/config/SuperBuild/include/Build_Trilinos.cmake
+++ b/config/SuperBuild/include/Build_Trilinos.cmake
@@ -336,8 +336,12 @@ ExternalProject_Add(${Trilinos_BUILD_TARGET}
                     TMP_DIR   ${Trilinos_tmp_dir}                     # Temporary files directory
                     STAMP_DIR ${Trilinos_stamp_dir}                   # Timestamp and log directory
                     # -- Download and URL definitions
-                    GIT_REPOSITORY ${Trilinos_GIT_REPOSITORY_TEMP}              
-                    GIT_TAG        ${Trilinos_GIT_TAG}      
+                    DOWNLOAD_DIR  ${TPL_DOWNLOAD_DIR}
+                    URL           ${Trilinos_URL}                # URL may be a web site OR a local file
+                    URL_MD5       ${Trilinos_MD5_SUM}            # md5sum of the archive file
+                    DOWNLOAD_NAME ${Trilinos_SAVEAS_FILE}        # file name to store (if not end of URL)
+                    #GIT_REPOSITORY ${Trilinos_GIT_REPOSITORY_TEMP}              
+                    #GIT_TAG        ${Trilinos_GIT_TAG}      
                     # -- Update (one way to skip this step is use null command)
                     UPDATE_COMMAND ""
                     # -- Patch


### PR DESCRIPTION
We used to need a specific hash of Trilinos -- currently we are using Trilinos 15.1.0.

When we stopped using the old hash, I must have missed that changing the version wasn't enough -- because we provided a GIT_REPOSITORY but not a GIT_HASH, we were likely getting the current master of Trilinos.

This changes Build_Trilinos to use the release version, not current master.