### PR TITLE
Rework of PKs to split out parseParameterList, make SetEvaluator() call EnsureEvaluators()

### DIFF
--- a/src/mpc/CycleDriver.cc
+++ b/src/mpc/CycleDriver.cc
@@ -1055,8 +1055,9 @@ CycleDriver::ResetDriver(int time_pr_id)
   //if (observations_ != Teuchos::null) observations_->RegisterWithTimeStepManager(tsm_);
 
   // Setup
-  pk_->Setup();
   pk_->set_tags(Tags::CURRENT, Tags::NEXT);
+  pk_->parseParameterList();
+  pk_->Setup();
 
   S_->Require<double>("dt", Tags::NEXT, "dt");
   S_->Setup();

--- a/src/mpc/CycleDriver.cc
+++ b/src/mpc/CycleDriver.cc
@@ -228,6 +228,7 @@ CycleDriver::Setup()
     }
   }
 
+  pk_->parseParameterList();
   pk_->Setup();
   S_->Require<double>("dt", Tags::NEXT, "dt");
   S_->Setup();

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -36,11 +36,6 @@ include_directories(${ASCEMIO_INCLUDE_DIR})
 include_directories(${Epetra_INCLUDE_DIRS})
 include_directories(${HDF5_INCLUDE_DIRS})
 
-if(ENABLE_ATSPhysicsModule)
-  add_definitions(-DATS_DAG_POLICY)
-endif(ENABLE_ATSPhysicsModule)
-
-
 #
 # Library: pks
 #

--- a/src/pks/CMakeLists.txt
+++ b/src/pks/CMakeLists.txt
@@ -36,6 +36,11 @@ include_directories(${ASCEMIO_INCLUDE_DIR})
 include_directories(${Epetra_INCLUDE_DIRS})
 include_directories(${HDF5_INCLUDE_DIRS})
 
+if(ENABLE_ATSPhysicsModule)
+  add_definitions(-DATS_DAG_POLICY)
+endif(ENABLE_ATSPhysicsModule)
+
+
 #
 # Library: pks
 #

--- a/src/pks/PK.hh
+++ b/src/pks/PK.hh
@@ -127,6 +127,12 @@ class PK {
   // Virtual destructor
   virtual ~PK() = default;
 
+  // call to allow a PK to modify its own list or lists of its children.
+  virtual void modifyParameterList() {}
+
+  // read said list
+  virtual void parseParameterList() {}
+
   // Setup
   virtual void Setup() = 0;
 

--- a/src/pks/PK.hh
+++ b/src/pks/PK.hh
@@ -128,9 +128,6 @@ class PK {
   virtual ~PK() = default;
 
   // call to allow a PK to modify its own list or lists of its children.
-  virtual void modifyParameterList() {}
-
-  // read said list
   virtual void parseParameterList() {}
 
   // Setup

--- a/src/pks/PK_Physical.hh
+++ b/src/pks/PK_Physical.hh
@@ -38,7 +38,7 @@ class PK_Physical : virtual public PK {
               const Teuchos::RCP<TreeVector>& soln)
     : PK(pk_tree, glist, S, soln)
   {
-    domain_ = Keys::readDomain(*plist_);
+    domain_ = Keys::readDomain(*plist_, "domain", "domain");
     mesh_ = S_->GetMesh(domain_);
   };
 

--- a/src/pks/PK_Physical.hh
+++ b/src/pks/PK_Physical.hh
@@ -38,7 +38,7 @@ class PK_Physical : virtual public PK {
               const Teuchos::RCP<TreeVector>& soln)
     : PK(pk_tree, glist, S, soln)
   {
-    domain_ = plist_->get<std::string>("domain name", "domain");
+    domain_ = Keys::readDomain(*plist_);
     mesh_ = S_->GetMesh(domain_);
   };
 

--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -52,8 +52,12 @@ Alquimia_PK::Alquimia_PK(Teuchos::ParameterList& pk_tree,
     chem_initialized_(false),
     current_time_(0.0),
     saved_time_(0.0)
+{}
+
+void
+Alquimia_PK::parseParameterList()
 {
-  domain_ = plist_->get<std::string>("domain name", "domain");
+  Chemistry_PK::parseParameterList();
 
   // obtain key of fields
   tcc_key_ = Keys::readKey(

--- a/src/pks/chemistry/Alquimia_PK.hh
+++ b/src/pks/chemistry/Alquimia_PK.hh
@@ -79,12 +79,13 @@ class Alquimia_PK : public Chemistry_PK {
   ~Alquimia_PK();
 
   // members required by PK interface
-  virtual void Setup() final;
-  virtual void Initialize() final;
+  virtual void parseParameterList() override;
+  virtual void Setup() override final;
+  virtual void Initialize() override final;
 
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) final;
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag) final;
-  virtual void CalculateDiagnostics(const Tag& tag) final { extra_chemistry_output_data(); }
+  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) override final;
+  virtual void CommitStep(double t_old, double t_new, const Tag& tag) override final;
+  virtual void CalculateDiagnostics(const Tag& tag) override final { extra_chemistry_output_data(); }
 
   // Ben: the following routine provides the interface for
   // output of auxillary cellwise data from chemistry

--- a/src/pks/chemistry/Chemistry_PK.cc
+++ b/src/pks/chemistry/Chemistry_PK.cc
@@ -57,13 +57,20 @@ Chemistry_PK::Chemistry_PK(Teuchos::ParameterList& pk_tree,
     dt_max_(9.9e9){};
 
 
+void
+Chemistry_PK::parseParameterList()
+{
+  PK_Physical::parseParameterList();
+  saturation_tolerance_ = plist_->get<double>("saturation tolerance", 1e-14);
+}
+
+
 /* ******************************************************************
 * Register fields and evaluators with the State
 ******************************************************************* */
 void
 Chemistry_PK::Setup()
 {
-  saturation_tolerance_ = plist_->get<double>("saturation tolerance", 1e-14);
   bool amanzi_physics = plist_->isSublist("physical models and assumptions");
 
   // require flow fields

--- a/src/pks/chemistry/Chemistry_PK.hh
+++ b/src/pks/chemistry/Chemistry_PK.hh
@@ -95,6 +95,7 @@ class Chemistry_PK : public PK_Physical {
   virtual ~Chemistry_PK() = default;
 
   // required members for PK interface
+  virtual void parseParameterList() override;
   virtual void Setup() override;
   virtual void Initialize() override;
 

--- a/src/pks/chemistry/test/chemistry_alquimia_pk.cc
+++ b/src/pks/chemistry/test/chemistry_alquimia_pk.cc
@@ -191,6 +191,7 @@ TEST(INITIALIZE_CRUNCH)
   auto pks_list = plist->sublist("PK tree").sublist("chemistry");
   Teuchos::RCP<TreeVector> soln = Teuchos::rcp(new TreeVector());
   auto CPK = Teuchos::rcp(new Alquimia_PK(pks_list, plist, S, soln));
+  CPK->parseParameterList();
   CPK->Setup();
 
   S->Setup();
@@ -202,6 +203,7 @@ TEST(INITIALIZE_CRUNCH)
 
   // Now create second chemistry PK
   auto CPK2 = Teuchos::rcp(new Alquimia_PK(pks_list, plist, S, soln));
+  CPK2->parseParameterList();
   CPK2->Setup();
   CPK2->Initialize();
 }

--- a/src/pks/chemistry/test/chemistry_amanzi_pk.cc
+++ b/src/pks/chemistry/test/chemistry_amanzi_pk.cc
@@ -141,6 +141,7 @@ SUITE(GeochemistryTestsChemistryPK)
     // object correctly based on the xml input....
     try {
       cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
+      cpk_->parseParameterList();
       cpk_->Setup();
       state_->Setup();
       state_->InitializeFields();
@@ -159,6 +160,7 @@ SUITE(GeochemistryTestsChemistryPK)
   {
     try {
       cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
+      cpk_->parseParameterList();
       cpk_->Setup();
       state_->Setup();
       state_->InitializeFields();

--- a/src/pks/mpc_pk/EnergyMatrixFracture_PK.cc
+++ b/src/pks/mpc_pk/EnergyMatrixFracture_PK.cc
@@ -105,16 +105,6 @@ EnergyMatrixFracture_PK::Setup()
     AddDefaultPrimaryEvaluator(S_, "fracture-molar_flow_rate", Tags::DEFAULT);
   }
 
-  // additional fields and evaluators related to matrix-frcature coupling
-  if (!S_->HasRecord(heat_diffusion_to_matrix_key_)) {
-    S_->Require<CV_t, CVS_t>(
-        heat_diffusion_to_matrix_key_, Tags::DEFAULT, heat_diffusion_to_matrix_key_)
-      .SetMesh(mesh_fracture_)
-      ->SetGhosted(true)
-      ->SetComponent("cell", AmanziMesh::CELL, 2);
-    S_->RequireEvaluator(heat_diffusion_to_matrix_key_, Tags::DEFAULT);
-  }
-
   // inform dependent PKs about coupling
   std::vector<std::string> pks = plist_->get<Teuchos::Array<std::string>>("PKs order").toVector();
 
@@ -130,6 +120,16 @@ EnergyMatrixFracture_PK::Setup()
 
   // process other PKs.
   PK_MPCStrong<PK_BDF>::Setup();
+
+  // additional fields and evaluators related to matrix-frcature coupling
+  if (!S_->HasRecord(heat_diffusion_to_matrix_key_)) {
+    S_->Require<CV_t, CVS_t>(
+        heat_diffusion_to_matrix_key_, Tags::DEFAULT, heat_diffusion_to_matrix_key_)
+      .SetMesh(mesh_fracture_)
+      ->SetGhosted(true)
+      ->SetComponent("cell", AmanziMesh::CELL, 2);
+    S_->RequireEvaluator(heat_diffusion_to_matrix_key_, Tags::DEFAULT);
+  }
 }
 
 

--- a/src/state/CMakeLists.txt
+++ b/src/state/CMakeLists.txt
@@ -47,6 +47,10 @@ if(ENABLE_Silo)
   add_definitions(-DENABLE_Silo)
 endif(ENABLE_Silo)
 
+if(ENABLE_ATSPhysicsModule)
+  add_definitions(-DATS_DAG_POLICY)
+endif(ENABLE_ATSPhysicsModule)
+
 # This state library will move to a new location 
 # once Markus has created the data manager.
 # I use global properties since all the PROJECT_NAME

--- a/src/state/CMakeLists.txt
+++ b/src/state/CMakeLists.txt
@@ -47,10 +47,6 @@ if(ENABLE_Silo)
   add_definitions(-DENABLE_Silo)
 endif(ENABLE_Silo)
 
-if(ENABLE_ATSPhysicsModule)
-  add_definitions(-DATS_DAG_POLICY)
-endif(ENABLE_ATSPhysicsModule)
-
 # This state library will move to a new location 
 # once Markus has created the data manager.
 # I use global properties since all the PROJECT_NAME

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -533,6 +533,7 @@ State::Setup()
   // Note that the first pass may modify the graph, but since it is a DAG, and
   // this is called recursively, we can just call it on the nodes that appear
   // initially.
+#ifndef ATS_DAG_POLICY
   { // scope for copy
     EvaluatorMap evaluators_copy(evaluators_);
     for (auto& e : evaluators_copy) {
@@ -553,6 +554,7 @@ State::Setup()
       }
     }
   }
+#endif
 
   // Second pass calls EnsureCompatibility, which checks data consistency.
   // This pass does not modify the graph.
@@ -890,7 +892,9 @@ void
 State::SetEvaluator(const Key& key, const Tag& tag, const Teuchos::RCP<Evaluator>& evaluator)
 {
   evaluators_[key][tag] = evaluator;
+#ifdef ATS_DAG_POLICY
   evaluator->EnsureEvaluators(*this);
+#endif
 }
 
 

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -890,6 +890,7 @@ void
 State::SetEvaluator(const Key& key, const Tag& tag, const Teuchos::RCP<Evaluator>& evaluator)
 {
   evaluators_[key][tag] = evaluator;
+//  evaluator->EnsureEvaluators();
 }
 
 

--- a/src/state/State.cc
+++ b/src/state/State.cc
@@ -890,7 +890,7 @@ void
 State::SetEvaluator(const Key& key, const Tag& tag, const Teuchos::RCP<Evaluator>& evaluator)
 {
   evaluators_[key][tag] = evaluator;
-//  evaluator->EnsureEvaluators();
+  evaluator->EnsureEvaluators(*this);
 }
 
 

--- a/src/state/state_evaluators_registration.hh
+++ b/src/state/state_evaluators_registration.hh
@@ -20,6 +20,7 @@
 #include "EvaluatorIndependentConstant.hh"
 #include "EvaluatorMultiplicativeReciprocal.hh"
 #include "EvaluatorSecondaryMonotypeFromFunction.hh"
+#include "EvaluatorPrimary.hh"
 
 namespace Amanzi {
 
@@ -39,5 +40,9 @@ Utils::RegisteredFactory<Evaluator, EvaluatorMultiplicativeReciprocal>
 
 Utils::RegisteredFactory<Evaluator, EvaluatorSecondaryMonotypeFromFunction>
   EvaluatorSecondaryMonotypeFromFunction::fac_("secondary variable from function");
+
+template<>
+Utils::RegisteredFactory<Evaluator, EvaluatorPrimaryCV>
+  EvaluatorPrimaryCV::fac_("primary variable");
 
 } // namespace Amanzi

--- a/src/state/test/state_dag.cc
+++ b/src/state/test/state_dag.cc
@@ -274,48 +274,9 @@ class make_state {
   {
     Teuchos::ParameterList es_list, ep_list;
     es_list.sublist("verbose object").set<std::string>("verbosity level", "extreme");
-    ep_list.sublist("verbose object").set<std::string>("verbosity level", "extreme");
-
-    // Secondary fields
-    // --  A and its evaluator
-    es_list.setName("fa");
     es_list.set("tag", "");
-    S.Require<double>("fa", Tags::DEFAULT, "fa");
-    S.RequireDerivative<double>("fa", Tags::DEFAULT, "fb", Tags::DEFAULT);
-    S.RequireDerivative<double>("fa", Tags::DEFAULT, "fg", Tags::DEFAULT);
-    fa_eval = Teuchos::rcp(new AEvaluator(es_list));
-    S.SetEvaluator("fa", Tags::DEFAULT, fa_eval);
 
-    // --  C and its evaluator
-    es_list.setName("fc");
-    S.Require<double>("fc", Tags::DEFAULT, "fc");
-    fc_eval = Teuchos::rcp(new CEvaluator(es_list));
-    S.SetEvaluator("fc", Tags::DEFAULT, fc_eval);
-
-    // --  D and its evaluator
-    es_list.setName("fd");
-    S.Require<double>("fd", Tags::DEFAULT, "fd");
-    fd_eval = Teuchos::rcp(new DEvaluator(es_list));
-    S.SetEvaluator("fd", Tags::DEFAULT, fd_eval);
-
-    // --  E and its evaluator
-    es_list.setName("fe");
-    S.Require<double>("fe", Tags::DEFAULT, "fe");
-    S.RequireDerivative<double>("fe", Tags::DEFAULT, "fg", Tags::DEFAULT);
-    fe_eval = Teuchos::rcp(new EEvaluator(es_list));
-    S.SetEvaluator("fe", Tags::DEFAULT, fe_eval);
-
-    // --  F and its evaluator
-    es_list.setName("ff");
-    S.Require<double>("ff", Tags::DEFAULT, "ff");
-    ff_eval = Teuchos::rcp(new FEvaluator(es_list));
-    S.SetEvaluator("ff", Tags::DEFAULT, ff_eval);
-
-    // --  H and its evaluator
-    es_list.setName("fh");
-    S.Require<double>("fh", Tags::DEFAULT, "fh");
-    fh_eval = Teuchos::rcp(new HEvaluator(es_list));
-    S.SetEvaluator("fh", Tags::DEFAULT, fh_eval);
+    ep_list.sublist("verbose object").set<std::string>("verbosity level", "extreme");
 
     // Primary fields
     ep_list.setName("fb");
@@ -329,6 +290,46 @@ class make_state {
     S.Require<double>("fg", Tags::DEFAULT, "fg");
     fg_eval = Teuchos::rcp(new EvaluatorPrimary<double>(ep_list));
     S.SetEvaluator("fg", Tags::DEFAULT, fg_eval);
+
+    // Secondary fields
+    // --  F and its evaluator
+    es_list.setName("ff");
+    S.Require<double>("ff", Tags::DEFAULT, "ff");
+    ff_eval = Teuchos::rcp(new FEvaluator(es_list));
+    S.SetEvaluator("ff", Tags::DEFAULT, ff_eval);
+
+    // --  D and its evaluator
+    es_list.setName("fd");
+    S.Require<double>("fd", Tags::DEFAULT, "fd");
+    fd_eval = Teuchos::rcp(new DEvaluator(es_list));
+    S.SetEvaluator("fd", Tags::DEFAULT, fd_eval);
+
+    // --  H and its evaluator
+    es_list.setName("fh");
+    S.Require<double>("fh", Tags::DEFAULT, "fh");
+    fh_eval = Teuchos::rcp(new HEvaluator(es_list));
+    S.SetEvaluator("fh", Tags::DEFAULT, fh_eval);
+
+    // --  E and its evaluator
+    es_list.setName("fe");
+    S.Require<double>("fe", Tags::DEFAULT, "fe");
+    S.RequireDerivative<double>("fe", Tags::DEFAULT, "fg", Tags::DEFAULT);
+    fe_eval = Teuchos::rcp(new EEvaluator(es_list));
+    S.SetEvaluator("fe", Tags::DEFAULT, fe_eval);
+
+    // --  C and its evaluator
+    es_list.setName("fc");
+    S.Require<double>("fc", Tags::DEFAULT, "fc");
+    fc_eval = Teuchos::rcp(new CEvaluator(es_list));
+    S.SetEvaluator("fc", Tags::DEFAULT, fc_eval);
+
+    // --  A and its evaluator
+    es_list.setName("fa");
+    S.Require<double>("fa", Tags::DEFAULT, "fa");
+    S.RequireDerivative<double>("fa", Tags::DEFAULT, "fb", Tags::DEFAULT);
+    S.RequireDerivative<double>("fa", Tags::DEFAULT, "fg", Tags::DEFAULT);
+    fa_eval = Teuchos::rcp(new AEvaluator(es_list));
+    S.SetEvaluator("fa", Tags::DEFAULT, fa_eval);
 
     // Setup fields initialize
     S.Setup();


### PR DESCRIPTION
This creates another level of setup, called parseParameterList(), that occurs after PK construction but before Setup. Most ATS PKs constructor contents are now moved into parseParameterList(), and all PKs are modified to have them set their primary variables in this call. This allows the key advancement that calling State::SetEvaluator(key, tag, eval) (the function that is called inside of RequireEvaluator(...) after construction) can now call eval->EnsureEvaluators(). This means that the DAG is now valid as soon as the evaluator is set. This allows some important changes to the use of the dag, e.g. calling Evaluator::IsDifferentiableWRT() immediately after calling RequireEvaluator().

This closes #654  and is an important step toward #646