### PR TITLE
Update pflotran md5

### DIFF
--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -538,7 +538,7 @@ set(PFLOTRAN_VERSION ${PFLOTRAN_VERSION_MAJOR}.${PFLOTRAN_VERSION_MINOR}.${PFLOT
 set(PFLOTRAN_URL_STRING     "https://gitlab.com/pflotran/pflotran/-/archive/v${PFLOTRAN_VERSION}")
 set(PFLOTRAN_ARCHIVE_FILE   pflotran-v${PFLOTRAN_VERSION}.tar.gz)
 set(PFLOTRAN_SAVEAS_FILE    pflotran-${PFLOTRAN_VERSION}.tar.gz)
-set(PFLOTRAN_MD5_SUM        4fa35ad356eab7e6a3fd19f8cde9dd13)
+set(PFLOTRAN_MD5_SUM        d44b5670223ea9e6fbb894a8842161e0)
 #set(PFLOTRAN_GIT_REPOSITORY "https://gitlab.com/pflotran/pflotran.git")
 #set(PFLOTRAN_GIT_TAG        "9e07f41")
 


### PR DESCRIPTION
Updates TPLConfig file to deal with changes to gitlab links for TPLs (pflotran specifically). Closes https://github.com/amanzi/amanzi/issues/874.

This commit was initially also in #875 but separating out as the distutils portion of that PR requires additional testing. 