### PR TITLE
add simplified netcdf-fortran-4.5.4 patch

### DIFF
--- a/config/SuperBuild/templates/netcdf-fortran-4.5.4-cmake.patch
+++ b/config/SuperBuild/templates/netcdf-fortran-4.5.4-cmake.patch
@@ -1,45 +1,13 @@
---- netcdf-fortran-4.5.4-source/fortran/CMakeLists-orig.txt	2023-02-06 13:33:49.000000000 -0500
-+++ netcdf-fortran-4.5.4-source/fortran/CMakeLists.txt	2023-02-06 13:38:03.000000000 -0500
-@@ -148,14 +148,14 @@
- # ADD_LIBRARY(netcdff STATIC SHARED ${netcdff_SOURCES})
- # Builds only static, not shared
- # Compile C-code to object, then link with Fortran
--ADD_LIBRARY(netcdff_c OBJECT ${netcdff_C_SOURCES})
--install(TARGETS netcdff_c OBJECTS DESTINATION lib)
--# or is this better?   list(APPEND NETCDF_C_LIBRARY netcdff_c)
--SET(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} netcdff_c)
--set_target_properties(netcdff_c PROPERTIES
-+ADD_LIBRARY(netcdf OBJECT ${netcdff_C_SOURCES})
-+install(TARGETS netcdf OBJECTS DESTINATION lib)
-+# or is this better?   list(APPEND NETCDF_C_LIBRARY netcdf)
-+SET(NETCDF_C_LIBRARY ${NETCDF_C_LIBRARY} netcdf)
-+set_target_properties(netcdf PROPERTIES
-     INTERFACE_INCLUDE_DIRECTORIES "${NETCDF_C_INCLUDE_DIR}"
-   )
--target_include_directories(netcdff_c PUBLIC "${NETCDF_C_INCLUDE_DIR}")
-+target_include_directories(netcdf PUBLIC "${NETCDF_C_INCLUDE_DIR}")
- 
- ADD_LIBRARY(netcdff ${netcdff_SOURCES})
- TARGET_LINK_LIBRARIES(netcdff PUBLIC netCDF::netcdf)
-@@ -171,9 +171,9 @@
-   $<INSTALL_INTERFACE:include>
-   )
- 
--if (HAVE_NC_USE_PARALLEL_ENABLED)
--  target_link_libraries(netcdff PUBLIC MPI::MPI_Fortran)
--endif()
-+#if (HAVE_NC_USE_PARALLEL_ENABLED)
-+#  target_link_libraries(netcdff PUBLIC MPI::MPI_Fortran)
-+#endif()
- 
- # copied from netcdf-c... Changed from ADD_DEFINITIONS to TARGET_COMPILE_DEFINITIONS
- # Option to Build DLL
-@@ -210,7 +210,7 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0ef674b..9a1289b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1045,6 +1045,8 @@ IF(NC_FLIBS)
+   STRING(REPLACE "-lhdf5::hdf5-static" "-lhdf5" NC_FLIBS ${NC_FLIBS})
+   STRING(REPLACE "-lhdf5::hdf5_hl-static" "-lhdf5_hl" NC_FLIBS ${NC_FLIBS})
+   STRING(REPLACE "-lnetCDF::netcdf" "-lnetcdf" NC_FLIBS ${NC_FLIBS})
++  STRING(REPLACE "-lMPI::MPI_Fortran" "" NC_FLIBS ${NC_FLIBS})
++  STRING(REPLACE "-lnetcdff_c" "" NC_FLIBS ${NC_FLIBS})
  ENDIF()
  
- # Installation of the program
--INSTALL(TARGETS netcdff netcdff_c
-+INSTALL(TARGETS netcdff
-     EXPORT netcdffTargets
-     RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT bin
-     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT shlib
+ STRING(REPLACE ";" " " LINKFLAGS "${LINKFLAGS}")


### PR DESCRIPTION
Existing netcdf-fortran 4.5.4 patch (from #735) appears to still permit `-lMPI::MPI_Fortran -lnetcdff_c` libraries to be added to `--flibs` output of nf-config in some cases.

This doesn't seem to cause any issues currently in Amanzi or ATS, but when trying to build ELM-ATS, E3SM compilation fails as nf-config is used to determine the netcdf-fortran libraries, which ends up possibly passing libraries that don't exist.

Unable to track down why the existing patch doesn't work in some situations, but this simplified patch is inspired by a change to CMakeLists.txt in Netcdf-fortran for versions > 4.5.4. (e.g., https://github.com/Unidata/netcdf-fortran/pull/322 first released in 4.6.0.)

Local test of these changes on arm Mac seems to be correct now.