### PR TITLE
Fixes bug in FV discretization

### DIFF
--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -274,7 +274,7 @@ Teuchos::RCP<const Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
   if (name == "boundary_face") {
-    if (!HasComponent("boundary_face") && HasComponent("face")) {
+    if (HasComponent("face")) {
       ApplyVandelay_();
       return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;
     }
@@ -292,7 +292,7 @@ Teuchos::RCP<Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted)
 {
   if (name == "boundary_face") {
-    if (!HasComponent("boundary_face") && HasComponent("face")) {
+    if (HasComponent("face")) {
       ApplyVandelay_();
       ChangedValue("face");
       return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;

--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -274,7 +274,7 @@ Teuchos::RCP<const Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
   if (name == "boundary_face") {
-    if (HasComponent("face")) {
+    if (!HasComponent("boundary_face") && HasComponent("face")) {
       ApplyVandelay_();
       return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;
     }
@@ -292,7 +292,7 @@ Teuchos::RCP<Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted)
 {
   if (name == "boundary_face") {
-    if (HasComponent("face")) {
+    if (!HasComponent("boundary_face") && HasComponent("face")) {
       ApplyVandelay_();
       ChangedValue("face");
       return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;

--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -245,7 +245,7 @@ CompositeVector::operator=(const CompositeVector& other)
       // If both are ghosted, copy the ghosted vector.
       // Exception: boundary_face component created on a fly is not ghosted
       for (name_iterator name = begin(); name != end(); ++name) {
-        bool ghosted = (*name == "boundary_face" && other.HasComponent("face")) ? false : true;
+        bool ghosted = (*name == "boundary_face" && other.ProvidesComponent("face")) ? false : true;
         Teuchos::RCP<Epetra_MultiVector> comp = ViewComponent(*name, ghosted);
         Teuchos::RCP<const Epetra_MultiVector> othercomp = other.ViewComponent(*name, ghosted);
         *comp = *othercomp;
@@ -273,6 +273,7 @@ CompositeVector::operator=(const CompositeVector& other)
 Teuchos::RCP<const Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
+  AMANZI_ASSERT(ProvidesComponent(name));
   if (name == "boundary_face") {
     if (!HasComponent("boundary_face") && HasComponent("face")) {
       ApplyVandelay_();
@@ -291,14 +292,7 @@ CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 Teuchos::RCP<Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted)
 {
-  if (name == "boundary_face") {
-    if (!HasComponent("boundary_face") && HasComponent("face")) {
-      ApplyVandelay_();
-      ChangedValue("face");
-      return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;
-    }
-  }
-
+  AMANZI_ASSERT(HasComponent(name));
   ChangedValue(name);
   if (ghosted) {
     return ghostvec_->ViewComponent(name);
@@ -501,7 +495,7 @@ CompositeVector::Dot(const CompositeVector& other, double* result) const
 {
   double tmp_result = 0.0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (other.HasComponent(*lcv)) {
+    if (other.ProvidesComponent(*lcv)) {
       std::vector<double> intermediate_result(ViewComponent(*lcv, false)->NumVectors(), 0.0);
       int ierr =
         ViewComponent(*lcv, false)->Dot(*other.ViewComponent(*lcv, false), &intermediate_result[0]);
@@ -524,7 +518,7 @@ CompositeVector::Update(double scalarA, const CompositeVector& A, double scalarT
   //  AMANZI_ASSERT(map_->SubsetOf(*A.map_));
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv))
       ViewComponent(*lcv, false)->Update(scalarA, *A.ViewComponent(*lcv, false), scalarThis);
   }
   return *this;
@@ -539,11 +533,9 @@ CompositeVector::Update(double scalarA,
                         const CompositeVector& B,
                         double scalarThis)
 {
-  //  AMANZI_ASSERT(map_->SubsetOf(*A.map_));
-  //  AMANZI_ASSERT(map_->SubsetOf(*B.map_));
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ViewComponent(*lcv, false)
         ->Update(scalarA,
                  *A.ViewComponent(*lcv, false),
@@ -567,7 +559,7 @@ CompositeVector::Multiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->Multiply(
@@ -589,7 +581,7 @@ CompositeVector::ReciprocalMultiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->ReciprocalMultiply(

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -175,6 +175,7 @@ class CompositeVector {
   Comm_ptr_type Comm() const { return map_->Comm(); }
   Teuchos::RCP<const AmanziMesh::Mesh> Mesh() const { return map_->Mesh(); }
   bool HasComponent(const std::string& name) const { return map_->HasComponent(name); }
+  bool ProvidesComponent(const std::string& name) const { return map_->ProvidesComponent(name); }
   int NumComponents() const { return size(); }
   AmanziMesh::Entity_kind Location(const std::string& name) const { return map_->Location(name); }
 

--- a/src/data_structures/CompositeVectorSpace.hh
+++ b/src/data_structures/CompositeVectorSpace.hh
@@ -85,6 +85,10 @@ class CompositeVectorSpace {
   {
     return indexmap_.find(name) != indexmap_.end();
   }
+  bool ProvidesComponent(const std::string& name) const
+  {
+    return HasComponent(name) || (name == "boundary_face" && HasComponent("face"));
+  }
   int NumComponents() const { return size(); }
 
   // Each component has a number of Degrees of Freedom.

--- a/src/data_structures/CompositeVectorSpace.hh
+++ b/src/data_structures/CompositeVectorSpace.hh
@@ -83,8 +83,7 @@ class CompositeVectorSpace {
 
   bool HasComponent(const std::string& name) const
   {
-    return indexmap_.find(name) != indexmap_.end() ||
-      (name == "boundary_face" && HasComponent("face"));
+    return indexmap_.find(name) != indexmap_.end();
   }
   int NumComponents() const { return size(); }
 

--- a/src/data_structures/CompositeVectorSpace.hh
+++ b/src/data_structures/CompositeVectorSpace.hh
@@ -83,7 +83,8 @@ class CompositeVectorSpace {
 
   bool HasComponent(const std::string& name) const
   {
-    return indexmap_.find(name) != indexmap_.end();
+    return indexmap_.find(name) != indexmap_.end() ||
+      (name == "boundary_face" && HasComponent("face"));
   }
   int NumComponents() const { return size(); }
 

--- a/src/data_structures/test/data_structures_vandelay.cc
+++ b/src/data_structures/test/data_structures_vandelay.cc
@@ -93,7 +93,7 @@ SUITE(VANDELAY_COMPOSITE_VECTOR)
     CHECK_CLOSE((*x)("cell", 1, 0), 2.0, 0.00001);
     CHECK_CLOSE((*x)("face", 0, 0), 2.0, 0.00001);
 
-    *x2->ViewComponent("boundary_face", false) = *x->ViewComponent("boundary_face", false);
+    *x2->ViewComponent("boundary_face", false) = *std::as_const(*x).ViewComponent("boundary_face", false);
     CHECK_CLOSE((*x2)("boundary_face", 0, 0), 2.0, 0.00001);
   }
 
@@ -106,7 +106,7 @@ SUITE(VANDELAY_COMPOSITE_VECTOR)
     CHECK_CLOSE((*x)("cell", 1, 0), 2.0, 0.00001);
     CHECK_CLOSE((*x)("face", 0, 0), 2.0, 0.00001);
 
-    *x2->ViewComponent("boundary_face", false) = *x->ViewComponent("boundary_face", false);
+    *x2->ViewComponent("boundary_face", false) = *std::as_const(*x).ViewComponent("boundary_face", false);
 
     // test the scatter of boundary_faces
     x2->ScatterMasterToGhosted("boundary_face");

--- a/src/operators/Operator.cc
+++ b/src/operators/Operator.cc
@@ -303,9 +303,11 @@ Operator::AssembleMatrix()
   }
 
   compute_complete_ = false;
+
   // std::stringstream filename_s2;
   // filename_s2 << "assembled_matrix" << 0 << ".txt";
   // EpetraExt::RowMatrixToMatlabFile(filename_s2.str().c_str(), *Amat_ ->Matrix());
+  // throw("dumped matrix");
 }
 
 

--- a/src/operators/UpwindDivK.hh
+++ b/src/operators/UpwindDivK.hh
@@ -78,7 +78,7 @@ UpwindDivK::Compute(const CompositeVector& flux,
   const Epetra_MultiVector& flx_face = *flux.ViewComponent("face", true);
 
   const Epetra_MultiVector& fld_cell = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& fld_boundary = *field.ViewComponent("boundary_face", true);
+  const Epetra_MultiVector& fld_boundary = *std::as_const(field).ViewComponent("boundary_face", true);
   const Epetra_Map& ext_face_map = mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true);
   const Epetra_Map& face_map = mesh_->getMap(AmanziMesh::Entity_kind::FACE, true);
   Epetra_MultiVector& upw_face = *field.ViewComponent(face_comp_, true);

--- a/src/operators/UpwindFlux.cc
+++ b/src/operators/UpwindFlux.cc
@@ -55,7 +55,7 @@ UpwindFlux::Compute(const CompositeVector& flux,
   const Epetra_MultiVector& flux_f = *flux.ViewComponent("face", true);
 
   const Epetra_MultiVector& field_c = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& field_bf = *field.ViewComponent("boundary_face");
+  const Epetra_MultiVector& field_bf = *std::as_const(field).ViewComponent("boundary_face");
   Epetra_MultiVector& field_f = *field.ViewComponent(face_comp_, true);
 
   double flxmin, flxmax, tol;

--- a/src/operators/UpwindFluxManifolds.cc
+++ b/src/operators/UpwindFluxManifolds.cc
@@ -51,7 +51,7 @@ UpwindFluxManifolds::Compute(const CompositeVector& flux,
 
   const auto& flux_f = *flux.ViewComponent("face", true);
   const auto& field_c = *field.ViewComponent("cell", true);
-  const auto& field_bf = *field.ViewComponent("boundary_face", true);
+  const auto& field_bf = *std::as_const(field).ViewComponent("boundary_face", true);
   auto& field_f = *field.ViewComponent("face", true);
 
   double flxmin, flxmax, tol;

--- a/src/operators/UpwindGravity.cc
+++ b/src/operators/UpwindGravity.cc
@@ -62,7 +62,7 @@ UpwindGravity::Compute(const CompositeVector& flux,
 
   field.ScatterMasterToGhosted("cell");
   const Epetra_MultiVector& field_c = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& field_bf = *field.ViewComponent("boundary_face");
+  const Epetra_MultiVector& field_bf = *std::as_const(field).ViewComponent("boundary_face");
   Epetra_MultiVector& field_f = *field.ViewComponent(face_comp_, true);
 
   int nfaces_owned =

--- a/src/operators/UpwindSecondOrder.cc
+++ b/src/operators/UpwindSecondOrder.cc
@@ -61,7 +61,7 @@ UpwindSecondOrder::Compute(const CompositeVector& flux,
 
   const Epetra_MultiVector& fld_cell = *field.ViewComponent("cell", true);
   const Epetra_MultiVector& fld_grad = *field.ViewComponent("grad", true);
-  const Epetra_MultiVector& fld_boundary = *field.ViewComponent("boundary_face", true);
+  const Epetra_MultiVector& fld_boundary = *std::as_const(field).ViewComponent("boundary_face", true);
   const Epetra_Map& ext_face_map = mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true);
   const Epetra_Map& face_map = mesh_->getMap(AmanziMesh::Entity_kind::FACE, true);
   Epetra_MultiVector& upw_face = *field.ViewComponent(face_comp_, true);

--- a/src/operators/test/operator_coupled_diffusion.cc
+++ b/src/operators/test/operator_coupled_diffusion.cc
@@ -350,9 +350,8 @@ struct Problem {
         u_f[0][f] = ana->exact0(xf, 0);
         v_f[0][f] = ana->exact1(xf, 0);
       }
-    }
 
-    if (u.HasComponent("boundary_face")) {
+    } else if (u.HasComponent("boundary_face")) {
       int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                  AmanziMesh::Parallel_kind::OWNED);
       Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);

--- a/src/operators/test/operator_diffusion_convergence.cc
+++ b/src/operators/test/operator_diffusion_convergence.cc
@@ -143,9 +143,8 @@ RunForwardProblem(const std::string& discretization, int nx, int ny)
       const AmanziGeometry::Point& xf = mesh->getFaceCentroid(f);
       u_f[0][f] = ana.pressure_exact(xf, 0.0);
     }
-  }
 
-  if (u.HasComponent("boundary_face")) {
+  } else if (u.HasComponent("boundary_face")) {
     int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                AmanziMesh::Parallel_kind::OWNED);
     Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);
@@ -278,9 +277,8 @@ RunInverseProblem(const std::string& discretization, int nx, int ny, bool write_
       const AmanziGeometry::Point& xf = mesh->getFaceCentroid(f);
       u_f[0][f] = ana.pressure_exact(xf, 0.0);
     }
-  }
 
-  if (u.HasComponent("boundary_face")) {
+  } else if (u.HasComponent("boundary_face")) {
     int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                AmanziMesh::Parallel_kind::OWNED);
     Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);

--- a/src/state/Debugger.cc
+++ b/src/state/Debugger.cc
@@ -171,10 +171,8 @@ Debugger::WriteVector(const std::string& vname,
   }
 
   Teuchos::RCP<const Epetra_MultiVector> vec_bf;
-  int nbfaces_valid = 0;
-  if (vec->HasComponent("boundary_face")) {
+  if (vec_f == Teuchos::null && vec->HasComponent("boundary_face")) {
     vec_bf = vec->ViewComponent("boundary_face", true);
-    nbfaces_valid = vec_bf->MyLength();
     n_vecs = vec_bf->NumVectors();
   }
 
@@ -201,12 +199,8 @@ Debugger::WriteVector(const std::string& vname,
           auto [fnums0, dirs] = mesh_->getCellFacesAndDirections(c0);
 
           for (unsigned int n = 0; n != fnums0.size(); ++n) {
-            AmanziMesh::Entity_ID f = fnums0[n];
-            AmanziMesh::Entity_ID bf =
-              mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true)
-                .LID(mesh_->getMap(AmanziMesh::Entity_kind::FACE, true).GID(f));
-            if (bf >= 0 && bf < nbfaces_valid)
-              *dcvo_[i]->os() << " " << formatter_.format((*vec_bf)[j][bf]);
+            AmanziMesh::Entity_ID bf = AmanziMesh::getFaceOnBoundaryBoundaryFace(*mesh_, fnums0[n]);
+            if (bf >= 0) *dcvo_[i]->os() << " " << formatter_.format((*vec_bf)[j][bf]);
           }
         }
         *dcvo_[i]->os() << std::endl;
@@ -268,7 +262,7 @@ Debugger::WriteVectors(const std::vector<std::string>& names,
         }
 
         Teuchos::RCP<const Epetra_MultiVector> vec_bf;
-        if (vec->HasComponent("boundary_face")) {
+        if (vec_f == Teuchos::null && vec->HasComponent("boundary_face")) {
           vec_bf = vec->ViewComponent("boundary_face", false);
           n_vec = vec_bf->NumVectors();
         }
@@ -288,10 +282,7 @@ Debugger::WriteVectors(const std::vector<std::string>& names,
             auto [fnums0, dirs] = mesh_->getCellFacesAndDirections(c0);
 
             for (unsigned int n = 0; n != fnums0.size(); ++n) {
-              AmanziMesh::Entity_ID f = fnums0[n];
-              AmanziMesh::Entity_ID bf =
-                mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true)
-                  .LID(mesh_->getMap(AmanziMesh::Entity_kind::FACE, true).GID(f));
+              AmanziMesh::Entity_ID bf = AmanziMesh::getFaceOnBoundaryBoundaryFace(*mesh_, fnums0[n]);
               if (bf >= 0) *dcvo_[i]->os() << " " << formatter_.format((*vec_bf)[j][bf]);
             }
           }

--- a/src/state/Debugger.cc
+++ b/src/state/Debugger.cc
@@ -163,15 +163,11 @@ Debugger::WriteVector(const std::string& vname,
   }
 
   Teuchos::RCP<const Epetra_MultiVector> vec_f;
-  int nfaces_valid = 0;
+  Teuchos::RCP<const Epetra_MultiVector> vec_bf;
   if (vec->HasComponent("face")) {
     vec_f = vec->ViewComponent("face", true);
-    nfaces_valid = vec_f->MyLength();
     n_vecs = vec_f->NumVectors();
-  }
-
-  Teuchos::RCP<const Epetra_MultiVector> vec_bf;
-  if (vec_f == Teuchos::null && vec->HasComponent("boundary_face")) {
+  } else if (vec->HasComponent("boundary_face")) {
     vec_bf = vec->ViewComponent("boundary_face", true);
     n_vecs = vec_bf->NumVectors();
   }
@@ -191,8 +187,7 @@ Debugger::WriteVector(const std::string& vname,
           auto [fnums0, dirs] = mesh_->getCellFacesAndDirections(c0);
 
           for (unsigned int n = 0; n != fnums0.size(); ++n)
-            if (fnums0[n] < nfaces_valid)
-              *dcvo_[i]->os() << " " << formatter_.format((*vec_f)[j][fnums0[n]]);
+            *dcvo_[i]->os() << " " << formatter_.format((*vec_f)[j][fnums0[n]]);
         }
 
         if (include_faces && vec_bf != Teuchos::null) {
@@ -256,13 +251,11 @@ Debugger::WriteVectors(const std::vector<std::string>& names,
         }
 
         Teuchos::RCP<const Epetra_MultiVector> vec_f;
+        Teuchos::RCP<const Epetra_MultiVector> vec_bf;
         if (vec->HasComponent("face")) {
           vec_f = vec->ViewComponent("face", false);
           n_vec = vec_f->NumVectors();
-        }
-
-        Teuchos::RCP<const Epetra_MultiVector> vec_bf;
-        if (vec_f == Teuchos::null && vec->HasComponent("boundary_face")) {
+        } else if (vec->HasComponent("boundary_face")) {
           vec_bf = vec->ViewComponent("boundary_face", false);
           n_vec = vec_bf->NumVectors();
         }

--- a/src/state/evaluators/EvaluatorSecondaryMonotype.cc
+++ b/src/state/evaluators/EvaluatorSecondaryMonotype.cc
@@ -153,7 +153,7 @@ EvaluatorSecondaryMonotype<CompositeVector, CompositeVectorSpace>::UpdateDerivat
         vecs.emplace_back(my_ptr.ptr());
       }
     }
-    db_->WriteVectors(names, vecs);
+    db_->WriteVectors(names, vecs, true);
     db_->WriteDivider();
   }
 }

--- a/src/state/evaluators/EvaluatorSecondaryMonotype.cc
+++ b/src/state/evaluators/EvaluatorSecondaryMonotype.cc
@@ -153,7 +153,7 @@ EvaluatorSecondaryMonotype<CompositeVector, CompositeVectorSpace>::UpdateDerivat
         vecs.emplace_back(my_ptr.ptr());
       }
     }
-    db_->WriteVectors(names, vecs, true);
+    db_->WriteVectors(names, vecs);
     db_->WriteDivider();
   }
 }

--- a/src/state/evaluators/EvaluatorSecondaryMonotype.hh
+++ b/src/state/evaluators/EvaluatorSecondaryMonotype.hh
@@ -408,7 +408,7 @@ EvaluatorSecondaryMonotype<Data_t, DataFactory_t>::Update_(State& S)
           vecs.emplace_back(dep_ptr.ptr());
         }
       }
-      db_->WriteVectors(names, vecs, true);
+      db_->WriteVectors(names, vecs);
       db_->WriteDivider();
 
       names.clear();
@@ -421,7 +421,7 @@ EvaluatorSecondaryMonotype<Data_t, DataFactory_t>::Update_(State& S)
           vecs.emplace_back(my_ptr.ptr());
         }
       }
-      db_->WriteVectors(names, vecs, true);
+      db_->WriteVectors(names, vecs);
       db_->WriteDivider();
     }
   }

--- a/src/state/evaluators/EvaluatorSecondaryMonotype.hh
+++ b/src/state/evaluators/EvaluatorSecondaryMonotype.hh
@@ -408,7 +408,7 @@ EvaluatorSecondaryMonotype<Data_t, DataFactory_t>::Update_(State& S)
           vecs.emplace_back(dep_ptr.ptr());
         }
       }
-      db_->WriteVectors(names, vecs);
+      db_->WriteVectors(names, vecs, true);
       db_->WriteDivider();
 
       names.clear();
@@ -421,7 +421,7 @@ EvaluatorSecondaryMonotype<Data_t, DataFactory_t>::Update_(State& S)
           vecs.emplace_back(my_ptr.ptr());
         }
       }
-      db_->WriteVectors(names, vecs);
+      db_->WriteVectors(names, vecs, true);
       db_->WriteDivider();
     }
   }


### PR DESCRIPTION
This actually fixes two bugs:

1. The Jacobian term in FV for Dirichlet BCs did not respect the upwinding scheme, so terms were included even if upwinding meant that the kr was not a function of the cell pressure (only a function of the boundary condition pressure).

2. HasComponent("boundary_face") returned False even in cases when HasComponent("face") was true, and therefore the Vandelay map could be used to create a boundary_face on the fly.  This incorrectly resulted in several evaluators not computing on boundary_faces when dependencies were on faces.  I don't believe that these changed answers, but they made for incorrect information to be printed in the Debugger/debug cells.