### PR TITLE
remove BUILD_ELM_ATS_API flag entirely from bootstrap

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -2029,7 +2029,6 @@ cmd_configure="${cmake_binary} \
     -DENABLE_OpenMP:BOOL=${openmp} \
     -DENABLE_AmanziPhysicsModule:BOOL=${amanzi_physics} \
     -DENABLE_ATSPhysicsModule:BOOL=${ats_physics} \
-    -DBUILD_ATS_ELM_API:BOOL=${elm_ats_api} \
     -DENABLE_DBC:BOOL=${dbc} \
     -DBUILD_SHARED_LIBS:BOOL=${shared} \
     -DCCSE_BL_SPACEDIM:INT=${spacedim} \


### PR DESCRIPTION
Removes BUILD_ELM_ATS_API flag from bootstrap following comment from @lipnikov on #848. 

(Apologies for the double PR - the one I had opened a few minutes ago had been from a stale branch).