### PR TITLE
Changed default floating number to 64

### DIFF
--- a/config/SuperBuild/include/Build_METIS.cmake
+++ b/config/SuperBuild/include/Build_METIS.cmake
@@ -16,6 +16,22 @@ amanzi_tpl_version_write(FILENAME ${TPL_VERSIONS_INCLUDE_FILE}
 set(METIS_DIR ${TPL_INSTALL_PREFIX})
 set(METIS_GKLIB_DIR ${METIS_source_dir}/GKlib)
 
+# --- Set the name of the patch
+set(METIS_patch_file metis-realtype.patch)
+
+# --- Configure the bash patch script
+set(METIS_sh_patch ${METIS_prefix_dir}/metis-patch-step.sh)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/metis-patch-step.sh.in
+               ${METIS_sh_patch}
+               @ONLY)
+# --- Configure the CMake patch step
+set(METIS_cmake_patch ${METIS_prefix_dir}/metis-patch-step.cmake)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/metis-patch-step.cmake.in
+               ${METIS_cmake_patch}
+               @ONLY)
+# --- Set the patch command
+set(METIS_PATCH_COMMAND ${CMAKE_COMMAND} -P ${METIS_cmake_patch})     
+
 # --- Define the CMake configure parameters
 # Note:
 #      CMAKE_CACHE_ARGS requires -DVAR:<TYPE>=VALUE syntax
@@ -37,6 +53,8 @@ ExternalProject_Add(${METIS_BUILD_TARGET}
                     DOWNLOAD_DIR ${TPL_DOWNLOAD_DIR}              # Download directory
                     URL          ${METIS_URL}                     # URL may be a web site OR a local file
                     URL_MD5      ${METIS_MD5_SUM}                 # md5sum of the archive file
+                    # -- Patch 
+                    PATCH_COMMAND  ${METIS_PATCH_COMMAND}
                     # -- Configure
                     SOURCE_DIR   ${METIS_source_dir}              # Source directory
                     CMAKE_ARGS   ${AMANZI_CMAKE_CACHE_ARGS}       # Ensure uniform build

--- a/config/SuperBuild/include/Build_ParMetis.cmake
+++ b/config/SuperBuild/include/Build_ParMetis.cmake
@@ -15,6 +15,24 @@ amanzi_tpl_version_write(FILENAME ${TPL_VERSIONS_INCLUDE_FILE}
 
 set(ParMetis_GKLIB_DIR ${METIS_source_dir}/GKlib)
 set(ParMetis_METIS_DIR ${METIS_source_dir})
+
+# --- Set the name of the patch
+set(ParMetis_patch_file parmetis-realtype.patch)
+
+# --- Configure the bash patch script
+set(ParMetis_sh_patch ${ParMetis_prefix_dir}/parmetis-patch-step.sh)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/parmetis-patch-step.sh.in
+               ${ParMetis_sh_patch}
+               @ONLY)
+# --- Configure the CMake patch step
+set(ParMetis_cmake_patch ${ParMetis_prefix_dir}/parmetis-patch-step.cmake)
+configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/parmetis-patch-step.cmake.in
+               ${ParMetis_cmake_patch}
+               @ONLY)
+
+# --- Set the patch command
+set(ParMetis_PATCH_COMMAND ${CMAKE_COMMAND} -P ${ParMetis_cmake_patch})     
+
 # --- Define the CMake configure parameters
 # Note:
 #      CMAKE_CACHE_ARGS requires -DVAR:<TYPE>=VALUE syntax
@@ -36,6 +54,8 @@ ExternalProject_Add(${ParMetis_BUILD_TARGET}
                     DOWNLOAD_DIR ${TPL_DOWNLOAD_DIR} 
                     URL          ${ParMetis_URL}                      # URL may be a web site OR a local file
                     URL_MD5      ${ParMetis_MD5_SUM}                  # md5sum of the archive file
+                    # -- Patch 
+                    PATCH_COMMAND  ${ParMetis_PATCH_COMMAND}
                     # -- Configure
                     SOURCE_DIR       ${ParMetis_source_dir}           # Source directory
                     CMAKE_CACHE_ARGS ${AMANZI_CMAKE_CACHE_ARGS}       # Ensure uniform build

--- a/config/SuperBuild/templates/metis-patch-step.cmake.in
+++ b/config/SuperBuild/templates/metis-patch-step.cmake.in
@@ -1,0 +1,17 @@
+# CMake Hypre patch file
+
+# Now run the patch script
+set(command sh @METIS_sh_patch@)
+execute_process(
+  COMMAND ${command}
+  WORKING_DIRECTORY "@METIS_source_dir@"
+  RESULT_VARIABLE result
+)
+
+if (result)
+  set(msg "METIS patch command failed")
+  foreach(arg IN LISTS command )
+    set(msg "${msg} '${arg}'")
+  endforeach()
+  message(FATAL_ERROR ${msg})
+endif()  

--- a/config/SuperBuild/templates/metis-patch-step.sh.in
+++ b/config/SuperBuild/templates/metis-patch-step.sh.in
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# CMake generates this file 
+# Replaces each @VAR@ with value of ${VAR}
+
+# Source and build locations
+metis_src_dir=@METIS_source_dir@
+
+OIFS=$IFS
+IFS=";"
+patch_files="@METIS_patch_file@"
+
+for i in ${patch_files}; do
+
+ patch_file=@SuperBuild_SOURCE_DIR@/templates/${i}
+ echo "Applying patch: ${patch_file}"
+
+ if [ ! -e "${patch_file}" ] ; then
+  echo "Patch file ${patch_file} does not exist"
+  exit 10
+ fi
+
+ (cd ${metis_src_dir}; patch -p1 < ${patch_file})
+
+done
+
+IFS=$OIFS
+
+exit $?

--- a/config/SuperBuild/templates/metis-realtype.patch
+++ b/config/SuperBuild/templates/metis-realtype.patch
@@ -1,0 +1,12 @@
+diff --color -ruNbB metis-5.1.0-old/include/metis.h metis-5.1.0-source/include/metis.h
+--- metis-5.1.0-old/include/metis.h	2013-03-30 10:24:45
++++ metis-5.1.0-source/include/metis.h	2025-02-12 13:07:55
+@@ -40,7 +40,7 @@
+    32 : single precission floating point (float)
+    64 : double precission floating point (double)
+ --------------------------------------------------------------------------*/
+-#define REALTYPEWIDTH 32
++#define REALTYPEWIDTH 64
+ 
+ 
+ 

--- a/config/SuperBuild/templates/parmetis-patch-step.cmake.in
+++ b/config/SuperBuild/templates/parmetis-patch-step.cmake.in
@@ -1,0 +1,17 @@
+# CMake Hypre patch file
+
+# Now run the patch script
+set(command sh @ParMetis_sh_patch@)
+execute_process(
+  COMMAND ${command}
+  WORKING_DIRECTORY "@ParMetis_source_dir@"
+  RESULT_VARIABLE result
+)
+
+if (result)
+  set(msg "ParMetis patch command failed")
+  foreach(arg IN LISTS command )
+    set(msg "${msg} '${arg}'")
+  endforeach()
+  message(FATAL_ERROR ${msg})
+endif()  

--- a/config/SuperBuild/templates/parmetis-patch-step.sh.in
+++ b/config/SuperBuild/templates/parmetis-patch-step.sh.in
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+# CMake generates this file 
+# Replaces each @VAR@ with value of ${VAR}
+
+# Source and build locations
+parmetis_src_dir=@ParMetis_source_dir@
+
+OIFS=$IFS
+IFS=";"
+patch_files="@ParMetis_patch_file@"
+
+for i in ${patch_files}; do
+
+ patch_file=@SuperBuild_SOURCE_DIR@/templates/${i}
+ echo "Applying patch: ${patch_file}"
+
+ if [ ! -e "${patch_file}" ] ; then
+  echo "Patch file ${patch_file} does not exist"
+  exit 10
+ fi
+
+ (cd ${parmetis_src_dir}; patch -p1 < ${patch_file})
+
+done
+
+IFS=$OIFS
+
+exit $?

--- a/config/SuperBuild/templates/parmetis-realtype.patch
+++ b/config/SuperBuild/templates/parmetis-realtype.patch
@@ -1,0 +1,12 @@
+diff --color -ruNbB parmetis-4.0.3a-old/metis/include/metis.h parmetis-4.0.3a-source/metis/include/metis.h
+--- parmetis-4.0.3a-old/metis/include/metis.h	2013-03-30 10:24:50
++++ parmetis-4.0.3a-source/metis/include/metis.h	2025-02-12 13:10:01
+@@ -40,7 +40,7 @@
+    32 : single precission floating point (float)
+    64 : double precission floating point (double)
+ --------------------------------------------------------------------------*/
+-#define REALTYPEWIDTH 32
++#define REALTYPEWIDTH 64
+ 
+ 
+ 


### PR DESCRIPTION
Metis defined real_t = float. This PR defines real_t = double. Note that MSTK does allocate real_t arrays. Hence, impact is limited to ParMetis. 