### PR TITLE
[WIP] Remove distutils

### DIFF
--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -36,7 +36,7 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   make \
   openssl \
   python3 \
-  python3-distutils \
+  python3-setuptools \
   python3-pip \
   python-is-python3 \
   rsync \

--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -36,7 +36,6 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   make \
   openssl \
   python3 \
-  python3-setuptools \
   python3-pip \
   python-is-python3 \
   rsync \

--- a/Docker/Dockerfile-TPLs-base
+++ b/Docker/Dockerfile-TPLs-base
@@ -33,7 +33,6 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   make \
   openssl \
   python3 \
-  python3-setuptools \
   python3-pip \
   python-is-python3 \
   rsync \

--- a/Docker/Dockerfile-TPLs-base
+++ b/Docker/Dockerfile-TPLs-base
@@ -33,7 +33,7 @@ RUN apt-get -q update -y && apt-get install -y tzdata && apt-get -q install -y \
   make \
   openssl \
   python3 \
-  python3-distutils \
+  python3-setuptools \
   python3-pip \
   python-is-python3 \
   rsync \

--- a/doc/user_guide/utils/IndexWriter.py
+++ b/doc/user_guide/utils/IndexWriter.py
@@ -34,7 +34,7 @@
 ###  Insert required lines in top-level index automatically
 ###  Correct paths in the .. plot:: directives
 
-import shutil, distutils.dir_util, os, sys, glob
+import shutil, os, sys, glob
 
 def IndexCreate(amanzi_home,data,logfile):
 
@@ -155,7 +155,7 @@ def RecurseCopy(amanzi_home,content,level,logfile):
         content_from=amanzi_home+os.sep+content['from_dir']
         content_dest=amanzi_home+os.sep+content['dest_dir']
         logfile.write('  %s\n  %s\n' % (content_from, content_dest) )
-        distutils.dir_util.copy_tree(content_from, content_dest)
+        shutil.copytree(content_from, content_dest)
 
         level=level-1
 

--- a/tools/py_lib/CMakeLists.txt
+++ b/tools/py_lib/CMakeLists.txt
@@ -18,10 +18,11 @@ if ( PYTHON_FOUND )
 
   # Define the install location
   get_filename_component(real_install_prefix ${CMAKE_INSTALL_PREFIX} REALPATH)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${real_install_prefix}'}))"
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('purelib', vars={'base': '${real_install_prefix}'}))"
                   OUTPUT_VARIABLE AmanziPython_INSTALL_PREFIX
                   RESULT_VARIABLE prefix_err
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
+  
   if(prefix_err)
     message(SEND_ERROR "Failed to define the python from sysconfig. Set to ${real_install_prefix}/python.")
     set(AmanziPython_INSTALL_PREFIX ${real_install_prefix}/python)

--- a/tools/py_lib/CMakeLists.txt
+++ b/tools/py_lib/CMakeLists.txt
@@ -18,12 +18,12 @@ if ( PYTHON_FOUND )
 
   # Define the install location
   get_filename_component(real_install_prefix ${CMAKE_INSTALL_PREFIX} REALPATH)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix='${real_install_prefix}'))"
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_path('platlib', vars={'base': '${real_install_prefix}'}))"
                   OUTPUT_VARIABLE AmanziPython_INSTALL_PREFIX
                   RESULT_VARIABLE prefix_err
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(prefix_err)
-    message(SEND_ERROR "Failed to define the python from distutils. Set to ${real_install_prefix}/python.")
+    message(SEND_ERROR "Failed to define the python from sysconfig. Set to ${real_install_prefix}/python.")
     set(AmanziPython_INSTALL_PREFIX ${real_install_prefix}/python)
   endif()
 


### PR DESCRIPTION
distutils has been deprecated and therefore amanzi-ATS installs will fail with python>=3.12. This PR removes distutils where it is used and replaces the functionality with sysconfig and shutil. Closes #843.

Also updates TPLConfig file to deal with changes to gitlab links for TPLs. Closes #874.