### PR TITLE
bump docker-login action version

### DIFF
--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         echo "TPLs version = ${{env.AMANZI_TPLS_VER}}"
     - name: Login to Docker Hub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{secrets.DOCKERHUB_USERNAME}}
         password: ${{secrets.DOCKERHUB_PASSWORD}}


### PR DESCRIPTION
docker-login action v2 is issuing warnings about
node.js deprecation. bumping to v3 to remove warning