### PR TITLE
Adds CV::ProvidesComponent() and uses it in vector math

### DIFF
--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -245,7 +245,7 @@ CompositeVector::operator=(const CompositeVector& other)
       // If both are ghosted, copy the ghosted vector.
       // Exception: boundary_face component created on a fly is not ghosted
       for (name_iterator name = begin(); name != end(); ++name) {
-        bool ghosted = (*name == "boundary_face" && other.ProvidesComponent("face")) ? false : true;
+        bool ghosted = (*name == "boundary_face" && other.HasImportedComponent("face")) ? false : true;
         Teuchos::RCP<Epetra_MultiVector> comp = ViewComponent(*name, ghosted);
         Teuchos::RCP<const Epetra_MultiVector> othercomp = other.ViewComponent(*name, ghosted);
         *comp = *othercomp;
@@ -273,7 +273,7 @@ CompositeVector::operator=(const CompositeVector& other)
 Teuchos::RCP<const Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
-  AMANZI_ASSERT(ProvidesComponent(name));
+  AMANZI_ASSERT(HasImportedComponent(name));
   if (name == "boundary_face") {
     if (!HasComponent("boundary_face") && HasComponent("face")) {
       ApplyVandelay_();
@@ -495,7 +495,7 @@ CompositeVector::Dot(const CompositeVector& other, double* result) const
 {
   double tmp_result = 0.0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (other.ProvidesComponent(*lcv)) {
+    if (other.HasImportedComponent(*lcv)) {
       std::vector<double> intermediate_result(ViewComponent(*lcv, false)->NumVectors(), 0.0);
       int ierr =
         ViewComponent(*lcv, false)->Dot(*other.ViewComponent(*lcv, false), &intermediate_result[0]);
@@ -518,7 +518,7 @@ CompositeVector::Update(double scalarA, const CompositeVector& A, double scalarT
   //  AMANZI_ASSERT(map_->SubsetOf(*A.map_));
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.ProvidesComponent(*lcv))
+    if (A.HasImportedComponent(*lcv))
       ViewComponent(*lcv, false)->Update(scalarA, *A.ViewComponent(*lcv, false), scalarThis);
   }
   return *this;
@@ -535,7 +535,7 @@ CompositeVector::Update(double scalarA,
 {
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
+    if (A.HasImportedComponent(*lcv) && B.HasImportedComponent(*lcv))
       ViewComponent(*lcv, false)
         ->Update(scalarA,
                  *A.ViewComponent(*lcv, false),
@@ -559,7 +559,7 @@ CompositeVector::Multiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
+    if (A.HasImportedComponent(*lcv) && B.HasImportedComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->Multiply(
@@ -581,7 +581,7 @@ CompositeVector::ReciprocalMultiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
+    if (A.HasImportedComponent(*lcv) && B.HasImportedComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->ReciprocalMultiply(

--- a/src/data_structures/CompositeVector.cc
+++ b/src/data_structures/CompositeVector.cc
@@ -245,7 +245,7 @@ CompositeVector::operator=(const CompositeVector& other)
       // If both are ghosted, copy the ghosted vector.
       // Exception: boundary_face component created on a fly is not ghosted
       for (name_iterator name = begin(); name != end(); ++name) {
-        bool ghosted = (*name == "boundary_face" && other.HasComponent("face")) ? false : true;
+        bool ghosted = (*name == "boundary_face" && other.ProvidesComponent("face")) ? false : true;
         Teuchos::RCP<Epetra_MultiVector> comp = ViewComponent(*name, ghosted);
         Teuchos::RCP<const Epetra_MultiVector> othercomp = other.ViewComponent(*name, ghosted);
         *comp = *othercomp;
@@ -273,6 +273,7 @@ CompositeVector::operator=(const CompositeVector& other)
 Teuchos::RCP<const Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 {
+  AMANZI_ASSERT(ProvidesComponent(name));
   if (name == "boundary_face") {
     if (!HasComponent("boundary_face") && HasComponent("face")) {
       ApplyVandelay_();
@@ -291,14 +292,7 @@ CompositeVector::ViewComponent(const std::string& name, bool ghosted) const
 Teuchos::RCP<Epetra_MultiVector>
 CompositeVector::ViewComponent(const std::string& name, bool ghosted)
 {
-  if (name == "boundary_face") {
-    if (!HasComponent("boundary_face") && HasComponent("face")) {
-      ApplyVandelay_();
-      ChangedValue("face");
-      return ghosted ? vandelay_vector_all_ : vandelay_vector_owned_;
-    }
-  }
-
+  AMANZI_ASSERT(HasComponent(name));
   ChangedValue(name);
   if (ghosted) {
     return ghostvec_->ViewComponent(name);
@@ -501,7 +495,7 @@ CompositeVector::Dot(const CompositeVector& other, double* result) const
 {
   double tmp_result = 0.0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (other.HasComponent(*lcv)) {
+    if (other.ProvidesComponent(*lcv)) {
       std::vector<double> intermediate_result(ViewComponent(*lcv, false)->NumVectors(), 0.0);
       int ierr =
         ViewComponent(*lcv, false)->Dot(*other.ViewComponent(*lcv, false), &intermediate_result[0]);
@@ -524,7 +518,7 @@ CompositeVector::Update(double scalarA, const CompositeVector& A, double scalarT
   //  AMANZI_ASSERT(map_->SubsetOf(*A.map_));
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv))
       ViewComponent(*lcv, false)->Update(scalarA, *A.ViewComponent(*lcv, false), scalarThis);
   }
   return *this;
@@ -539,11 +533,9 @@ CompositeVector::Update(double scalarA,
                         const CompositeVector& B,
                         double scalarThis)
 {
-  //  AMANZI_ASSERT(map_->SubsetOf(*A.map_));
-  //  AMANZI_ASSERT(map_->SubsetOf(*B.map_));
   ChangedValue();
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ViewComponent(*lcv, false)
         ->Update(scalarA,
                  *A.ViewComponent(*lcv, false),
@@ -567,7 +559,7 @@ CompositeVector::Multiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->Multiply(
@@ -589,7 +581,7 @@ CompositeVector::ReciprocalMultiply(double scalarAB,
   ChangedValue();
   int ierr = 0;
   for (name_iterator lcv = begin(); lcv != end(); ++lcv) {
-    if (A.HasComponent(*lcv) && B.HasComponent(*lcv))
+    if (A.ProvidesComponent(*lcv) && B.ProvidesComponent(*lcv))
       ierr |=
         ViewComponent(*lcv, false)
           ->ReciprocalMultiply(

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -174,7 +174,12 @@ class CompositeVector {
 
   Comm_ptr_type Comm() const { return map_->Comm(); }
   Teuchos::RCP<const AmanziMesh::Mesh> Mesh() const { return map_->Mesh(); }
+
+  // note, HasComponent() indicates that a _writable_ view may be obtained.
   bool HasComponent(const std::string& name) const { return map_->HasComponent(name); }
+  // note, ProvidesComponent() indicates that a _readable_ view may be obtained.
+  bool ProvidesComponent(const std::string& name) const { return map_->ProvidesComponent(name); }
+
   int NumComponents() const { return size(); }
   AmanziMesh::Entity_kind Location(const std::string& name) const { return map_->Location(name); }
 

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -175,9 +175,12 @@ class CompositeVector {
   Comm_ptr_type Comm() const { return map_->Comm(); }
   Teuchos::RCP<const AmanziMesh::Mesh> Mesh() const { return map_->Mesh(); }
 
-  // note, HasComponent() indicates that a _writable_ view may be obtained.
+  // note, HasComponent() indicates that a non-const view may be obtained via ViewComponent()
   bool HasComponent(const std::string& name) const { return map_->HasComponent(name); }
-  // note, HasImportedComponent() indicates that a _readable_ view may be obtained.
+
+  // HasImportedComponent() indicates that only a const view may be obtained
+  // via a call to the const version of ViewComponent(), as the component may
+  // be imported (e.g. boundary_face imported from face).
   bool HasImportedComponent(const std::string& name) const { return map_->HasImportedComponent(name); }
 
   int NumComponents() const { return size(); }

--- a/src/data_structures/CompositeVector.hh
+++ b/src/data_structures/CompositeVector.hh
@@ -177,8 +177,8 @@ class CompositeVector {
 
   // note, HasComponent() indicates that a _writable_ view may be obtained.
   bool HasComponent(const std::string& name) const { return map_->HasComponent(name); }
-  // note, ProvidesComponent() indicates that a _readable_ view may be obtained.
-  bool ProvidesComponent(const std::string& name) const { return map_->ProvidesComponent(name); }
+  // note, HasImportedComponent() indicates that a _readable_ view may be obtained.
+  bool HasImportedComponent(const std::string& name) const { return map_->HasImportedComponent(name); }
 
   int NumComponents() const { return size(); }
   AmanziMesh::Entity_kind Location(const std::string& name) const { return map_->Location(name); }

--- a/src/data_structures/CompositeVectorSpace.hh
+++ b/src/data_structures/CompositeVectorSpace.hh
@@ -85,6 +85,10 @@ class CompositeVectorSpace {
   {
     return indexmap_.find(name) != indexmap_.end();
   }
+  bool ProvidesComponent(const std::string& name) const
+  {
+    return HasComponent(name) || (name == "boundary_face" && HasComponent("face"));
+  }
   int NumComponents() const { return size(); }
 
   // Each component has a number of Degrees of Freedom.

--- a/src/data_structures/CompositeVectorSpace.hh
+++ b/src/data_structures/CompositeVectorSpace.hh
@@ -85,7 +85,7 @@ class CompositeVectorSpace {
   {
     return indexmap_.find(name) != indexmap_.end();
   }
-  bool ProvidesComponent(const std::string& name) const
+  bool HasImportedComponent(const std::string& name) const
   {
     return HasComponent(name) || (name == "boundary_face" && HasComponent("face"));
   }

--- a/src/data_structures/test/data_structures_vandelay.cc
+++ b/src/data_structures/test/data_structures_vandelay.cc
@@ -93,7 +93,7 @@ SUITE(VANDELAY_COMPOSITE_VECTOR)
     CHECK_CLOSE((*x)("cell", 1, 0), 2.0, 0.00001);
     CHECK_CLOSE((*x)("face", 0, 0), 2.0, 0.00001);
 
-    *x2->ViewComponent("boundary_face", false) = *x->ViewComponent("boundary_face", false);
+    *x2->ViewComponent("boundary_face", false) = *std::as_const(*x).ViewComponent("boundary_face", false);
     CHECK_CLOSE((*x2)("boundary_face", 0, 0), 2.0, 0.00001);
   }
 
@@ -106,7 +106,7 @@ SUITE(VANDELAY_COMPOSITE_VECTOR)
     CHECK_CLOSE((*x)("cell", 1, 0), 2.0, 0.00001);
     CHECK_CLOSE((*x)("face", 0, 0), 2.0, 0.00001);
 
-    *x2->ViewComponent("boundary_face", false) = *x->ViewComponent("boundary_face", false);
+    *x2->ViewComponent("boundary_face", false) = *std::as_const(*x).ViewComponent("boundary_face", false);
 
     // test the scatter of boundary_faces
     x2->ScatterMasterToGhosted("boundary_face");

--- a/src/operators/UpwindDivK.hh
+++ b/src/operators/UpwindDivK.hh
@@ -78,7 +78,7 @@ UpwindDivK::Compute(const CompositeVector& flux,
   const Epetra_MultiVector& flx_face = *flux.ViewComponent("face", true);
 
   const Epetra_MultiVector& fld_cell = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& fld_boundary = *field.ViewComponent("boundary_face", true);
+  const Epetra_MultiVector& fld_boundary = *std::as_const(field).ViewComponent("boundary_face", true);
   const Epetra_Map& ext_face_map = mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true);
   const Epetra_Map& face_map = mesh_->getMap(AmanziMesh::Entity_kind::FACE, true);
   Epetra_MultiVector& upw_face = *field.ViewComponent(face_comp_, true);

--- a/src/operators/UpwindFlux.cc
+++ b/src/operators/UpwindFlux.cc
@@ -55,7 +55,7 @@ UpwindFlux::Compute(const CompositeVector& flux,
   const Epetra_MultiVector& flux_f = *flux.ViewComponent("face", true);
 
   const Epetra_MultiVector& field_c = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& field_bf = *field.ViewComponent("boundary_face");
+  const Epetra_MultiVector& field_bf = *std::as_const(field).ViewComponent("boundary_face");
   Epetra_MultiVector& field_f = *field.ViewComponent(face_comp_, true);
 
   double flxmin, flxmax, tol;

--- a/src/operators/UpwindFluxManifolds.cc
+++ b/src/operators/UpwindFluxManifolds.cc
@@ -51,7 +51,7 @@ UpwindFluxManifolds::Compute(const CompositeVector& flux,
 
   const auto& flux_f = *flux.ViewComponent("face", true);
   const auto& field_c = *field.ViewComponent("cell", true);
-  const auto& field_bf = *field.ViewComponent("boundary_face", true);
+  const auto& field_bf = *std::as_const(field).ViewComponent("boundary_face", true);
   auto& field_f = *field.ViewComponent("face", true);
 
   double flxmin, flxmax, tol;

--- a/src/operators/UpwindGravity.cc
+++ b/src/operators/UpwindGravity.cc
@@ -62,7 +62,7 @@ UpwindGravity::Compute(const CompositeVector& flux,
 
   field.ScatterMasterToGhosted("cell");
   const Epetra_MultiVector& field_c = *field.ViewComponent("cell", true);
-  const Epetra_MultiVector& field_bf = *field.ViewComponent("boundary_face");
+  const Epetra_MultiVector& field_bf = *std::as_const(field).ViewComponent("boundary_face");
   Epetra_MultiVector& field_f = *field.ViewComponent(face_comp_, true);
 
   int nfaces_owned =

--- a/src/operators/UpwindSecondOrder.cc
+++ b/src/operators/UpwindSecondOrder.cc
@@ -61,7 +61,7 @@ UpwindSecondOrder::Compute(const CompositeVector& flux,
 
   const Epetra_MultiVector& fld_cell = *field.ViewComponent("cell", true);
   const Epetra_MultiVector& fld_grad = *field.ViewComponent("grad", true);
-  const Epetra_MultiVector& fld_boundary = *field.ViewComponent("boundary_face", true);
+  const Epetra_MultiVector& fld_boundary = *std::as_const(field).ViewComponent("boundary_face", true);
   const Epetra_Map& ext_face_map = mesh_->getMap(AmanziMesh::Entity_kind::BOUNDARY_FACE, true);
   const Epetra_Map& face_map = mesh_->getMap(AmanziMesh::Entity_kind::FACE, true);
   Epetra_MultiVector& upw_face = *field.ViewComponent(face_comp_, true);

--- a/src/operators/test/operator_coupled_diffusion.cc
+++ b/src/operators/test/operator_coupled_diffusion.cc
@@ -350,9 +350,8 @@ struct Problem {
         u_f[0][f] = ana->exact0(xf, 0);
         v_f[0][f] = ana->exact1(xf, 0);
       }
-    }
 
-    if (u.HasComponent("boundary_face")) {
+    } else if (u.HasComponent("boundary_face")) {
       int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                  AmanziMesh::Parallel_kind::OWNED);
       Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);

--- a/src/operators/test/operator_diffusion_convergence.cc
+++ b/src/operators/test/operator_diffusion_convergence.cc
@@ -143,9 +143,8 @@ RunForwardProblem(const std::string& discretization, int nx, int ny)
       const AmanziGeometry::Point& xf = mesh->getFaceCentroid(f);
       u_f[0][f] = ana.pressure_exact(xf, 0.0);
     }
-  }
 
-  if (u.HasComponent("boundary_face")) {
+  } else if (u.HasComponent("boundary_face")) {
     int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                AmanziMesh::Parallel_kind::OWNED);
     Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);
@@ -278,9 +277,8 @@ RunInverseProblem(const std::string& discretization, int nx, int ny, bool write_
       const AmanziGeometry::Point& xf = mesh->getFaceCentroid(f);
       u_f[0][f] = ana.pressure_exact(xf, 0.0);
     }
-  }
 
-  if (u.HasComponent("boundary_face")) {
+  } else if (u.HasComponent("boundary_face")) {
     int nboundary_faces = mesh->getNumEntities(AmanziMesh::Entity_kind::BOUNDARY_FACE,
                                                AmanziMesh::Parallel_kind::OWNED);
     Epetra_MultiVector& u_f = *u.ViewComponent("boundary_face", false);


### PR DESCRIPTION
Previously, if A & B are CVs,

A.Update(1, B, 1)

where A.HasComponent("boundary_face") and B.HasComponent("face") would
do nothing, because !B.HasComponent("boundary_face").  This should be
allowed, however, because B.ViewComponent("boundary_face") uses the
Vandelay map and all is fine.

This commit makes the logic:

A.HasComponent(comp) <-- a _writable_ view of comp is available (no change)
A.ProvidesComponent(comp) <-- a _readable_ view of comp is available (new)

and uses ProvidesComponent() where possible to let Update(), Dot(),
etc work through the Vandelay map.

Note also that it is probably implied that:
!(A.HasComponent("boundary_face") && A.HasComponent("face"))
(you can't have both) though I'm not sure whether this breaks anything
or not.

Several changes to code were also made to:

if (A.HasComponent("face")) {
  ...
} else if (A.HasComponent("boundary_face")) {
  ...
}

rather than two independent if conditionals.  Likely this doesn't
really matter, and both are now valid.