### PR TITLE
reformatting all xml

### DIFF
--- a/demos/phase1/f-area/chemistry/1d-uo2-17-component.xml
+++ b/demos/phase1/f-area/chemistry/1d-uo2-17-component.xml
@@ -1,6 +1,4 @@
-<!-- 1D 5 component UO2 reactive transport problem for comparison to pflotran -->
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="Simple"/>
     <ParameterList name="Simple Mesh Parameters">
@@ -10,107 +8,135 @@
       <Parameter name="Y_Max" type="double" value="1.0"/>
       <Parameter name="Z_Min" type="double" value="0.0"/>
       <Parameter name="Z_Max" type="double" value="1.0"/>
-      <Parameter name="Numer of Cells in X" type="int" value="100"/> 
-      <Parameter name="Numer of Cells in Y" type="int" value="1"/> 
-      <Parameter name="Numer of Cells in Z" type="int" value="1"/> 
+      <Parameter name="Numer of Cells in X" type="int" value="100"/>
+      <Parameter name="Numer of Cells in Y" type="int" value="1"/>
+      <Parameter name="Numer of Cells in Z" type="int" value="1"/>
     </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="47335389"/> <!-- 1.5 years -->
+    <Parameter name="End Time" type="double" value="47335389.0"/>
+    <!-- 1.5 years -->
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="yes"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 0.05 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="1577846.3"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="1577846.3"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="1d-uo2-17-component.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="1"/>
     <Parameter name="Number of component concentrations" type="int" value="17"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
-    <Parameter name="Constant water density" type="double" value="997.16"/> <!-- what value did pflotran use? -->
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- 10 C, what value did pflotran use? --> 
+    <Parameter name="Constant water density" type="double" value="997.16"/>
+    <!-- what value did pflotran use? -->
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- 10 C, what value did pflotran use? -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="0"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="3.02388e-11"/>
-      <Parameter name="Constant Darcy flux x" type="double" value="6.02486e-7"/> <!-- 19 m/year -->
-      <Parameter name="Constant Darcy flux y" type="double" value="0"/>
-      <Parameter name="Constant Darcy flux z" type="double" value="0"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.0000E-05"/> <!-- Na+ -->
-      <Parameter name="Constant component concentration 1" type="double" value="1.0000E-05"/> <!-- Ca++ -->
-      <Parameter name="Constant component concentration 2" type="double" value="8.4757E-08"/> <!-- Fe++ -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211E-04"/> <!-- K+ -->
-      <Parameter name="Constant component concentration 4" type="double" value="6.6779E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683E-05"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 6" type="double" value="1.0000E-05"/> <!-- N2(aq) -->
-      <Parameter name="Constant component concentration 7" type="double" value="1.0000E-05"/> <!-- NO3- -->
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999E-04"/> <!-- HCO3- -->
-      <Parameter name="Constant component concentration 9" type="double" value="1.0000E-05"/> <!-- Cl- -->
-      <Parameter name="Constant component concentration 10" type="double" value="1.0000E-06"/> <!-- SO4-2 -->
-      <Parameter name="Constant component concentration 11" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 12" type="double" value="1.0000E-06"/> <!-- F- -->
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 14" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279E-04"/> <!-- O2(aq) -->
-      <Parameter name="Constant component concentration 16" type="double" value="1.0000E-15"/> <!-- Tracer -->
-   </ParameterList>
+      <Parameter name="Constant Darcy flux x" type="double" value="6.02486e-7"/>
+      <!-- 19 m/year -->
+      <Parameter name="Constant Darcy flux y" type="double" value="0.0"/>
+      <Parameter name="Constant Darcy flux z" type="double" value="0.0"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.000010000"/>
+      <!-- Na+ -->
+      <Parameter name="Constant component concentration 1" type="double" value="0.000010000"/>
+      <!-- Ca++ -->
+      <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
+      <!-- Fe++ -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
+      <!-- K+ -->
+      <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 6" type="double" value="0.000010000"/>
+      <!-- N2(aq) -->
+      <Parameter name="Constant component concentration 7" type="double" value="0.000010000"/>
+      <!-- NO3- -->
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <!-- HCO3- -->
+      <Parameter name="Constant component concentration 9" type="double" value="0.000010000"/>
+      <!-- Cl- -->
+      <Parameter name="Constant component concentration 10" type="double" value="0.0000010000"/>
+      <!-- SO4-2 -->
+      <Parameter name="Constant component concentration 11" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 12" type="double" value="0.0000010000"/>
+      <!-- F- -->
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 14" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <!-- O2(aq) -->
+      <Parameter name="Constant component concentration 16" type="double" value="1.0000e-15"/>
+      <!-- Tracer -->
+    </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="0.5"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-
+    <Parameter name="CFL" type="double" value="0.5"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="1"/>
       <!-- source -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="3"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="3.4363E-02"/> <!-- Na+ -->
-        <Parameter name="Constant component concentration 1" type="double" value="1.2475E-05"/> <!-- Ca++ -->
-        <Parameter name="Constant component concentration 2" type="double" value="3.0440E-05"/> <!-- Fe++ -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.7136E-05"/> <!-- K+ -->
-        <Parameter name="Constant component concentration 4" type="double" value="2.8909E-05"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 5" type="double" value="3.6351E-03"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 6" type="double" value="1.3305E-03"/> <!-- N2(aq) -->
-        <Parameter name="Constant component concentration 7" type="double" value="3.4572E-02"/> <!-- NO3- -->
-        <Parameter name="Constant component concentration 8" type="double" value="2.1830E-03"/> <!-- HCO3- -->
-        <Parameter name="Constant component concentration 9" type="double" value="3.3848E-05"/> <!-- Cl- -->
-        <Parameter name="Constant component concentration 10" type="double" value="6.2463E-04"/> <!-- SO4-2 -->
-        <Parameter name="Constant component concentration 11" type="double" value="7.1028E-05"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 12" type="double" value="7.8954E-05"/> <!-- F- -->
-        <Parameter name="Constant component concentration 13" type="double" value="2.5280E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 14" type="double" value="3.5414E-05"/> <!-- UO2++ -->
-        <Parameter name="Constant component concentration 15" type="double" value="2.6038E-04"/> <!-- O2(aq) -->
-        <Parameter name="Constant component concentration 16" type="double" value="3.5414E-05"/> <!-- Tracer -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="3"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="0.034363"/>
+        <!-- Na+ -->
+        <Parameter name="Constant component concentration 1" type="double" value="0.000012475"/>
+        <!-- Ca++ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.000030440"/>
+        <!-- Fe++ -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000017136"/>
+        <!-- K+ -->
+        <Parameter name="Constant component concentration 4" type="double" value="0.000028909"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 5" type="double" value="0.0036351"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 6" type="double" value="0.0013305"/>
+        <!-- N2(aq) -->
+        <Parameter name="Constant component concentration 7" type="double" value="0.034572"/>
+        <!-- NO3- -->
+        <Parameter name="Constant component concentration 8" type="double" value="0.0021830"/>
+        <!-- HCO3- -->
+        <Parameter name="Constant component concentration 9" type="double" value="0.000033848"/>
+        <!-- Cl- -->
+        <Parameter name="Constant component concentration 10" type="double" value="0.00062463"/>
+        <!-- SO4-2 -->
+        <Parameter name="Constant component concentration 11" type="double" value="0.000071028"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 12" type="double" value="0.000078954"/>
+        <!-- F- -->
+        <Parameter name="Constant component concentration 13" type="double" value="0.00025280"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 14" type="double" value="0.000035414"/>
+        <!-- UO2++ -->
+        <Parameter name="Constant component concentration 15" type="double" value="0.00026038"/>
+        <!-- O2(aq) -->
+        <Parameter name="Constant component concentration 16" type="double" value="0.000035414"/>
+        <!-- Tracer -->
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd" />
-    <Parameter name="Verbosity" type="int" value="1" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd"/>
+    <Parameter name="Verbosity" type="int" value="1"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
-<!--    <Parameter name="Max Time Step (s)" type="double" value="3600.0"/> -->
+    <!--    <Parameter name="Max Time Step (s)" type="double" value="3600.0"/> -->
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Using sorption" type="string" value="yes"/>
     <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
@@ -119,44 +145,52 @@
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="0"/>
       <Parameter name="Number of mesh blocks" type="int" value="1"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="0"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.0"/> <!-- Gibbsite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.15"/> <!-- K-Feldspar -->
-          <Parameter name="Mineral 3" type="double" value="0.0001"/> <!-- Jurbanite -->
-          <Parameter name="Mineral 4" type="double" value="0.1"/> <!-- Ferrihydrite -->
-          <Parameter name="Mineral 5" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 6" type="double" value="0.0001"/> <!-- Schoepite -->
-          <Parameter name="Mineral 7" type="double" value="0.0001"/> <!-- (UO2)3(PO4)2.4H2O -->
-          <Parameter name="Mineral 8" type="double" value="0.0001"/> <!-- Soddyite -->
-          <Parameter name="Mineral 9" type="double" value="0.0001"/> <!-- Calcite -->
-          <Parameter name="Mineral 10" type="double" value="0.0001"/> <!-- Chalcedony -->
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
+          <!-- Gibbsite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.15"/>
+          <!-- K-Feldspar -->
+          <Parameter name="Mineral 3" type="double" value="0.0001"/>
+          <!-- Jurbanite -->
+          <Parameter name="Mineral 4" type="double" value="0.1"/>
+          <!-- Ferrihydrite -->
+          <Parameter name="Mineral 5" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 6" type="double" value="0.0001"/>
+          <!-- Schoepite -->
+          <Parameter name="Mineral 7" type="double" value="0.0001"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 8" type="double" value="0.0001"/>
+          <!-- Soddyite -->
+          <Parameter name="Mineral 9" type="double" value="0.0001"/>
+          <!-- Calcite -->
+          <Parameter name="Mineral 10" type="double" value="0.0001"/>
+          <!-- Chalcedony -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/1d-uo2-5-component.xml
+++ b/demos/phase1/f-area/chemistry/1d-uo2-5-component.xml
@@ -1,6 +1,4 @@
-<!-- 1D 5 component UO2 reactive transport problem for comparison to pflotran -->
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="Simple"/>
     <ParameterList name="Simple Mesh Parameters">
@@ -10,129 +8,158 @@
       <Parameter name="Y_Max" type="double" value="1.0"/>
       <Parameter name="Z_Min" type="double" value="0.0"/>
       <Parameter name="Z_Max" type="double" value="1.0"/>
-      <Parameter name="Numer of Cells in X" type="int" value="100"/> 
-      <Parameter name="Numer of Cells in Y" type="int" value="1"/> 
-      <Parameter name="Numer of Cells in Z" type="int" value="1"/> 
+      <Parameter name="Numer of Cells in X" type="int" value="100"/>
+      <Parameter name="Numer of Cells in Y" type="int" value="1"/>
+      <Parameter name="Numer of Cells in Z" type="int" value="1"/>
     </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="47335389"/> <!-- 1.5 years -->
+    <Parameter name="End Time" type="double" value="47335389.0"/>
+    <!-- 1.5 years -->
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="yes"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 0.05 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="1577846.3"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="1577846.3"/>
     <Parameter name="Gnuplot output" type="bool" value="true"/>
     <!-- <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="1d-uo2-5-component.cgns"/>
     </ParameterList>    -->
-  </ParameterList> 
-
-
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="1"/>
     <Parameter name="Number of component concentrations" type="int" value="5"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
-    <Parameter name="Constant water density" type="double" value="997.16"/> <!-- what value did pflotran use? -->
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- 10 C, what value did pflotran use? --> 
+    <Parameter name="Constant water density" type="double" value="997.16"/>
+    <!-- what value did pflotran use? -->
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- 10 C, what value did pflotran use? -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="0"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="3.02388e-11"/>
-      <Parameter name="Constant Darcy flux x" type="double" value="6.02486e-7"/> <!-- 19 m/year -->
-      <Parameter name="Constant Darcy flux y" type="double" value="0"/>
-      <Parameter name="Constant Darcy flux z" type="double" value="0"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/>  <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="2.1593E-08"/>  <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/>  <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/>  <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/>  <!-- UO2++ -->
-   </ParameterList>
+      <Parameter name="Constant Darcy flux x" type="double" value="6.02486e-7"/>
+      <!-- 19 m/year -->
+      <Parameter name="Constant Darcy flux y" type="double" value="0.0"/>
+      <Parameter name="Constant Darcy flux z" type="double" value="0.0"/>
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="2.1593e-8"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
+    </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="0.5"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-
+    <Parameter name="CFL" type="double" value="0.5"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="6"/>
       <!-- source -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="3"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="2.8909E-05"/>  <!-- Al+++ -->
-	<Parameter name="Component 1" type="double" value="1.2807E-03"/>  <!-- H+ -->
-	<Parameter name="Component 2" type="double" value="7.1028E-05"/>  <!-- HPO4-2 -->
-	<Parameter name="Component 3" type="double" value="2.5280E-04"/>  <!-- SiO2(aq) -->
-	<Parameter name="Component 4" type="double" value="3.5414E-05"/>  <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="3"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000028909"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="0.0012807"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.000071028"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00025280"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="0.000035414"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="0"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5862E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="2.1593E-08"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="0"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5862e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="2.1593e-8"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="1"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5862E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="2.1593e-08"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="1"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5862e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="2.1593e-8"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="2"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5862E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="2.1593E-08"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="2"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5862e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="2.1593e-8"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 4">
-	<Parameter name="Side set ID" type="int" value="4"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5862E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="2.1593E-08"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="4"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5862e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="2.1593e-8"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 5">
-	<Parameter name="Side set ID" type="int" value="5"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5862E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="2.1593E-08"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-     </ParameterList>  
+        <Parameter name="Side set ID" type="int" value="5"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5862e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="2.1593e-8"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd" />
-    <Parameter name="Verbosity" type="int" value="1" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd"/>
+    <Parameter name="Verbosity" type="int" value="1"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
-<!--    <Parameter name="Max Time Step (s)" type="double" value="86400.0"/> -->
+    <!--    <Parameter name="Max Time Step (s)" type="double" value="86400.0"/> -->
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Using sorption" type="string" value="yes"/>
     <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
@@ -141,24 +168,29 @@
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="0"/>
       <Parameter name="Number of mesh blocks" type="int" value="1"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="0"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/>  <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/>  <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/>   <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/fbasin-17-components-025.xml
+++ b/demos/phase1/f-area/chemistry/fbasin-17-components-025.xml
@@ -1,703 +1,673 @@
-<!--
-This is a resolution specific input file. It will only work with our
-current of (12/6/2010) 25 resolution fbasin meshes.  
-
-It is set up for the 17 component problem.
-
-Please adjust the viz dump output, frequency, mesh file location, 
-time limits, etc. 
--->
-
-
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="MOAB"/>
     <ParameterList name="MOAB Mesh Parameters">
       <Parameter name="Exodus file name" type="string" value="./fbasin_unstr_025_V02_128P.h5m"/>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="315360000"/>
+    <Parameter name="End Time" type="double" value="315360000.0"/>
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 100 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="8640000"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="8640000.0"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="fbasin_dump_geh_4.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="5"/>
     <Parameter name="Number of component concentrations" type="int" value="17"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
     <!-- GCU -->
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="20000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- LAZ -->
-    <ParameterList name="Mesh block 2"> 
+    <ParameterList name="Mesh block 2">
       <Parameter name="Mesh block ID" type="int" value="30000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="4.29e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- TCCZ -->
-    <ParameterList name="Mesh block 3"> 
+    <ParameterList name="Mesh block 3">
       <Parameter name="Mesh block ID" type="int" value="40000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="1.98e-14"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- UAZ -->
-    <ParameterList name="Mesh block 4"> 
+    <ParameterList name="Mesh block 4">
       <Parameter name="Mesh block ID" type="int" value="50000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- basin -->
-    <ParameterList name="Mesh block 5"> 
+    <ParameterList name="Mesh block 5">
       <Parameter name="Mesh block ID" type="int" value="70000"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="1.0e-10"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="1.0"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-1"/>
-
+    <Parameter name="CFL" type="double" value="1.0"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.1"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="11"/>
       <!-- infiltration from the basin -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="50001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="3.4363E-02"/>
-	<Parameter name="Component 1" type="double" value="1.2475E-05"/>
-	<Parameter name="Component 2" type="double" value="3.0440E-05"/>
-	<Parameter name="Component 3" type="double" value="1.7136E-05"/>
-	<Parameter name="Component 4" type="double" value="2.8909E-05"/>
-	<Parameter name="Component 5" type="double" value="3.6351E-03"/>
-	<Parameter name="Component 6" type="double" value="1.3305E-03"/>
-	<Parameter name="Component 7" type="double" value="3.4572E-02"/>
-	<Parameter name="Component 8" type="double" value="2.1830E-03"/>
-	<Parameter name="Component 9" type="double" value="3.3848E-05"/>
-	<Parameter name="Component 10" type="double" value="6.2463E-04"/>
-	<Parameter name="Component 11" type="double" value="7.1028E-05"/>
-	<Parameter name="Component 12" type="double" value="7.8954E-05"/>
-	<Parameter name="Component 13" type="double" value="2.5280E-04"/>
-	<Parameter name="Component 14" type="double" value="3.5414E-05"/>
-	<Parameter name="Component 15" type="double" value="2.6038E-04"/>
-	<Parameter name="Component 16" type="double" value="3.5414E-05"/>
-      </ParameterList>  
-      <!-- rain infiltration on the top --> 
+        <Parameter name="Side set ID" type="int" value="50001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.034363"/>
+        <Parameter name="Component 1" type="double" value="0.000012475"/>
+        <Parameter name="Component 2" type="double" value="0.000030440"/>
+        <Parameter name="Component 3" type="double" value="0.000017136"/>
+        <Parameter name="Component 4" type="double" value="0.000028909"/>
+        <Parameter name="Component 5" type="double" value="0.0036351"/>
+        <Parameter name="Component 6" type="double" value="0.0013305"/>
+        <Parameter name="Component 7" type="double" value="0.034572"/>
+        <Parameter name="Component 8" type="double" value="0.0021830"/>
+        <Parameter name="Component 9" type="double" value="0.000033848"/>
+        <Parameter name="Component 10" type="double" value="0.00062463"/>
+        <Parameter name="Component 11" type="double" value="0.000071028"/>
+        <Parameter name="Component 12" type="double" value="0.000078954"/>
+        <Parameter name="Component 13" type="double" value="0.00025280"/>
+        <Parameter name="Component 14" type="double" value="0.000035414"/>
+        <Parameter name="Component 15" type="double" value="0.00026038"/>
+        <Parameter name="Component 16" type="double" value="0.000035414"/>
+      </ParameterList>
+      <!-- rain infiltration on the top -->
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="40033"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="40033"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="30005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="30006"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
       </ParameterList>
       <ParameterList name="BC 4">
-	<Parameter name="Side set ID" type="int" value="30007"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
+        <Parameter name="Side set ID" type="int" value="30007"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
       </ParameterList>
       <!-- inflow -->
       <ParameterList name="BC 5">
-	<Parameter name="Side set ID" type="int" value="10005"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 6">
-	<Parameter name="Side set ID" type="int" value="20004"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 7">
-	<Parameter name="Side set ID" type="int" value="30004"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
-      <!-- should be outflow, but specify BCs anyway -->	
+      <!-- should be outflow, but specify BCs anyway -->
       <ParameterList name="BC 8">
-	<Parameter name="Side set ID" type="int" value="10002"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="10002"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 9">
-	<Parameter name="Side set ID" type="int" value="20001"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
-      </ParameterList>     
+        <Parameter name="Side set ID" type="int" value="20001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
+      </ParameterList>
       <ParameterList name="BC 10">
-	<Parameter name="Side set ID" type="int" value="30001"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
-      </ParameterList>     
+        <Parameter name="Side set ID" type="int" value="30001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd" />
-<!--    <Parameter name="Verbosity" type="int" value="2" />-->
-    <Parameter name="Verbosity" type="int" value="2" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd"/>
+    <!--    <Parameter name="Verbosity" type="int" value="2" />-->
+    <Parameter name="Verbosity" type="int" value="2"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
-    <Parameter name="Using sorption" type="string" value="yes"/>   
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>   
+    <Parameter name="Using sorption" type="string" value="yes"/>
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="11"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="3"/>
       <Parameter name="Number of mesh blocks" type="int" value="5"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="20000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 2"> 
+      <ParameterList name="Mesh block 2">
         <Parameter name="Mesh block ID" type="int" value="30000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 3"> 
+      <ParameterList name="Mesh block 3">
         <Parameter name="Mesh block ID" type="int" value="40000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 4"> 
+      <ParameterList name="Mesh block 4">
         <Parameter name="Mesh block ID" type="int" value="50000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 5"> 
+      <ParameterList name="Mesh block 5">
         <Parameter name="Mesh block ID" type="int" value="70000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-14"/>
-    
     <ParameterList name="Darcy Problem">
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="12"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="10005" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="20004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="30004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="No Flow"/>
-	<Parameter name="Side set ID" type="int" value="40004" />
+        <Parameter name="Type" type="string" value="No Flow"/>
+        <Parameter name="Side set ID" type="int" value="40004"/>
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC04">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="10002" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="10002"/>
+      </ParameterList>
       <ParameterList name="BC05">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="20001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="20001"/>
+      </ParameterList>
       <ParameterList name="BC06">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="30001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="30001"/>
+      </ParameterList>
       <!-- basin, 19 m/y infiltration of water plus pollutants -->
       <ParameterList name="BC07">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-6.0249e-7" />
-	<Parameter name="Side set ID" type="int" value="50001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-6.0249e-7"/>
+        <Parameter name="Side set ID" type="int" value="50001"/>
+      </ParameterList>
       <!-- infiltration on the top, .37338 m/y rain water -->
       <ParameterList name="BC08">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="40033" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="40033"/>
+      </ParameterList>
       <ParameterList name="BC09">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30005" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30005"/>
+      </ParameterList>
       <ParameterList name="BC10">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30006" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+      </ParameterList>
       <ParameterList name="BC11">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30007" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30007"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/fbasin-17-components-100.xml
+++ b/demos/phase1/f-area/chemistry/fbasin-17-components-100.xml
@@ -1,676 +1,647 @@
-<!--
-This is a resolution specific input file. It will only work with our
-current of (12/6/2010) 100 resolution fbasin meshes.  
-
-It is set up for the 17 component problem.
-
-Please adjust the viz dump output, frequency, mesh file location, 
-time limits, etc. 
--->
-
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="MOAB"/>
     <ParameterList name="MOAB Mesh Parameters">
       <Parameter name="Exodus file name" type="string" value="unstruc_100_V02/fbasin_unstr_100_V02_4P.h5m"/>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="315360000"/>
+    <Parameter name="End Time" type="double" value="315360000.0"/>
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 100 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="8640000"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="8640000.0"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="fbasin_dump_geh_4.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="5"/>
     <Parameter name="Number of component concentrations" type="int" value="17"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
     <!-- GCU -->
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="20000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- LAZ -->
-    <ParameterList name="Mesh block 2"> 
+    <ParameterList name="Mesh block 2">
       <Parameter name="Mesh block ID" type="int" value="30000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="4.29e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- TCCZ -->
-    <ParameterList name="Mesh block 3"> 
+    <ParameterList name="Mesh block 3">
       <Parameter name="Mesh block ID" type="int" value="40000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="1.98e-14"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- UAZ -->
-    <ParameterList name="Mesh block 4"> 
+    <ParameterList name="Mesh block 4">
       <Parameter name="Mesh block ID" type="int" value="50000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- basin -->
-    <ParameterList name="Mesh block 5"> 
+    <ParameterList name="Mesh block 5">
       <Parameter name="Mesh block ID" type="int" value="70000"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="1.0e-10"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="1.0"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-1"/>
-
+    <Parameter name="CFL" type="double" value="1.0"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.1"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="10"/>
       <!-- infiltration from the basin -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="50001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="3.4363E-02"/>
-	<Parameter name="Component 1" type="double" value="1.2475E-05"/>
-	<Parameter name="Component 2" type="double" value="3.0440E-05"/>
-	<Parameter name="Component 3" type="double" value="1.7136E-05"/>
-	<Parameter name="Component 4" type="double" value="2.8909E-05"/>
-	<Parameter name="Component 5" type="double" value="3.6351E-03"/>
-	<Parameter name="Component 6" type="double" value="1.3305E-03"/>
-	<Parameter name="Component 7" type="double" value="3.4572E-02"/>
-	<Parameter name="Component 8" type="double" value="2.1830E-03"/>
-	<Parameter name="Component 9" type="double" value="3.3848E-05"/>
-	<Parameter name="Component 10" type="double" value="6.2463E-04"/>
-	<Parameter name="Component 11" type="double" value="7.1028E-05"/>
-	<Parameter name="Component 12" type="double" value="7.8954E-05"/>
-	<Parameter name="Component 13" type="double" value="2.5280E-04"/>
-	<Parameter name="Component 14" type="double" value="3.5414E-05"/>
-	<Parameter name="Component 15" type="double" value="2.6038E-04"/>
-	<Parameter name="Component 16" type="double" value="3.5414E-05"/>
-      </ParameterList>  
-      <!-- rain infiltration on the top --> 
+        <Parameter name="Side set ID" type="int" value="50001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.034363"/>
+        <Parameter name="Component 1" type="double" value="0.000012475"/>
+        <Parameter name="Component 2" type="double" value="0.000030440"/>
+        <Parameter name="Component 3" type="double" value="0.000017136"/>
+        <Parameter name="Component 4" type="double" value="0.000028909"/>
+        <Parameter name="Component 5" type="double" value="0.0036351"/>
+        <Parameter name="Component 6" type="double" value="0.0013305"/>
+        <Parameter name="Component 7" type="double" value="0.034572"/>
+        <Parameter name="Component 8" type="double" value="0.0021830"/>
+        <Parameter name="Component 9" type="double" value="0.000033848"/>
+        <Parameter name="Component 10" type="double" value="0.00062463"/>
+        <Parameter name="Component 11" type="double" value="0.000071028"/>
+        <Parameter name="Component 12" type="double" value="0.000078954"/>
+        <Parameter name="Component 13" type="double" value="0.00025280"/>
+        <Parameter name="Component 14" type="double" value="0.000035414"/>
+        <Parameter name="Component 15" type="double" value="0.00026038"/>
+        <Parameter name="Component 16" type="double" value="0.000035414"/>
+      </ParameterList>
+      <!-- rain infiltration on the top -->
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="40033"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="40033"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="30005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="30006"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
       </ParameterList>
       <!-- inflow -->
       <ParameterList name="BC 4">
-	<Parameter name="Side set ID" type="int" value="10005"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 5">
-	<Parameter name="Side set ID" type="int" value="20004"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 6">
-	<Parameter name="Side set ID" type="int" value="30004"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
-      <!-- should be outflow, but specify BCs anyway -->	
+      <!-- should be outflow, but specify BCs anyway -->
       <ParameterList name="BC 7">
-	<Parameter name="Side set ID" type="int" value="10002"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
+        <Parameter name="Side set ID" type="int" value="10002"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
       </ParameterList>
       <ParameterList name="BC 8">
-	<Parameter name="Side set ID" type="int" value="20001"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
-      </ParameterList>     
+        <Parameter name="Side set ID" type="int" value="20001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
+      </ParameterList>
       <ParameterList name="BC 9">
-	<Parameter name="Side set ID" type="int" value="30001"/>
-	<Parameter name="Type" type="string" value="Constant"/>      
-	<Parameter name="Component 0" type="double" value="1.e-5"/>
-	<Parameter name="Component 1" type="double" value="1.e-5"/>
-	<Parameter name="Component 2" type="double" value="8.4757e-8"/>
-	<Parameter name="Component 3" type="double" value="1.9211e-4"/>
-	<Parameter name="Component 4" type="double" value="6.6779e-9"/>
-	<Parameter name="Component 5" type="double" value="1.2683e-5"/>
-	<Parameter name="Component 6" type="double" value="1.e-5"/>
-	<Parameter name="Component 7" type="double" value="1.e-5"/>
-	<Parameter name="Component 8" type="double" value="2.0999e-4"/>
-	<Parameter name="Component 9" type="double" value="1.e-5"/>
-	<Parameter name="Component 10" type="double" value="1.e-6"/>
-	<Parameter name="Component 11" type="double" value="1.e-6"/>
-	<Parameter name="Component 12" type="double" value="1.e-6"/>
-	<Parameter name="Component 13" type="double" value="1.8703e-4"/>
-	<Parameter name="Component 14" type="double" value="1.e-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279e-4"/>
-	<Parameter name="Component 16" type="double" value="1.e-15"/>
-      </ParameterList>     
+        <Parameter name="Side set ID" type="int" value="30001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.00001"/>
+        <Parameter name="Component 1" type="double" value="0.00001"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.00001"/>
+        <Parameter name="Component 7" type="double" value="0.00001"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.00001"/>
+        <Parameter name="Component 10" type="double" value="0.000001"/>
+        <Parameter name="Component 11" type="double" value="0.000001"/>
+        <Parameter name="Component 12" type="double" value="0.000001"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1e-15"/>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd" />
-<!--    <Parameter name="Verbosity" type="int" value="2" />-->
-    <Parameter name="Verbosity" type="int" value="2" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd"/>
+    <!--    <Parameter name="Verbosity" type="int" value="2" />-->
+    <Parameter name="Verbosity" type="int" value="2"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
-    <Parameter name="Using sorption" type="string" value="yes"/>   
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>   
+    <Parameter name="Using sorption" type="string" value="yes"/>
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="11"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="3"/>
       <Parameter name="Number of mesh blocks" type="int" value="5"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="20000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 2"> 
+      <ParameterList name="Mesh block 2">
         <Parameter name="Mesh block ID" type="int" value="30000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 3"> 
+      <ParameterList name="Mesh block 3">
         <Parameter name="Mesh block ID" type="int" value="40000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 4"> 
+      <ParameterList name="Mesh block 4">
         <Parameter name="Mesh block ID" type="int" value="50000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 5"> 
+      <ParameterList name="Mesh block 5">
         <Parameter name="Mesh block ID" type="int" value="70000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-14"/>
-    
     <ParameterList name="Darcy Problem">
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="11"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="10005" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="20004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="30004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="No Flow"/>
-	<Parameter name="Side set ID" type="int" value="40004" />
+        <Parameter name="Type" type="string" value="No Flow"/>
+        <Parameter name="Side set ID" type="int" value="40004"/>
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC04">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="10002" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="10002"/>
+      </ParameterList>
       <ParameterList name="BC05">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="20001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="20001"/>
+      </ParameterList>
       <ParameterList name="BC06">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="30001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="30001"/>
+      </ParameterList>
       <!-- basin, 19 m/y infiltration of water plus pollutants -->
       <ParameterList name="BC07">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-6.0249e-7" />
-	<Parameter name="Side set ID" type="int" value="50001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-6.0249e-7"/>
+        <Parameter name="Side set ID" type="int" value="50001"/>
+      </ParameterList>
       <!-- infiltration on the top, .37338 m/y rain water -->
       <ParameterList name="BC08">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="40033" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="40033"/>
+      </ParameterList>
       <ParameterList name="BC09">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30005" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30005"/>
+      </ParameterList>
       <ParameterList name="BC10">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30006" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/fbasin-5-components-025.xml
+++ b/demos/phase1/f-area/chemistry/fbasin-5-components-025.xml
@@ -1,411 +1,501 @@
-<!--
-This is a resolution specific input file. It will only work with our
-current of (12/6/2010) 25 resolution fbasin meshes.  
-
-It is set up for the five component problem.
-
-Please adjust the viz dump output, frequency, mesh file location, 
-time limits, etc. 
--->
-
-
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="MOAB"/>
     <ParameterList name="MOAB Mesh Parameters">
       <Parameter name="Exodus file name" type="string" value="./fbasin_unstr_025_V02_128P.h5m"/>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="315360000"/>
+    <Parameter name="End Time" type="double" value="315360000.0"/>
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 10 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="8640000"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="8640000.0"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="fbasin-5-component-128.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="5"/>
     <Parameter name="Number of component concentrations" type="int" value="5"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
     <!-- GCU -->
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="20000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- LAZ -->
-    <ParameterList name="Mesh block 2"> 
+    <ParameterList name="Mesh block 2">
       <Parameter name="Mesh block ID" type="int" value="30000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="4.29e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- TCCZ -->
-    <ParameterList name="Mesh block 3"> 
+    <ParameterList name="Mesh block 3">
       <Parameter name="Mesh block ID" type="int" value="40000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="1.98e-14"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- UAZ -->
-    <ParameterList name="Mesh block 4"> 
+    <ParameterList name="Mesh block 4">
       <Parameter name="Mesh block ID" type="int" value="50000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- basin -->
-    <ParameterList name="Mesh block 5"> 
+    <ParameterList name="Mesh block 5">
       <Parameter name="Mesh block ID" type="int" value="70000"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="1.0e-10"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="1.0"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-1"/>
-
+    <Parameter name="CFL" type="double" value="1.0"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.1"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="11"/>
       <!-- infiltration from the basin -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="50001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="2.8909E-05"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="1.2786E-03"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="7.1028E-05"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="2.5280E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="3.5414E-05"/> <!-- UO2++ -->
-      </ParameterList>  
-      <!-- rain infiltration on the top --> 
+        <Parameter name="Side set ID" type="int" value="50001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000028909"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="0.0012786"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.000071028"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00025280"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="0.000035414"/>
+        <!-- UO2++ -->
+      </ParameterList>
+      <!-- rain infiltration on the top -->
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="40049"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="40049"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="30005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="30006"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30006"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 4">
-	<Parameter name="Side set ID" type="int" value="30007"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList>    
+        <Parameter name="Side set ID" type="int" value="30007"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <!-- inflow -->
       <ParameterList name="BC 5">
-	<Parameter name="Side set ID" type="int" value="10005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+        <Parameter name="Side set ID" type="int" value="10005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
       </ParameterList>
       <ParameterList name="BC 6">
-	<Parameter name="Side set ID" type="int" value="20004"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+        <Parameter name="Side set ID" type="int" value="20004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
       </ParameterList>
       <ParameterList name="BC 7">
-	<Parameter name="Side set ID" type="int" value="30004"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+        <Parameter name="Side set ID" type="int" value="30004"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC 8">
-	<Parameter name="Side set ID" type="int" value="10002"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList> 
+        <Parameter name="Side set ID" type="int" value="10002"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 9">
-	<Parameter name="Side set ID" type="int" value="20001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList> 
+        <Parameter name="Side set ID" type="int" value="20001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 10">
-	<Parameter name="Side set ID" type="int" value="30001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-      </ParameterList> 
+        <Parameter name="Side set ID" type="int" value="30001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="6.5874e-9"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="-3.1408e-7"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00018703"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd" />
-<!--    <Parameter name="Verbosity" type="int" value="2" />-->
-    <Parameter name="Verbosity" type="int" value="1" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd"/>
+    <!--    <Parameter name="Verbosity" type="int" value="2" />-->
+    <Parameter name="Verbosity" type="int" value="1"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
-    <Parameter name="Using sorption" type="string" value="yes"/>   
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>   
+    <Parameter name="Using sorption" type="string" value="yes"/>
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="3"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="3"/>
       <Parameter name="Number of mesh blocks" type="int" value="5"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="20000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 2"> 
+      <ParameterList name="Mesh block 2">
         <Parameter name="Mesh block ID" type="int" value="30000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 3"> 
+      <ParameterList name="Mesh block 3">
         <Parameter name="Mesh block ID" type="int" value="40000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 4"> 
+      <ParameterList name="Mesh block 4">
         <Parameter name="Mesh block ID" type="int" value="50000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 5"> 
+      <ParameterList name="Mesh block 5">
         <Parameter name="Mesh block ID" type="int" value="70000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-14"/>
-    
     <ParameterList name="Darcy Problem">
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="12"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="10005" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="20004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="30004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="No Flow"/>
-	<Parameter name="Side set ID" type="int" value="40004" />
+        <Parameter name="Type" type="string" value="No Flow"/>
+        <Parameter name="Side set ID" type="int" value="40004"/>
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC04">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="10002" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="10002"/>
+      </ParameterList>
       <ParameterList name="BC05">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="20001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="20001"/>
+      </ParameterList>
       <ParameterList name="BC06">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="30001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="30001"/>
+      </ParameterList>
       <!-- basin, 19 m/y infiltration of water plus pollutants -->
       <ParameterList name="BC07">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-6.0249e-7" />
-	<Parameter name="Side set ID" type="int" value="50001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-6.0249e-7"/>
+        <Parameter name="Side set ID" type="int" value="50001"/>
+      </ParameterList>
       <!-- infiltration on the top, .37338 m/y rain water -->
       <ParameterList name="BC08">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="40049" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="40049"/>
+      </ParameterList>
       <ParameterList name="BC09">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30005" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30005"/>
+      </ParameterList>
       <ParameterList name="BC10">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30006" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+      </ParameterList>
       <ParameterList name="BC11">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30007" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30007"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/fbasin-5-components.xml
+++ b/demos/phase1/f-area/chemistry/fbasin-5-components.xml
@@ -1,322 +1,385 @@
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="MOAB"/>
     <ParameterList name="MOAB Mesh Parameters">
       <Parameter name="Exodus file name" type="string" value="./unstruc_400_V02/fbasin_unstr_400_V02.exo"/>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="315360000"/>
+    <Parameter name="End Time" type="double" value="315360000.0"/>
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 10 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="2592000"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="2592000.0"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="fbasin-5-component.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="5"/>
     <Parameter name="Number of component concentrations" type="int" value="5"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
     <!-- GCU -->
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="20000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- LAZ -->
-    <ParameterList name="Mesh block 2"> 
+    <ParameterList name="Mesh block 2">
       <Parameter name="Mesh block ID" type="int" value="30000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="4.29e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- TCCZ -->
-    <ParameterList name="Mesh block 3"> 
+    <ParameterList name="Mesh block 3">
       <Parameter name="Mesh block ID" type="int" value="40000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="1.98e-14"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
     <!-- UAZ -->
-    <ParameterList name="Mesh block 4"> 
+    <ParameterList name="Mesh block 4">
       <Parameter name="Mesh block ID" type="int" value="50000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
-
-    <ParameterList name="Mesh block 5"> 
+    <ParameterList name="Mesh block 5">
       <Parameter name="Mesh block ID" type="int" value="70000"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="1.0e-10"/>
-      <Parameter name="Constant component concentration 0" type="double" value="6.5874E-09"/> <!-- Al+++ -->
-      <Parameter name="Constant component concentration 1" type="double" value="-3.1408E-07"/> <!-- H+ -->
-      <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-      <Parameter name="Constant component concentration 3" type="double" value="1.8703E-04"/> <!-- SiO2(aq) -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
+      <Parameter name="Constant component concentration 0" type="double" value="6.5874e-9"/>
+      <!-- Al+++ -->
+      <Parameter name="Constant component concentration 1" type="double" value="-3.1408e-7"/>
+      <!-- H+ -->
+      <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+      <!-- HPO4-2 -->
+      <Parameter name="Constant component concentration 3" type="double" value="0.00018703"/>
+      <!-- SiO2(aq) -->
+      <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+      <!-- UO2++ -->
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="0.5"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-5"/>
-
+    <Parameter name="CFL" type="double" value="0.5"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="4"/>
       <!-- infiltration from the basin -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="50001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="2.8909E-05"/> <!-- Al+++ -->
-        <Parameter name="Component 1" type="double" value="1.2786E-03"/> <!-- H+ -->
-        <Parameter name="Component 2" type="double" value="7.1028E-05"/> <!-- HPO4-2 -->
-        <Parameter name="Component 3" type="double" value="2.5280E-04"/> <!-- SiO2(aq) -->
-        <Parameter name="Component 4" type="double" value="3.5414E-05"/> <!-- UO2++ -->
-      </ParameterList>  
-      <!-- rain infiltration on the top --> 
+        <Parameter name="Side set ID" type="int" value="50001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000028909"/>
+        <!-- Al+++ -->
+        <Parameter name="Component 1" type="double" value="0.0012786"/>
+        <!-- H+ -->
+        <Parameter name="Component 2" type="double" value="0.000071028"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Component 3" type="double" value="0.00025280"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Component 4" type="double" value="0.000035414"/>
+        <!-- UO2++ -->
+      </ParameterList>
+      <!-- rain infiltration on the top -->
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="40011"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="40011"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="30005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="30006"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Constant component concentration 0" type="double" value="1.0000E-12"/> <!-- Al+++ -->
-        <Parameter name="Constant component concentration 1" type="double" value="-1.1407E-09"/> <!-- H+ -->
-        <Parameter name="Constant component concentration 2" type="double" value="1.0000E-06"/> <!-- HPO4-2 -->
-        <Parameter name="Constant component concentration 3" type="double" value="1.0000E-05"/> <!-- SiO2(aq) -->
-        <Parameter name="Constant component concentration 4" type="double" value="1.0000E-15"/> <!-- UO2++ -->
-
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30006"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Constant component concentration 0" type="double" value="1.0000e-12"/>
+        <!-- Al+++ -->
+        <Parameter name="Constant component concentration 1" type="double" value="-1.1407e-9"/>
+        <!-- H+ -->
+        <Parameter name="Constant component concentration 2" type="double" value="0.0000010000"/>
+        <!-- HPO4-2 -->
+        <Parameter name="Constant component concentration 3" type="double" value="0.000010000"/>
+        <!-- SiO2(aq) -->
+        <Parameter name="Constant component concentration 4" type="double" value="1.0000e-15"/>
+        <!-- UO2++ -->
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd" />
-<!--    <Parameter name="Verbosity" type="int" value="2" />-->
-    <Parameter name="Verbosity" type="int" value="1" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-5-component.bgd"/>
+    <!--    <Parameter name="Verbosity" type="int" value="2" />-->
+    <Parameter name="Verbosity" type="int" value="1"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
-    <Parameter name="Using sorption" type="string" value="yes"/>   
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>   
+    <Parameter name="Using sorption" type="string" value="yes"/>
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="3"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="3"/>
       <Parameter name="Number of mesh blocks" type="int" value="5"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="20000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 2"> 
+      <ParameterList name="Mesh block 2">
         <Parameter name="Mesh block ID" type="int" value="30000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 3"> 
+      <ParameterList name="Mesh block 3">
         <Parameter name="Mesh block ID" type="int" value="40000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 4"> 
+      <ParameterList name="Mesh block 4">
         <Parameter name="Mesh block ID" type="int" value="50000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 5"> 
+      <ParameterList name="Mesh block 5">
         <Parameter name="Mesh block ID" type="int" value="70000"/>
         <ParameterList name="Free Ion Species">
-	  <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>  <!-- Al+++ -->
-	  <Parameter name="Free Ion Species 1" type="double" value="3.16772e-08"/>  <!-- H+ -->
-	  <Parameter name="Free Ion Species 2" type="double" value="1.00000e-06"/>  <!-- HPO4-2 -->
-	  <Parameter name="Free Ion Species 3" type="double" value="1.87000e-04"/>  <!-- SiO2(aq) -->
-	  <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>  <!-- UO2++ -->
+          <Parameter name="Free Ion Species 0" type="double" value="4.36476e-16"/>
+          <!-- Al+++ -->
+          <Parameter name="Free Ion Species 1" type="double" value="3.16772e-8"/>
+          <!-- H+ -->
+          <Parameter name="Free Ion Species 2" type="double" value="0.00000100000"/>
+          <!-- HPO4-2 -->
+          <Parameter name="Free Ion Species 3" type="double" value="0.000187000"/>
+          <!-- SiO2(aq) -->
+          <Parameter name="Free Ion Species 4" type="double" value="1.84374e-20"/>
+          <!-- UO2++ -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.15"/> <!-- Kaolinite -->
-          <Parameter name="Mineral 1" type="double" value="0.21"/> <!-- Quartz -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/> <!-- (UO2)3(PO4)2.4H2O -->
+          <Parameter name="Mineral 0" type="double" value="0.15"/>
+          <!-- Kaolinite -->
+          <Parameter name="Mineral 1" type="double" value="0.21"/>
+          <!-- Quartz -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- (UO2)3(PO4)2.4H2O -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-14"/>
-    
     <ParameterList name="Darcy Problem">
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="9"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="10005" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="20004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="30004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="No Flow"/>
-	<Parameter name="Side set ID" type="int" value="40004" />
+        <Parameter name="Type" type="string" value="No Flow"/>
+        <Parameter name="Side set ID" type="int" value="40004"/>
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC04">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="102" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="102"/>
+      </ParameterList>
       <!-- basin, 19 m/y infiltration of water plus pollutants -->
       <ParameterList name="BC05">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-6.0249e-7" />
-	<Parameter name="Side set ID" type="int" value="50001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-6.0249e-7"/>
+        <Parameter name="Side set ID" type="int" value="50001"/>
+      </ParameterList>
       <!-- infiltration on the top, .37338 m/y rain water -->
       <ParameterList name="BC06">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="40011" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="40011"/>
+      </ParameterList>
       <ParameterList name="BC07">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30005" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30005"/>
+      </ParameterList>
       <ParameterList name="BC08">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30006" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase1/f-area/chemistry/fbasin_geh.xml
+++ b/demos/phase1/f-area/chemistry/fbasin_geh.xml
@@ -1,527 +1,508 @@
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="MOAB"/>
     <ParameterList name="MOAB Mesh Parameters">
       <Parameter name="Exodus file name" type="string" value="./unstruc_200_V02/fbasin_unstr_200_V02_4P.h5m"/>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="315360000"/>
+    <Parameter name="End Time" type="double" value="315360000.0"/>
     <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
     <!-- dump every 10 days -->
-    <Parameter name="Viz dump time frequency" type="double" value="2592000"/> 
+    <Parameter name="Viz dump time frequency" type="double" value="2592000.0"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="fbasin_dump.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="5"/>
     <Parameter name="Number of component concentrations" type="int" value="17"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
     <!-- GCU -->
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="20000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- LAZ -->
-    <ParameterList name="Mesh block 2"> 
+    <ParameterList name="Mesh block 2">
       <Parameter name="Mesh block ID" type="int" value="30000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="4.29e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- TCCZ -->
-    <ParameterList name="Mesh block 3"> 
+    <ParameterList name="Mesh block 3">
       <Parameter name="Mesh block ID" type="int" value="40000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="1.98e-14"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
     <!-- UAZ -->
-    <ParameterList name="Mesh block 4"> 
+    <ParameterList name="Mesh block 4">
       <Parameter name="Mesh block ID" type="int" value="50000"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-11"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
-
-    <ParameterList name="Mesh block 5"> 
+    <ParameterList name="Mesh block 5">
       <Parameter name="Mesh block ID" type="int" value="70000"/>
       <Parameter name="Constant porosity" type="double" value="0.2"/>
       <Parameter name="Constant permeability" type="double" value="1.0e-10"/>
-      <Parameter name="Constant component concentration 0" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 1" type="double" value="1.e-5"/>
+      <Parameter name="Constant component concentration 0" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 1" type="double" value="0.00001"/>
       <Parameter name="Constant component concentration 2" type="double" value="8.4757e-8"/>
-      <Parameter name="Constant component concentration 3" type="double" value="1.9211e-4"/>
+      <Parameter name="Constant component concentration 3" type="double" value="0.00019211"/>
       <Parameter name="Constant component concentration 4" type="double" value="6.6779e-9"/>
-      <Parameter name="Constant component concentration 5" type="double" value="1.2683e-5"/>
-      <Parameter name="Constant component concentration 6" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 7" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 8" type="double" value="2.0999e-4"/>
-      <Parameter name="Constant component concentration 9" type="double" value="1.e-5"/>
-      <Parameter name="Constant component concentration 10" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 11" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 12" type="double" value="1.e-6"/>
-      <Parameter name="Constant component concentration 13" type="double" value="1.8703e-4"/>
-      <Parameter name="Constant component concentration 14" type="double" value="1.e-15"/>
-      <Parameter name="Constant component concentration 15" type="double" value="2.5279e-4"/>
-      <Parameter name="Constant component concentration 16" type="double" value="1.e-15"/>
+      <Parameter name="Constant component concentration 5" type="double" value="0.000012683"/>
+      <Parameter name="Constant component concentration 6" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 7" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 8" type="double" value="0.00020999"/>
+      <Parameter name="Constant component concentration 9" type="double" value="0.00001"/>
+      <Parameter name="Constant component concentration 10" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 11" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 12" type="double" value="0.000001"/>
+      <Parameter name="Constant component concentration 13" type="double" value="0.00018703"/>
+      <Parameter name="Constant component concentration 14" type="double" value="1e-15"/>
+      <Parameter name="Constant component concentration 15" type="double" value="0.00025279"/>
+      <Parameter name="Constant component concentration 16" type="double" value="1e-15"/>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="0.5"/>   
-    <Parameter name="enable internal tests" type="string" value="yes"/>   
-    <Parameter name="verbosity level" type="int" value="10"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-5"/>
-
+    <Parameter name="CFL" type="double" value="0.5"/>
+    <Parameter name="enable internal tests" type="string" value="yes"/>
+    <Parameter name="verbosity level" type="int" value="10"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="4"/>
       <!-- infiltration from the basin -->
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="50001"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="3.4363E-02"/>
-	<Parameter name="Component 1" type="double" value="1.2475E-05"/>
-	<Parameter name="Component 2" type="double" value="3.0440E-05"/>
-	<Parameter name="Component 3" type="double" value="1.7136E-05"/>
-	<Parameter name="Component 4" type="double" value="2.8909E-05"/>
-	<Parameter name="Component 5" type="double" value="3.6351E-03"/>
-	<Parameter name="Component 6" type="double" value="1.3305E-03"/>
-	<Parameter name="Component 7" type="double" value="3.4572E-02"/>
-	<Parameter name="Component 8" type="double" value="2.1830E-03"/>
-	<Parameter name="Component 9" type="double" value="3.3848E-05"/>
-	<Parameter name="Component 10" type="double" value="6.2463E-04"/>
-	<Parameter name="Component 11" type="double" value="7.1028E-05"/>
-	<Parameter name="Component 12" type="double" value="7.8954E-05"/>
-	<Parameter name="Component 13" type="double" value="2.5280E-04"/>
-	<Parameter name="Component 14" type="double" value="3.5414E-05"/>
-	<Parameter name="Component 15" type="double" value="2.6038E-04"/>
-	<Parameter name="Component 16" type="double" value="3.5414E-05"/>
-      </ParameterList>  
-      <!-- rain infiltration on the top --> 
+        <Parameter name="Side set ID" type="int" value="50001"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.034363"/>
+        <Parameter name="Component 1" type="double" value="0.000012475"/>
+        <Parameter name="Component 2" type="double" value="0.000030440"/>
+        <Parameter name="Component 3" type="double" value="0.000017136"/>
+        <Parameter name="Component 4" type="double" value="0.000028909"/>
+        <Parameter name="Component 5" type="double" value="0.0036351"/>
+        <Parameter name="Component 6" type="double" value="0.0013305"/>
+        <Parameter name="Component 7" type="double" value="0.034572"/>
+        <Parameter name="Component 8" type="double" value="0.0021830"/>
+        <Parameter name="Component 9" type="double" value="0.000033848"/>
+        <Parameter name="Component 10" type="double" value="0.00062463"/>
+        <Parameter name="Component 11" type="double" value="0.000071028"/>
+        <Parameter name="Component 12" type="double" value="0.000078954"/>
+        <Parameter name="Component 13" type="double" value="0.00025280"/>
+        <Parameter name="Component 14" type="double" value="0.000035414"/>
+        <Parameter name="Component 15" type="double" value="0.00026038"/>
+        <Parameter name="Component 16" type="double" value="0.000035414"/>
+      </ParameterList>
+      <!-- rain infiltration on the top -->
       <ParameterList name="BC 1">
-	<Parameter name="Side set ID" type="int" value="40011"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="40011"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 2">
-	<Parameter name="Side set ID" type="int" value="30005"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30005"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
       <ParameterList name="BC 3">
-	<Parameter name="Side set ID" type="int" value="30006"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-	<Parameter name="Component 0" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 1" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 2" type="double" value="8.4757E-08"/>
-	<Parameter name="Component 3" type="double" value="1.9211E-04"/>
-	<Parameter name="Component 4" type="double" value="6.6779E-09"/>
-	<Parameter name="Component 5" type="double" value="1.2683E-05"/>
-	<Parameter name="Component 6" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 7" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 8" type="double" value="2.0999E-04"/>
-	<Parameter name="Component 9" type="double" value="1.0000E-05"/>
-	<Parameter name="Component 10" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 11" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 12" type="double" value="1.0000E-06"/>
-	<Parameter name="Component 13" type="double" value="1.8703E-04"/>
-	<Parameter name="Component 14" type="double" value="1.0000E-15"/>
-	<Parameter name="Component 15" type="double" value="2.5279E-04"/>
-	<Parameter name="Component 16" type="double" value="1.0000E-15"/>
-      </ParameterList>        
+        <Parameter name="Side set ID" type="int" value="30006"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="0.000010000"/>
+        <Parameter name="Component 1" type="double" value="0.000010000"/>
+        <Parameter name="Component 2" type="double" value="8.4757e-8"/>
+        <Parameter name="Component 3" type="double" value="0.00019211"/>
+        <Parameter name="Component 4" type="double" value="6.6779e-9"/>
+        <Parameter name="Component 5" type="double" value="0.000012683"/>
+        <Parameter name="Component 6" type="double" value="0.000010000"/>
+        <Parameter name="Component 7" type="double" value="0.000010000"/>
+        <Parameter name="Component 8" type="double" value="0.00020999"/>
+        <Parameter name="Component 9" type="double" value="0.000010000"/>
+        <Parameter name="Component 10" type="double" value="0.0000010000"/>
+        <Parameter name="Component 11" type="double" value="0.0000010000"/>
+        <Parameter name="Component 12" type="double" value="0.0000010000"/>
+        <Parameter name="Component 13" type="double" value="0.00018703"/>
+        <Parameter name="Component 14" type="double" value="1.0000e-15"/>
+        <Parameter name="Component 15" type="double" value="0.00025279"/>
+        <Parameter name="Component 16" type="double" value="1.0000e-15"/>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd" />
-<!--    <Parameter name="Verbosity" type="int" value="2" />-->
-    <Parameter name="Verbosity" type="int" value="8" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="fbasin-uo2-17-component.bgd"/>
+    <!--    <Parameter name="Verbosity" type="int" value="2" />-->
+    <Parameter name="Verbosity" type="int" value="8"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
-    <Parameter name="Using sorption" type="string" value="yes"/>   
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>   
+    <Parameter name="Using sorption" type="string" value="yes"/>
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="11"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="3"/>
       <Parameter name="Number of mesh blocks" type="int" value="5"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="20000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 2"> 
+      <ParameterList name="Mesh block 2">
         <Parameter name="Mesh block ID" type="int" value="30000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 3"> 
+      <ParameterList name="Mesh block 3">
         <Parameter name="Mesh block ID" type="int" value="40000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 4"> 
+      <ParameterList name="Mesh block 4">
         <Parameter name="Mesh block ID" type="int" value="50000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Mesh block 5"> 
+      <ParameterList name="Mesh block 5">
         <Parameter name="Mesh block ID" type="int" value="70000"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="9.9969E-06"/>
-          <Parameter name="Free Ion Species 1" type="double" value="9.9746E-06"/>
-          <Parameter name="Free Ion Species 2" type="double" value="2.2405E-18"/>
-          <Parameter name="Free Ion Species 3" type="double" value="1.8874E-04"/>
-          <Parameter name="Free Ion Species 4" type="double" value="5.2970E-16"/>
-          <Parameter name="Free Ion Species 5" type="double" value="3.2759E-08"/>
-          <Parameter name="Free Ion Species 6" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 7" type="double" value="1.0000E-05"/>
-          <Parameter name="Free Ion Species 8" type="double" value="1.9282E-04"/>
-          <Parameter name="Free Ion Species 9" type="double" value="9.9999E-06"/>
-          <Parameter name="Free Ion Species 10" type="double" value="9.9860E-07"/>
-          <Parameter name="Free Ion Species 11" type="double" value="9.9886E-07"/>
-          <Parameter name="Free Ion Species 12" type="double" value="1.0000E-06"/>
-          <Parameter name="Free Ion Species 13" type="double" value="1.8703E-04"/>
-          <Parameter name="Free Ion Species 14" type="double" value="1.7609E-20"/>
-          <Parameter name="Free Ion Species 15" type="double" value="2.5277E-04"/>
-          <Parameter name="Free Ion Species 16" type="double" value="1.0000E-15"/>
+          <Parameter name="Free Ion Species 0" type="double" value="0.0000099969"/>
+          <Parameter name="Free Ion Species 1" type="double" value="0.0000099746"/>
+          <Parameter name="Free Ion Species 2" type="double" value="2.2405e-18"/>
+          <Parameter name="Free Ion Species 3" type="double" value="0.00018874"/>
+          <Parameter name="Free Ion Species 4" type="double" value="5.2970e-16"/>
+          <Parameter name="Free Ion Species 5" type="double" value="3.2759e-8"/>
+          <Parameter name="Free Ion Species 6" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 7" type="double" value="0.000010000"/>
+          <Parameter name="Free Ion Species 8" type="double" value="0.00019282"/>
+          <Parameter name="Free Ion Species 9" type="double" value="0.0000099999"/>
+          <Parameter name="Free Ion Species 10" type="double" value="9.9860e-7"/>
+          <Parameter name="Free Ion Species 11" type="double" value="9.9886e-7"/>
+          <Parameter name="Free Ion Species 12" type="double" value="0.0000010000"/>
+          <Parameter name="Free Ion Species 13" type="double" value="0.00018703"/>
+          <Parameter name="Free Ion Species 14" type="double" value="1.7609e-20"/>
+          <Parameter name="Free Ion Species 15" type="double" value="0.00025277"/>
+          <Parameter name="Free Ion Species 16" type="double" value="1.0000e-15"/>
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0."/>
+          <Parameter name="Mineral 0" type="double" value="0.0"/>
           <Parameter name="Mineral 1" type="double" value="0.21"/>
           <Parameter name="Mineral 2" type="double" value="0.15"/>
-          <Parameter name="Mineral 3" type="double" value="0."/>
+          <Parameter name="Mineral 3" type="double" value="0.0"/>
           <Parameter name="Mineral 4" type="double" value="0.1"/>
           <Parameter name="Mineral 5" type="double" value="0.15"/>
-          <Parameter name="Mineral 6" type="double" value="0."/>
-          <Parameter name="Mineral 7" type="double" value="0."/>
-          <Parameter name="Mineral 8" type="double" value="0."/>
-          <Parameter name="Mineral 9" type="double" value="0."/>
-          <Parameter name="Mineral 10" type="double" value="0."/>
+          <Parameter name="Mineral 6" type="double" value="0.0"/>
+          <Parameter name="Mineral 7" type="double" value="0.0"/>
+          <Parameter name="Mineral 8" type="double" value="0.0"/>
+          <Parameter name="Mineral 9" type="double" value="0.0"/>
+          <Parameter name="Mineral 10" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-14"/>
-    
     <ParameterList name="Darcy Problem">
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="9"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="10005" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="10005"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="20004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="20004"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="60.0" />
-	<Parameter name="Side set ID" type="int" value="30004" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="60.0"/>
+        <Parameter name="Side set ID" type="int" value="30004"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="No Flow"/>
-	<Parameter name="Side set ID" type="int" value="40004" />
+        <Parameter name="Type" type="string" value="No Flow"/>
+        <Parameter name="Side set ID" type="int" value="40004"/>
       </ParameterList>
       <!-- outflow -->
       <ParameterList name="BC04">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="48.0" />
-	<Parameter name="Side set ID" type="int" value="102" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="48.0"/>
+        <Parameter name="Side set ID" type="int" value="102"/>
+      </ParameterList>
       <!-- basin, 19 m/y infiltration of water plus pollutants -->
       <ParameterList name="BC05">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-6.0249e-7" />
-	<Parameter name="Side set ID" type="int" value="50001" />
-      </ParameterList>  
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-6.0249e-7"/>
+        <Parameter name="Side set ID" type="int" value="50001"/>
+      </ParameterList>
       <!-- infiltration on the top, .37338 m/y rain water -->
       <ParameterList name="BC06">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="40011" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="40011"/>
+      </ParameterList>
       <ParameterList name="BC07">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30005" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30005"/>
+      </ParameterList>
       <ParameterList name="BC08">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1.1840e-08" />
-	<Parameter name="Side set ID" type="int" value="30006" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1.1840e-8"/>
+        <Parameter name="Side set ID" type="int" value="30006"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase1/f-area/richards/block.xml
+++ b/demos/phase1/f-area/richards/block.xml
@@ -1,14 +1,11 @@
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <Parameter name="Mesh Class" type="string" value="STK"/>
-    <Parameter name="STK File name"  type="string" value="block-basin.exo"/>
+    <Parameter name="STK File name" type="string" value="block-basin.exo"/>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="1e200"/>
+    <Parameter name="End Time" type="double" value="1e+200"/>
     <Parameter name="End Cycle" type="int" value="1000"/>
     <Parameter name="disable Flow_PK" type="string" value="no"/>
     <Parameter name="Flow model" type="string" value="Richards"/>
@@ -17,120 +14,109 @@
     <Parameter name="Viz dump cycle frequency" type="int" value="10"/>
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="block.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-  
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="1"/>
     <Parameter name="Number of component concentrations" type="int" value="1"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
     <Parameter name="Constant water density" type="double" value="1000.0"/>
-    <Parameter name="Constant viscosity" type="double" value="0.001308"/> <!-- water at 10 Celsius --> 
+    <Parameter name="Constant viscosity" type="double" value="0.001308"/>
+    <!-- water at 10 Celsius -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
     <Parameter name="Gravity z" type="double" value="-9.8"/>
-
-    <ParameterList name="Mesh block 1"> 
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="1"/>
       <Parameter name="Constant porosity" type="double" value="0.39"/>
       <Parameter name="Constant permeability" type="double" value="3.3e-17"/>
       <Parameter name="Constant component concentration 0" type="double" value="0.01"/>
     </ParameterList>
-  </ParameterList>  
-
-
+  </ParameterList>
   <ParameterList name="Flow">
     <Parameter name="Max Iterations" type="int" value="500"/>
     <Parameter name="Error Tolerance" type="double" value="1.0e-15"/>
     <Parameter name="Nonlinear Solver" type="string" value="NLK"/>
     <Parameter name="Preconditioner Update Frequency" type="int" value="10"/>
-    
     <ParameterList name="NKADirection">
-      <Parameter name="vtol" type="double" value="1e-2"/>
-      <Parameter name="maxv" type="int" value="20"/>      
-    </ParameterList> 
-
+      <Parameter name="vtol" type="double" value="0.01"/>
+      <Parameter name="maxv" type="int" value="20"/>
+    </ParameterList>
     <ParameterList name="Richards Problem">
       <Parameter name="van Genuchten m" type="double" value="0.5"/>
       <Parameter name="van Genuchten alpha" type="double" value="0.00005"/>
       <Parameter name="van Genuchten residual saturation" type="double" value="0.40969"/>
       <Parameter name="atmospheric pressure" type="double" value="1.020e+5"/>
-
       <ParameterList name="Diffusion Preconditioner">
-	<ParameterList name="ML Parameters">
-  	  <Parameter name="max levels" type="int" value="40"/>
-	  <Parameter name="prec type" type="string" value="MGV"/>
-	  <Parameter name="increasing or decreasing" type="string" value="increasing"/>
-	  <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-	  <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
-	  <Parameter name="aggregation: threshold" type="double" value="0.03"/>
-	  <Parameter name="eigen-analysis: type" type="string" value="cg"/>
-	  <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
-	  <Parameter name="smoother: sweeps" type="int" value="5"/>
-	  <Parameter name="smoother: damping factor" type="double" value="1.0"/>
-	  <Parameter name="smoother: pre or post" type="string" value="both"/>
-	  <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
-	  <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
-	  <Parameter name="coarse: max size" type="int" value="128"/>	   
-	</ParameterList>
+        <ParameterList name="ML Parameters">
+          <Parameter name="max levels" type="int" value="40"/>
+          <Parameter name="prec type" type="string" value="MGV"/>
+          <Parameter name="increasing or decreasing" type="string" value="increasing"/>
+          <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
+          <Parameter name="aggregation: damping factor" type="double" value="1.333"/>
+          <Parameter name="aggregation: threshold" type="double" value="0.03"/>
+          <Parameter name="eigen-analysis: type" type="string" value="cg"/>
+          <Parameter name="eigen-analysis: iterations" type="int" value="20"/>
+          <Parameter name="smoother: sweeps" type="int" value="5"/>
+          <Parameter name="smoother: damping factor" type="double" value="1.0"/>
+          <Parameter name="smoother: pre or post" type="string" value="both"/>
+          <Parameter name="smoother: type" type="string" value="symmetric Gauss-Seidel"/>
+          <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
+          <Parameter name="coarse: max size" type="int" value="128"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Flow BC">
       <Parameter name="number of BCs" type="int" value="4"/>
       <ParameterList name="BC00">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="30.0" />
-	<Parameter name="Side set ID" type="int" value="8" />
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="30.0"/>
+        <Parameter name="Side set ID" type="int" value="8"/>
       </ParameterList>
       <ParameterList name="BC01">
-	<Parameter name="Type" type="string" value="Static Head"/>
-	<Parameter name="BC value" type="double" value="23.3333" />
-	<Parameter name="Side set ID" type="int" value="10" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Static Head"/>
+        <Parameter name="BC value" type="double" value="23.3333"/>
+        <Parameter name="Side set ID" type="int" value="10"/>
+      </ParameterList>
       <ParameterList name="BC02">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1e-11" />
-	<Parameter name="Side set ID" type="int" value="7" />
-      </ParameterList>      
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1e-11"/>
+        <Parameter name="Side set ID" type="int" value="7"/>
+      </ParameterList>
       <ParameterList name="BC03">
-	<Parameter name="Type" type="string" value="Darcy Constant"/>
-	<Parameter name="BC value" type="double" value="-1e-11" />
-	<Parameter name="Side set ID" type="int" value="7" />
-      </ParameterList>      
-     </ParameterList>
+        <Parameter name="Type" type="string" value="Darcy Constant"/>
+        <Parameter name="BC value" type="double" value="-1e-11"/>
+        <Parameter name="Side set ID" type="int" value="7"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="1.0"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="0"/>  
-    <Parameter name="internal tests tolerance" type="double" value="1e-1"/>
-
+    <Parameter name="CFL" type="double" value="1.0"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="0"/>
+    <Parameter name="internal tests tolerance" type="double" value="0.1"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="4"/>
       <ParameterList name="BC 0">
         <Parameter name="Side set ID" type="int" value="8"/>
         <Parameter name="Type" type="string" value="Constant"/>
         <Parameter name="Component 0" type="double" value="0.01"/>
-      </ParameterList>  
+      </ParameterList>
       <ParameterList name="BC 1">
         <Parameter name="Side set ID" type="int" value="10"/>
         <Parameter name="Type" type="string" value="Constant"/>
         <Parameter name="Component 0" type="double" value="0.01"/>
-      </ParameterList>  
+      </ParameterList>
       <ParameterList name="BC 2">
         <Parameter name="Side set ID" type="int" value="6"/>
         <Parameter name="Type" type="string" value="Constant"/>
         <Parameter name="Component 0" type="double" value="0.01"/>
-      </ParameterList>  
+      </ParameterList>
       <ParameterList name="BC 3">
         <Parameter name="Side set ID" type="int" value="7"/>
         <Parameter name="Type" type="string" value="Constant"/>
         <Parameter name="Component 0" type="double" value="1.0"/>
-      </ParameterList>  
-    </ParameterList>   
-  </ParameterList>   
-
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
 </ParameterList>

--- a/demos/phase2/chemistry/1d-decay-sorbed/amanzi-u-1d-decay-sorbed.xml
+++ b/demos/phase2/chemistry/1d-decay-sorbed/amanzi-u-1d-decay-sorbed.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -59,8 +59,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -68,20 +68,20 @@
   <ParameterList name="Regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -92,18 +92,18 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="A(aq)">
-	  <Parameter name="Kd" type="double" value="250.0"/>
-	</ParameterList>
-	<ParameterList name="B(aq)">
-	  <Parameter name="Kd" type="double" value="0.0"/>
-	</ParameterList>
-	<ParameterList name="C(aq)">
-	  <Parameter name="Kd" type="double" value="62.5"/>
-	</ParameterList>
+        <ParameterList name="A(aq)">
+          <Parameter name="Kd" type="double" value="250.0"/>
+        </ParameterList>
+        <ParameterList name="B(aq)">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
+        <ParameterList name="C(aq)">
+          <Parameter name="Kd" type="double" value="62.5"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -111,10 +111,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -136,17 +136,17 @@
           <ParameterList name="Water">
             <ParameterList name="A(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="B(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="C(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -158,33 +158,33 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="A(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-1, 1.e-1}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.1, 0.1}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="B(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="C(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -194,32 +194,32 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="A(aq)">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="B(aq)">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="C(aq)">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -230,29 +230,29 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="decay-linear-sorption"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="ABC-decay-linear-sorption.bgd" />
-    </ParameterList> <!-- Thermodynamic Database -->
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="ABC-decay-linear-sorption.bgd"/>
+    </ParameterList>
+    <!-- Thermodynamic Database -->
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="ABC_decay_linear_sorption.in"/>
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose, debug}" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose, debug}"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
@@ -260,17 +260,23 @@
       <ParameterList name="initial">
         <Parameter name="PFloTran Constraint" type="string" value="initial"/>
         <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
-      </ParameterList> <!-- initial -->
-    </ParameterList> <!-- Initial Conditions -->
+      </ParameterList>
+      <!-- initial -->
+    </ParameterList>
+    <!-- Initial Conditions -->
     <ParameterList name="Boundary Conditions">
       <ParameterList name="East BC">
         <Parameter name="PFloTran Constraint" type="string" value="initial"/>
         <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
-      </ParameterList> <!-- East BC -->
+      </ParameterList>
+      <!-- East BC -->
       <ParameterList name="West BC">
         <Parameter name="PFloTran Constraint" type="string" value="inlet"/>
         <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
-      </ParameterList> <!-- West BC -->
-    </ParameterList> <!-- Boundary Conditions -->
-  </ParameterList> <!-- Chemistry -->
+      </ParameterList>
+      <!-- West BC -->
+    </ParameterList>
+    <!-- Boundary Conditions -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase2/chemistry/amanzi/amanzi-u-1d-eq-surface-complexation.xml
+++ b/demos/phase2/chemistry/amanzi/amanzi-u-1d-eq-surface-complexation.xml
@@ -12,7 +12,7 @@
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="End" type="double" value="3.1536e+7"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -56,8 +56,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -65,32 +65,32 @@
   <ParameterList name="Regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -101,15 +101,15 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Surface Complexation Sites">
-	<ParameterList name=">FeOH_w">
-	  <Parameter name="Site Density" type="double" value="7.63550e4"/>
-	</ParameterList>
-	<ParameterList name=">FeOH_s">
-	  <Parameter name="Site Density" type="double" value="1.90800e3"/>
-	</ParameterList>
+        <ParameterList name="&gt;FeOH_w">
+          <Parameter name="Site Density" type="double" value="76355.0"/>
+        </ParameterList>
+        <ParameterList name="&gt;FeOH_s">
+          <Parameter name="Site Density" type="double" value="1908.00"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
@@ -118,15 +118,15 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Surface Complexation Sites">
-	<ParameterList name=">FeOH_s">
-	  <Parameter name="Site Density" type="double" value="3.816e3"/>
-	</ParameterList>
-	<ParameterList name=">FeOH_w">
-	  <Parameter name="Site Density" type="double" value="3.81775e4"/>
-	</ParameterList>
+        <ParameterList name="&gt;FeOH_s">
+          <Parameter name="Site Density" type="double" value="3816.0"/>
+        </ParameterList>
+        <ParameterList name="&gt;FeOH_w">
+          <Parameter name="Site Density" type="double" value="38177.5"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -134,10 +134,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -147,7 +147,7 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="Solid">
-      <Parameter name="Sorption Sites" type="Array(string)" value="{>FeOH_w, >FeOH_s}"/>
+      <Parameter name="Sorption Sites" type="Array(string)" value="{&gt;FeOH_w, &gt;FeOH_s}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Initial Conditions">
@@ -162,22 +162,22 @@
           <ParameterList name="Water">
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0e-06"/>
+                <Parameter name="Value" type="double" value="0.0000010"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0e-6"/>
+                <Parameter name="Value" type="double" value="0.0000010"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="NO3-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="4.0e-6"/>
+                <Parameter name="Value" type="double" value="0.0000040"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Zn++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0e-6"/>
+                <Parameter name="Value" type="double" value="0.0000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -191,8 +191,8 @@
       <ParameterList name="BC: Flux">
         <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 1317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 1.317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -201,28 +201,28 @@
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0e-5,1.0e-5}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010, 0.000010}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0e-01,1.0e-01}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.10, 0.10}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0003e-01,1.0003e-01}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.10003, 0.10003}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Zn++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0e-05,1.0e-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010, 0.000010}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -234,7 +234,7 @@
       <ParameterList name="BC: Uniform Pressure">
         <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -243,28 +243,28 @@
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Na+">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="NO3-">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Zn++">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -275,7 +275,7 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-      <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -290,8 +290,7 @@
       <Parameter name="File" type="string" value="surface-complexation-2-site.bgd"/>
     </ParameterList>
     <Parameter name="Activity Model" type="string" value="unit"/>
-<!--    <Parameter name="Activity Model" type="string" value="debye-huckel"/> -->
+    <!--    <Parameter name="Activity Model" type="string" value="debye-huckel"/> -->
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
-
   </ParameterList>
 </ParameterList>

--- a/demos/phase2/chemistry/amanzi/amanzi-u-1d-ion-exchange-valocchi.xml
+++ b/demos/phase2/chemistry/amanzi/amanzi-u-1d-ion-exchange-valocchi.xml
@@ -56,8 +56,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -65,32 +65,32 @@
   <ParameterList name="Regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -100,42 +100,42 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Soil_1}"/>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Halite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0001"/>
-	  <Parameter name="Specific Surface Area" type="double" value="1.0"/>
-	</ParameterList>
+        <ParameterList name="Halite">
+          <Parameter name="Volume Fraction" type="double" value="0.0001"/>
+          <Parameter name="Specific Surface Area" type="double" value="1.0"/>
+        </ParameterList>
       </ParameterList>
-      <Parameter name="Cation Exchange Capacity" type="double" value="750"/>
+      <Parameter name="Cation Exchange Capacity" type="double" value="750.0"/>
     </ParameterList>
     <ParameterList name="Soil_2">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Soil_2}"/>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Halite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0002"/>
-	  <Parameter name="Specific Surface Area" type="double" value="2.0"/>
-	</ParameterList>
+        <ParameterList name="Halite">
+          <Parameter name="Volume Fraction" type="double" value="0.0002"/>
+          <Parameter name="Specific Surface Area" type="double" value="2.0"/>
+        </ParameterList>
       </ParameterList>
-      <Parameter name="Cation Exchange Capacity" type="double" value="250"/>
+      <Parameter name="Cation Exchange Capacity" type="double" value="250.0"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -160,26 +160,26 @@
           <ParameterList name="Water">
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="8.674633E-02"/>
-                <Parameter name="Free Ion Guess" type="double" value="8.674633E-02"/>
+                <Parameter name="Value" type="double" value="0.08674633"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.08674633"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.825183E-02"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.825183E-02"/>
+                <Parameter name="Value" type="double" value="0.01825183"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.01825183"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Mg++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.113161E-02"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.113161E-02"/>
+                <Parameter name="Value" type="double" value="0.01113161"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.01113161"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cl-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.4551321E-01"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.4551321E-01"/>
+                <Parameter name="Value" type="double" value="0.14551321"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.14551321"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -193,9 +193,9 @@
       <ParameterList name="BC: Flux">
         <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-<!--        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.0, 0.0}"/> -->
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 1317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <!--        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.0, 0.0}"/> -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 1.317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -204,28 +204,28 @@
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.426769E-03, 9.426769E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.009426769, 0.009426769}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.014239E-04, 5.014239E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0005014239, 0.0005014239}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.136066E-03, 2.136066E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.002136066, 0.002136066}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.47017488E-02, 1.47017488E-02}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0147017488, 0.0147017488}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -237,7 +237,7 @@
       <ParameterList name="BC: Uniform Pressure">
         <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-				<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -246,28 +246,28 @@
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Mg++">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cl-">
               <ParameterList name="BC: Zero Gradient">
                 <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+7}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -278,22 +278,22 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-      <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_step">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10_steps">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="ion-exchange-valocchi"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
-<!--      <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
-      <Parameter name="Cycle Macros" type="Array(string)" value="Every_step"/>
+      <!--      <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_step}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Chemistry">
@@ -304,6 +304,6 @@
     <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="50"/>
-<!--    <Parameter name="Max Time Step (s)" type="double" value="1.0e4"/> -->
+    <!--    <Parameter name="Max Time Step (s)" type="double" value="1.0e4"/> -->
   </ParameterList>
 </ParameterList>

--- a/demos/phase2/chemistry/misc/1d-structured/inputs_twophase_simple.xml
+++ b/demos/phase2/chemistry/misc/1d-structured/inputs_twophase_simple.xml
@@ -129,7 +129,6 @@
     <ParameterList name="SiO2">
       <Parameter name="group" type="string" value="Total"/>
     </ParameterList>
-
     <ParameterList name="UO2++">
       <Parameter name="group" type="string" value="Total"/>
     </ParameterList>
@@ -228,4 +227,3 @@
   </ParameterList>
   <Parameter name="stop_time" type="string" value="1000"/>
 </ParameterList>
-

--- a/demos/phase2/chemistry/misc/dewan-waste-tanks/dewan_uo2_backfill_conv.xml
+++ b/demos/phase2/chemistry/misc/dewan-waste-tanks/dewan_uo2_backfill_conv.xml
@@ -277,4 +277,3 @@
     <Parameter name="tracer" type="string" value="{Al+++ H+ HPO4-- SiO2 UO2++ Koalinite Quartz Uranium SAl+++ SH+ SHPO4-- SSiO2 SUO2++}"/>
   </ParameterList>
 </ParameterList>
-

--- a/demos/phase2/chemistry/misc/dewan-waste-tanks/dewan_uo2_granite_limestone_conv.xml
+++ b/demos/phase2/chemistry/misc/dewan-waste-tanks/dewan_uo2_granite_limestone_conv.xml
@@ -336,4 +336,3 @@
     <Parameter name="tracer" type="string" value="{Al+++ H+ HPO4-- SiO2 UO2++ Ca++ Kaolinite Quartz Calcite SAl+++ SH+ SHPO4-- SSiO2 SUO2++ SCa++}"/>
   </ParameterList>
 </ParameterList>
-

--- a/demos/phase2/chemistry/misc/pitzer/rt_polyhalite_diss/rt_polyhalite_diss.xml
+++ b/demos/phase2/chemistry/misc/pitzer/rt_polyhalite_diss/rt_polyhalite_diss.xml
@@ -1,13 +1,4 @@
-<!-- 
-The test consists of a one-dimensional reactive transport where a K-enriched solution in equilibrium
-with halite (NaCl) and polyhalite (polyhalite (K2Ca2Mg(SO4)4.2H2O)  flows through a column initially 
-equilibrated with halite (NaCl) and gypsum (CaSO4.2H2O). The length of the domain is 1m 
-(porosity and dispersivity are 0.4 and 0.01 m, respectively), and contains gypsum and halite.
-
-This input file is running on amazi-alt-driver.
--->
 <ParameterList name="Main">
-
   <ParameterList name="Mesh">
     <ParameterList name="Generate">
       <Parameter name="X_Min" type="double" value="0.0"/>
@@ -16,125 +7,150 @@ This input file is running on amazi-alt-driver.
       <Parameter name="Y_Max" type="double" value="1.0"/>
       <Parameter name="Z_Min" type="double" value="0.0"/>
       <Parameter name="Z_Max" type="double" value="1.0"/>
-      <Parameter name="Number of Cells in X" type="int" value="101"/> 
-      <Parameter name="Number of Cells in Y" type="int" value="1"/> 
-      <Parameter name="Number of Cells in Z" type="int" value="1"/> 
+      <Parameter name="Number of Cells in X" type="int" value="101"/>
+      <Parameter name="Number of Cells in Y" type="int" value="1"/>
+      <Parameter name="Number of Cells in Z" type="int" value="1"/>
     </ParameterList>
   </ParameterList>
-  
-
   <ParameterList name="MPC">
     <Parameter name="Start Time" type="double" value="0.0"/>
-    <Parameter name="End Time" type="double" value="3.1536e9"/> <!-- 100 years --> 
-    <Parameter name="End Cycle" type="int" value="-1"/>      
+    <Parameter name="End Time" type="double" value="3.1536e+9"/>
+    <!-- 100 years -->
+    <Parameter name="End Cycle" type="int" value="-1"/>
     <Parameter name="disable Flow_PK" type="string" value="yes"/>
     <Parameter name="disable Transport_PK" type="string" value="no"/>
     <Parameter name="disable Chemistry_PK" type="string" value="no"/>
-   <Parameter name="Viz dump time frequency" type="double" value="3.1536e8"/>
+    <Parameter name="Viz dump time frequency" type="double" value="3.1536e+8"/>
     <Parameter name="Viz dump cycle frequency" type="int" value="-1"/>
- <!--   <Parameter name="Gnuplot output" type="bool" value="true"/> -->
+    <!--   <Parameter name="Gnuplot output" type="bool" value="true"/> -->
     <ParameterList name="CGNS">
       <Parameter name="File name" type="string" value="rt_polyhalite_diss.cgns"/>
-    </ParameterList>    
-  </ParameterList> 
-
-
+    </ParameterList>
+  </ParameterList>
   <ParameterList name="State">
     <Parameter name="Number of mesh blocks" type="int" value="1"/>
     <Parameter name="Number of component concentrations" type="int" value="9"/>
     <Parameter name="Constant water saturation" type="double" value="1.0"/>
-    <Parameter name="Constant water density" type="double" value="1000.0e0"/> <!-- 1000 [kg m-3] -->
-    <Parameter name="Constant viscosity" type="double" value="1.0e-3"/>            <!-- 1.0e-3 [kg m-1 s-1] => 1.0e-3 [Pa s] --> 
+    <Parameter name="Constant water density" type="double" value="1000.0"/>
+    <!-- 1000 [kg m-3] -->
+    <Parameter name="Constant viscosity" type="double" value="0.0010"/>
+    <!-- 1.0e-3 [kg m-1 s-1] => 1.0e-3 [Pa s] -->
     <Parameter name="Gravity x" type="double" value="0.0"/>
     <Parameter name="Gravity y" type="double" value="0.0"/>
-    <Parameter name="Gravity z" type="double" value="-9.806e0"/>  <!-- 9.806 [m s-2] -->
-
-    <ParameterList name="Mesh block 1"> 
+    <Parameter name="Gravity z" type="double" value="-9.806"/>
+    <!-- 9.806 [m s-2] -->
+    <ParameterList name="Mesh block 1">
       <Parameter name="Mesh block ID" type="int" value="0"/>
-      <Parameter name="Constant porosity" type="double" value="0.4e0"/>
-      <Parameter name="Constant permeability" type="double" value="1.0"/> <!-- 1.18031e-12 [m2] => 1.15741e-5 [m s-1] --> 
-      <Parameter name="Constant Darcy flux x" type="double" value="4.0e-10"/>     <!-- 4.0e-10 [m s-1] => 1.26e-2 [m year-1] -->
-      <Parameter name="Constant Darcy flux y" type="double" value="0"/>
-      <Parameter name="Constant Darcy flux z" type="double" value="0"/>
-      <Parameter name="Constant component concentration 0" type="double" value="-9.3494e-04"/>  <!-- H+1 -->
-      <Parameter name="Constant component concentration 1" type="double" value="1.08E-02"/>        <!-- Ca+2 -->
-      <Parameter name="Constant component concentration 2" type="double" value="5.9480E+00"/>   <!-- Cl-1 -->
-      <Parameter name="Constant component concentration 3" type="double" value="5.1780E+00"/>   <!-- Na+1 -->
-      <Parameter name="Constant component concentration 4" type="double" value="1.712E-05"/>      <!-- CO3-2 -->
-      <Parameter name="Constant component concentration 5" type="double" value="6.2820E-01"/>   <!-- Mg+2 -->
-      <Parameter name="Constant component concentration 6" type="double" value="1.2080E-01"/>   <!-- K+1 -->
-      <Parameter name="Constant component concentration 7" type="double" value="2.2500E-01"/>   <!-- SO4-2 -->
-      <Parameter name="Constant component concentration 8" type="double" value="1.0000E-09"/>   <!-- Br-1 -->
+      <Parameter name="Constant porosity" type="double" value="0.4"/>
+      <Parameter name="Constant permeability" type="double" value="1.0"/>
+      <!-- 1.18031e-12 [m2] => 1.15741e-5 [m s-1] -->
+      <Parameter name="Constant Darcy flux x" type="double" value="4.0e-10"/>
+      <!-- 4.0e-10 [m s-1] => 1.26e-2 [m year-1] -->
+      <Parameter name="Constant Darcy flux y" type="double" value="0.0"/>
+      <Parameter name="Constant Darcy flux z" type="double" value="0.0"/>
+      <Parameter name="Constant component concentration 0" type="double" value="-0.00093494"/>
+      <!-- H+1 -->
+      <Parameter name="Constant component concentration 1" type="double" value="0.0108"/>
+      <!-- Ca+2 -->
+      <Parameter name="Constant component concentration 2" type="double" value="5.9480"/>
+      <!-- Cl-1 -->
+      <Parameter name="Constant component concentration 3" type="double" value="5.1780"/>
+      <!-- Na+1 -->
+      <Parameter name="Constant component concentration 4" type="double" value="0.00001712"/>
+      <!-- CO3-2 -->
+      <Parameter name="Constant component concentration 5" type="double" value="0.62820"/>
+      <!-- Mg+2 -->
+      <Parameter name="Constant component concentration 6" type="double" value="0.12080"/>
+      <!-- K+1 -->
+      <Parameter name="Constant component concentration 7" type="double" value="0.22500"/>
+      <!-- SO4-2 -->
+      <Parameter name="Constant component concentration 8" type="double" value="1.0000e-9"/>
+      <!-- Br-1 -->
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Transport">
-    <Parameter name="CFL" type="double" value="0.5"/>   
-    <Parameter name="enable internal tests" type="string" value="no"/>   
-    <Parameter name="verbosity level" type="int" value="1"/>  
-
+    <Parameter name="CFL" type="double" value="0.5"/>
+    <Parameter name="enable internal tests" type="string" value="no"/>
+    <Parameter name="verbosity level" type="int" value="1"/>
     <ParameterList name="Transport BCs">
       <Parameter name="number of BCs" type="int" value="1"/>
       <ParameterList name="BC 0">
-	<Parameter name="Side set ID" type="int" value="3"/>
-	<Parameter name="Type" type="string" value="Constant"/>
-        <Parameter name="Component 0" type="double" value="-1.7768E-04"/>  <!-- H+1 -->  
-        <Parameter name="Component 1" type="double" value="3.8000E-03"/>   <!-- Ca+2 -->
-        <Parameter name="Component 2" type="double" value="6.4880E+00"/>   <!-- Cl-1 -->
-        <Parameter name="Component 3" type="double" value="2.7230E+00"/>   <!-- Na+1 -->
-        <Parameter name="Component 4" type="double" value="4.963E-05"/>   <!-- CO3-2 -->
-        <Parameter name="Component 5" type="double" value="2.1950E+00"/>   <!-- Mg+2 -->
-        <Parameter name="Component 6" type="double" value="7.268E+00"/>   <!-- K+1 -->
-        <Parameter name="Component 7" type="double" value="5.5650E-01"/>   <!-- SO4-2 -->
-        <Parameter name="Component 8" type="double" value="1.0e-6"/>   <!-- Br-1 -->
-     </ParameterList>             
+        <Parameter name="Side set ID" type="int" value="3"/>
+        <Parameter name="Type" type="string" value="Constant"/>
+        <Parameter name="Component 0" type="double" value="-0.00017768"/>
+        <!-- H+1 -->
+        <Parameter name="Component 1" type="double" value="0.0038000"/>
+        <!-- Ca+2 -->
+        <Parameter name="Component 2" type="double" value="6.4880"/>
+        <!-- Cl-1 -->
+        <Parameter name="Component 3" type="double" value="2.7230"/>
+        <!-- Na+1 -->
+        <Parameter name="Component 4" type="double" value="0.00004963"/>
+        <!-- CO3-2 -->
+        <Parameter name="Component 5" type="double" value="2.1950"/>
+        <!-- Mg+2 -->
+        <Parameter name="Component 6" type="double" value="7.268"/>
+        <!-- K+1 -->
+        <Parameter name="Component 7" type="double" value="0.55650"/>
+        <!-- SO4-2 -->
+        <Parameter name="Component 8" type="double" value="0.0000010"/>
+        <!-- Br-1 -->
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="rt_polyhalite_db.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="rt_polyhalite_db.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="int" value="1" />
+    <Parameter name="Verbosity" type="int" value="1"/>
     <!-- 
         HWM model is specified 
     -->
-    <Parameter name="Activity Model" type="string" value="pitzer-hwm" /> 
-    <Parameter name="Pitzer Database File" type="string" value="phreeqc-pitzer.dat" />  <!-- Name of the virial coefficients database (it is based on PHREEQC database)-->
+    <Parameter name="Activity Model" type="string" value="pitzer-hwm"/>
+    <Parameter name="Pitzer Database File" type="string" value="phreeqc-pitzer.dat"/>
+    <!-- Name of the virial coefficients database (it is based on PHREEQC database)-->
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="100"/>
     <Parameter name="Using sorption" type="string" value="no"/>
-    <Parameter name="Free ion concentrations provided" type="string" value="yes"/> <!-- Initial guess is specified -->
+    <Parameter name="Free ion concentrations provided" type="string" value="yes"/>
+    <!-- Initial guess is specified -->
     <ParameterList name="Initial Conditions">
       <Parameter name="Number of minerals" type="int" value="3"/>
       <Parameter name="Number of ion exchange sites" type="int" value="0"/>
       <Parameter name="Number of sorption sites" type="int" value="0"/>
       <Parameter name="Number of mesh blocks" type="int" value="1"/>
-      <ParameterList name="Mesh block 1"> 
+      <ParameterList name="Mesh block 1">
         <Parameter name="Mesh block ID" type="int" value="0"/>
         <ParameterList name="Free Ion Species">
-          <Parameter name="Free Ion Species 0" type="double" value="1.0e-7"/>           <!-- H+1 -->
-          <Parameter name="Free Ion Species 1" type="double" value="1.0850E-02"/>   <!-- Ca+2 -->
-          <Parameter name="Free Ion Species 2" type="double" value="5.9430E+00"/>   <!-- Cl-1 -->
-          <Parameter name="Free Ion Species 3" type="double" value="5.1780E+00"/>   <!-- Na+1 -->
-          <Parameter name="Free Ion Species 4" type="double" value="1.7070E-05"/>   <!-- CO3-2 -->
-          <Parameter name="Free Ion Species 5" type="double" value="6.2820E-01"/>   <!-- Mg+2 -->
-          <Parameter name="Free Ion Species 6" type="double" value="1.2080E-01"/>   <!-- K+1 -->
-          <Parameter name="Free Ion Species 7" type="double" value="2.2500E-01"/>   <!-- SO4-2 -->
-          <Parameter name="Free Ion Species 8" type="double" value="1.0000E-06"/>   <!-- Br-1 -->
+          <Parameter name="Free Ion Species 0" type="double" value="1.0e-7"/>
+          <!-- H+1 -->
+          <Parameter name="Free Ion Species 1" type="double" value="0.010850"/>
+          <!-- Ca+2 -->
+          <Parameter name="Free Ion Species 2" type="double" value="5.9430"/>
+          <!-- Cl-1 -->
+          <Parameter name="Free Ion Species 3" type="double" value="5.1780"/>
+          <!-- Na+1 -->
+          <Parameter name="Free Ion Species 4" type="double" value="0.000017070"/>
+          <!-- CO3-2 -->
+          <Parameter name="Free Ion Species 5" type="double" value="0.62820"/>
+          <!-- Mg+2 -->
+          <Parameter name="Free Ion Species 6" type="double" value="0.12080"/>
+          <!-- K+1 -->
+          <Parameter name="Free Ion Species 7" type="double" value="0.22500"/>
+          <!-- SO4-2 -->
+          <Parameter name="Free Ion Species 8" type="double" value="0.0000010000"/>
+          <!-- Br-1 -->
         </ParameterList>
         <ParameterList name="Minerals">
-          <Parameter name="Mineral 0" type="double" value="0.002968"/>      <!-- gypsum (CaSO4.2H2O) -->
-          <Parameter name="Mineral 1" type="double" value="0.01082274"/>  <!-- halite (NaCl) -->
-          <Parameter name="Mineral 2" type="double" value="0.0"/>                <!-- polyhalite (K2Ca2Mg(SO4)4.2H2O) -->
+          <Parameter name="Mineral 0" type="double" value="0.002968"/>
+          <!-- gypsum (CaSO4.2H2O) -->
+          <Parameter name="Mineral 1" type="double" value="0.01082274"/>
+          <!-- halite (NaCl) -->
+          <Parameter name="Mineral 2" type="double" value="0.0"/>
+          <!-- polyhalite (K2Ca2Mg(SO4)4.2H2O) -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
-
 </ParameterList>

--- a/demos/phase2/chemistry/waste-tanks/amanzi-s-1d-amr-advection.xml
+++ b/demos/phase2/chemistry/waste-tanks/amanzi-s-1d-amr-advection.xml
@@ -11,34 +11,30 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient with Static Flow">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.0e11"/>
-      	<Parameter name="Maximum Cycle Number" type="int" value="20"/>
+        <Parameter name="End" type="double" value="1.0e+11"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="20"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{2, 2, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{1}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{2, 2, 2, 2}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Tc-99 Gradient Ref}"/>
-	  <Parameter name="Do AMR Subcycling" type="bool" value="True"/>
-
-	  <ParameterList name="Tc-99 Gradient Ref">
-	    <Parameter name="Adjacent Difference Greater" type="double" value="0.1"/>
-	    <Parameter name="Field Name" type="string" value="Tc_99_Aqueous_Concentration"/>
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{2, 2, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{1}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{2, 2, 2, 2}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Tc-99 Gradient Ref}"/>
+          <Parameter name="Do AMR Subcycling" type="bool" value="true"/>
+          <ParameterList name="Tc-99 Gradient Ref">
+            <Parameter name="Adjacent Difference Greater" type="double" value="0.1"/>
+            <Parameter name="Field Name" type="string" value="Tc_99_Aqueous_Concentration"/>
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-
     </ParameterList>
-
   </ParameterList>
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
@@ -50,7 +46,6 @@
       <Parameter name="Number of Cells" type="Array(int)" value="{100, 2}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="West Well">
       <ParameterList name="Region: Point">
@@ -75,43 +70,42 @@
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Pu_238">
-	      <Parameter name="Kd" type="double" value="461168.4"/>
-	    </ParameterList>
-	    <ParameterList name="U_234">
-	      <Parameter name="Kd" type="double" value="329406.0"/>
-	    </ParameterList>
-	    <ParameterList name="Th_230">
-	      <Parameter name="Kd" type="double" value="1482327.0"/>
-	    </ParameterList>
-	    <ParameterList name="Ra_226">
-	      <Parameter name="Kd" type="double" value="41175.75"/>
-	    </ParameterList>
-	    <ParameterList name="Pb_210">
-	      <Parameter name="Kd" type="double" value="3294060.0"/>
-	    </ParameterList>
-	    <ParameterList name="Tc_99">
-	      <Parameter name="Kd" type="double" value="988.218"/>
-	    </ParameterList> 
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Pu_238">
+              <Parameter name="Kd" type="double" value="461168.4"/>
+            </ParameterList>
+            <ParameterList name="U_234">
+              <Parameter name="Kd" type="double" value="329406.0"/>
+            </ParameterList>
+            <ParameterList name="Th_230">
+              <Parameter name="Kd" type="double" value="1482327.0"/>
+            </ParameterList>
+            <ParameterList name="Ra_226">
+              <Parameter name="Kd" type="double" value="41175.75"/>
+            </ParameterList>
+            <ParameterList name="Pb_210">
+              <Parameter name="Kd" type="double" value="3294060.0"/>
+            </ParameterList>
+            <ParameterList name="Tc_99">
+              <Parameter name="Kd" type="double" value="988.218"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -121,50 +115,49 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Uniform Velocity">
-        <Parameter name="Velocity Vector" type="Array(double)" value="{1.e-8, 0}"/>
+        <Parameter name="Velocity Vector" type="Array(double)" value="{1e-8, 0.0}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -172,12 +165,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -219,7 +211,7 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-	<Parameter name="Values" type="Array(double)" value="{0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{0.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -253,16 +245,15 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every step">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Time Macros">
       <ParameterList name="Every year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -273,116 +264,115 @@
       <Parameter name="File Name Base" type="string" value="amr_data/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every step}"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="amr_data/observations.txt"/>
       <ParameterList name="Pu 238 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pu 238 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pu 238 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>

--- a/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark-amr.xml
+++ b/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark-amr.xml
@@ -11,11 +11,11 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-<!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
-        <Parameter name="End" type="double" value="1.0e11"/>
+        <!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
+        <Parameter name="End" type="double" value="1.0e+11"/>
         <Parameter name="Switch" type="double" value="0.0"/>
         <!-- <Parameter name="Transient Initial Time Step" type="double" value="3.15576000e7"/> -->
-      	<Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="Extreme"/>
@@ -29,24 +29,19 @@
         <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{2, 2, 2, 2}"/>
         <Parameter name="Refinement Indicators" type="Array(string)" value="{Pu_238 Gradient Ref}"/>
         <Parameter name="grid_log" type="string" value="grdlog"/>
-	<!--Parameter name="Do AMR Subcycling" type="bool" value="false"/-->
-
+        <!--Parameter name="Do AMR Subcycling" type="bool" value="false"/-->
         <ParameterList name="Pu_238 Gradient Ref">
-          <Parameter name="Adjacent Difference Greater" type="double" value="1.e-8"/>
+          <Parameter name="Adjacent Difference Greater" type="double" value="1e-8"/>
           <Parameter name="Field Name" type="string" value="Pu_238 Aqueous Concentration"/>
           <Parameter name="Regions" type="Array(string)" value="{ALL}"/>
           <Parameter name="Maximum Refinement Level" type="int" value="3"/>
         </ParameterList>
-
       </ParameterList>
-
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-
           <Parameter name="do_multilevel_full" type="int" value="1"/>
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
-          <Parameter name="ic_chem_relax_dt" type="double" value="1.e3"/>
-
+          <Parameter name="ic_chem_relax_dt" type="double" value="1e+3"/>
           <Parameter name="richard_init_to_steady_verbose" type="int" value="3"/>
           <Parameter name="steady_limit_iterations" type="int" value="30"/>
           <Parameter name="steady_max_iterations" type="int" value="20"/>
@@ -54,45 +49,41 @@
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.5"/>
           <Parameter name="steady_min_iterations_2" type="int" value="1"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.5"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="2"/>
           <Parameter name="steady_time_step_retry_factor_2" type="double" value="0.1"/>
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.01"/>
           <Parameter name="steady_max_time_steps" type="int" value="1000"/>
-          <Parameter name="steady_max_time_step_size" type="double" value="1.e20"/>
+          <Parameter name="steady_max_time_step_size" type="double" value="1e+20"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e14"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+14"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
-          <Parameter name="steady_abs_update_tolerance" type="double" value="1.e-10"/>
-          <Parameter name="steady_rel_update_tolerance" type="double" value="-1"/>
-          <Parameter name="steady_abs_tolerance" type="double" value="1.e-9"/>
-          <Parameter name="steady_rel_tolerance" type="double" value="1.e-10"/>
+          <Parameter name="steady_abs_update_tolerance" type="double" value="1e-10"/>
+          <Parameter name="steady_rel_update_tolerance" type="double" value="-1.0"/>
+          <Parameter name="steady_abs_tolerance" type="double" value="1e-9"/>
+          <Parameter name="steady_rel_tolerance" type="double" value="1e-10"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
-
           <Parameter name="richard_solver_verbose" type="int" value="3"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
           <Parameter name="richard_ls_acceptance_factor" type="double" value="1.4"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="0"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-6"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="0.000001"/>
           <Parameter name="richard_use_fd_jac" type="int" value="1"/>
           <Parameter name="richard_use_dense_Jacobian" type="int" value="0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="4"/>
-          <Parameter name="v" type="double" value="2"/>
-
+          <Parameter name="v" type="double" value="2.0"/>
         </ParameterList>
       </ParameterList>
-
-
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -123,41 +114,39 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <Parameter name="Permeability Output File" type="string" value="amr_data/kp"/>
     <Parameter name="Porosity Output File" type="string" value="amr_data/pp"/>
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Pu_238">
-	      <Parameter name="Kd" type="double" value="461168.4"/>
-	    </ParameterList>
-	    <ParameterList name="U_234">
-	      <Parameter name="Kd" type="double" value="329406.0"/>
-	    </ParameterList>
-	    <ParameterList name="Th_230">
-	      <Parameter name="Kd" type="double" value="1482327.0"/>
-	    </ParameterList>
-	    <ParameterList name="Ra_226">
-	      <Parameter name="Kd" type="double" value="41175.75"/>
-	    </ParameterList>
-	    <ParameterList name="Pb_210">
-	      <Parameter name="Kd" type="double" value="3294060.0"/>
-	    </ParameterList>
-	    <ParameterList name="Tc_99">
-	      <Parameter name="Kd" type="double" value="988.218"/>
-	    </ParameterList> 
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Pu_238">
+              <Parameter name="Kd" type="double" value="461168.4"/>
+            </ParameterList>
+            <ParameterList name="U_234">
+              <Parameter name="Kd" type="double" value="329406.0"/>
+            </ParameterList>
+            <ParameterList name="Th_230">
+              <Parameter name="Kd" type="double" value="1482327.0"/>
+            </ParameterList>
+            <ParameterList name="Ra_226">
+              <Parameter name="Kd" type="double" value="41175.75"/>
+            </ParameterList>
+            <ParameterList name="Pb_210">
+              <Parameter name="Kd" type="double" value="3294060.0"/>
+            </ParameterList>
+            <ParameterList name="Tc_99">
+              <Parameter name="Kd" type="double" value="988.218"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -165,10 +154,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -190,43 +179,43 @@
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -239,16 +228,16 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.983266e-6, 9.983266e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000009983266, 0.000009983266}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
@@ -256,7 +245,7 @@
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -264,7 +253,7 @@
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -272,7 +261,7 @@
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -280,7 +269,7 @@
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -288,7 +277,7 @@
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
@@ -301,9 +290,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -347,30 +336,30 @@
     <Parameter name="File Name Digits" type="int" value="7"/>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 1 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every 10 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every 100 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every 1000 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Time Macros">
       <ParameterList name="Every 0.05 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 0.5 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 10 years">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -382,130 +371,129 @@
       <Parameter name="File Name Base" type="string" value="amr_data/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100 steps}"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="amr_data/observations.txt"/>
       <ParameterList name="Pu 238 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="31557600.0"/>
-    <Parameter name="Max Time Step (s)" type="double" value="3.75686e5"/>
-  </ParameterList> <!-- Chemistry -->
+    <Parameter name="Max Time Step (s)" type="double" value="375686.0"/>
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark-point-source.xml
+++ b/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark-point-source.xml
@@ -12,11 +12,11 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-<!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
-        <Parameter name="End" type="double" value="1.0e11"/>
+        <!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
+        <Parameter name="End" type="double" value="1.0e+11"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="3.15576000e7"/>
-      	<Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="31557600.0"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="Extreme"/>
@@ -27,14 +27,11 @@
         <Parameter name="Maximum Grid Size" type="Array(int)" value="{100}"/>
         <Parameter name="v" type="int" value="2"/>
       </ParameterList>
-
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-
           <Parameter name="do_multilevel_full" type="int" value="1"/>
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
-          <Parameter name="ic_chem_relax_dt" type="double" value="1.e3"/>
-
+          <Parameter name="ic_chem_relax_dt" type="double" value="1e+3"/>
           <Parameter name="richard_init_to_steady_verbose" type="int" value="3"/>
           <Parameter name="steady_limit_iterations" type="int" value="30"/>
           <Parameter name="steady_max_iterations" type="int" value="20"/>
@@ -42,45 +39,41 @@
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.5"/>
           <Parameter name="steady_min_iterations_2" type="int" value="1"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.5"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="2"/>
           <Parameter name="steady_time_step_retry_factor_2" type="double" value="0.1"/>
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.01"/>
           <Parameter name="steady_max_time_steps" type="int" value="1000"/>
-          <Parameter name="steady_max_time_step_size" type="double" value="1.e20"/>
+          <Parameter name="steady_max_time_step_size" type="double" value="1e+20"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e14"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+14"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
-          <Parameter name="steady_abs_update_tolerance" type="double" value="1.e-10"/>
-          <Parameter name="steady_rel_update_tolerance" type="double" value="-1"/>
-          <Parameter name="steady_abs_tolerance" type="double" value="1.e-9"/>
-          <Parameter name="steady_rel_tolerance" type="double" value="1.e-10"/>
+          <Parameter name="steady_abs_update_tolerance" type="double" value="1e-10"/>
+          <Parameter name="steady_rel_update_tolerance" type="double" value="-1.0"/>
+          <Parameter name="steady_abs_tolerance" type="double" value="1e-9"/>
+          <Parameter name="steady_rel_tolerance" type="double" value="1e-10"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
-
           <Parameter name="richard_solver_verbose" type="int" value="3"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
           <Parameter name="richard_ls_acceptance_factor" type="double" value="1.4"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="0"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-6"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="0.000001"/>
           <Parameter name="richard_use_fd_jac" type="int" value="1"/>
           <Parameter name="richard_use_dense_Jacobian" type="int" value="0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="4"/>
-          <Parameter name="v" type="double" value="2"/>
-
+          <Parameter name="v" type="double" value="2.0"/>
         </ParameterList>
       </ParameterList>
-
-
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -123,41 +116,39 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <Parameter name="Permeability Output File" type="string" value="amr_data/kp"/>
     <Parameter name="Porosity Output File" type="string" value="amr_data/pp"/>
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Pu_238">
-	      <Parameter name="Kd" type="double" value="461168.4"/>
-	    </ParameterList>
-	    <ParameterList name="U_234">
-	      <Parameter name="Kd" type="double" value="329406.0"/>
-	    </ParameterList>
-	    <ParameterList name="Th_230">
-	      <Parameter name="Kd" type="double" value="1482327.0"/>
-	    </ParameterList>
-	    <ParameterList name="Ra_226">
-	      <Parameter name="Kd" type="double" value="41175.75"/>
-	    </ParameterList>
-	    <ParameterList name="Pb_210">
-	      <Parameter name="Kd" type="double" value="3294060.0"/>
-	    </ParameterList>
-	    <ParameterList name="Tc_99">
-	      <Parameter name="Kd" type="double" value="988.218"/>
-	    </ParameterList> 
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Pu_238">
+              <Parameter name="Kd" type="double" value="461168.4"/>
+            </ParameterList>
+            <ParameterList name="U_234">
+              <Parameter name="Kd" type="double" value="329406.0"/>
+            </ParameterList>
+            <ParameterList name="Th_230">
+              <Parameter name="Kd" type="double" value="1482327.0"/>
+            </ParameterList>
+            <ParameterList name="Ra_226">
+              <Parameter name="Kd" type="double" value="41175.75"/>
+            </ParameterList>
+            <ParameterList name="Pb_210">
+              <Parameter name="Kd" type="double" value="3294060.0"/>
+            </ParameterList>
+            <ParameterList name="Tc_99">
+              <Parameter name="Kd" type="double" value="988.218"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -165,10 +156,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -177,8 +168,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  </ParameterList> <!-- phase definitions -->
-
+  </ParameterList>
+  <!-- phase definitions -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition Clean">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Clean_Sand}"/>
@@ -191,50 +182,51 @@
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- initial condition: clean sand -->
+    </ParameterList>
+    <!-- initial condition: clean sand -->
     <ParameterList name="Initial Condition Waste">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste_Source}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -253,29 +245,29 @@
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -289,23 +281,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- initial condition: waste source -->
-  </ParameterList> <!-- initial conditions -->
-
+    </ParameterList>
+    <!-- initial condition: waste source -->
+  </ParameterList>
+  <!-- initial conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.983266e-6, 9.983266e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000009983266, 0.000009983266}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -313,7 +306,7 @@
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -321,7 +314,7 @@
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -329,7 +322,7 @@
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -337,7 +330,7 @@
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -345,7 +338,7 @@
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -358,9 +351,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -404,30 +397,30 @@
     <Parameter name="File Name Digits" type="int" value="7"/>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 1 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every 10 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every 100 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every 1000 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Time Macros">
       <ParameterList name="Every 0.01 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576.000, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576.000, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 0.1 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3155760.00, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3155760.00, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 10 years">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -438,129 +431,128 @@
       <Parameter name="File Name Base" type="string" value="amr_data/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100 steps}"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="amr_data/observations.txt"/>
       <ParameterList name="Pu 238 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="31557600.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark.xml
+++ b/demos/phase2/chemistry/waste-tanks/amanzi-s-waste-tanks-1d-benchmark.xml
@@ -11,28 +11,25 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.0e11"/>
+        <Parameter name="End" type="double" value="1.0e+11"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="1.e2"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.e2"/>
-      	<Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1e+2"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+2"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="2000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="Extreme"/>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="1"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{1}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{100}"/>
-	  <Parameter name="v" type="int" value="2"/>
-	</ParameterList>
-
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="1"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{1}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{100}"/>
+          <Parameter name="v" type="int" value="2"/>
+        </ParameterList>
         <ParameterList name="Expert Settings">
-
           <Parameter name="do_multilevel_full" type="int" value="1"/>
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
-
           <Parameter name="richard_init_to_steady_verbose" type="int" value="3"/>
           <Parameter name="steady_limit_iterations" type="int" value="30"/>
           <Parameter name="steady_max_iterations" type="int" value="20"/>
@@ -40,45 +37,41 @@
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.5"/>
           <Parameter name="steady_min_iterations_2" type="int" value="1"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.5"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="2"/>
           <Parameter name="steady_time_step_retry_factor_2" type="double" value="0.1"/>
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.01"/>
           <Parameter name="steady_max_time_steps" type="int" value="1000"/>
-          <Parameter name="steady_max_time_step_size" type="double" value="1.e20"/>
+          <Parameter name="steady_max_time_step_size" type="double" value="1e+20"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e14"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+14"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
-          <Parameter name="steady_abs_update_tolerance" type="double" value="1.e-10"/>
-          <Parameter name="steady_rel_update_tolerance" type="double" value="-1"/>
-          <Parameter name="steady_abs_tolerance" type="double" value="1.e-9"/>
-          <Parameter name="steady_rel_tolerance" type="double" value="1.e-10"/>
+          <Parameter name="steady_abs_update_tolerance" type="double" value="1e-10"/>
+          <Parameter name="steady_rel_update_tolerance" type="double" value="-1.0"/>
+          <Parameter name="steady_abs_tolerance" type="double" value="1e-9"/>
+          <Parameter name="steady_rel_tolerance" type="double" value="1e-10"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
-
           <Parameter name="richard_solver_verbose" type="int" value="3"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
           <Parameter name="richard_ls_acceptance_factor" type="double" value="1.4"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="0"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-6"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="0.000001"/>
           <Parameter name="richard_use_fd_jac" type="int" value="1"/>
           <Parameter name="richard_use_dense_Jacobian" type="int" value="0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="4"/>
-          <Parameter name="v" type="double" value="2"/>
-
+          <Parameter name="v" type="double" value="2.0"/>
         </ParameterList>
       </ParameterList>
-
-
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -115,31 +108,31 @@
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Pu_238">
-	      <Parameter name="Kd" type="double" value="461168.4"/>
-	    </ParameterList>
-	    <ParameterList name="U_234">
-	      <Parameter name="Kd" type="double" value="329406.0"/>
-	    </ParameterList>
-	    <ParameterList name="Th_230">
-	      <Parameter name="Kd" type="double" value="1482327.0"/>
-	    </ParameterList>
-	    <ParameterList name="Ra_226">
-	      <Parameter name="Kd" type="double" value="41175.75"/>
-	    </ParameterList>
-	    <ParameterList name="Pb_210">
-	      <Parameter name="Kd" type="double" value="3294060.0"/>
-	    </ParameterList>
-	    <ParameterList name="Tc_99">
-	      <Parameter name="Kd" type="double" value="988.218"/>
-	    </ParameterList> 
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Pu_238">
+              <Parameter name="Kd" type="double" value="461168.4"/>
+            </ParameterList>
+            <ParameterList name="U_234">
+              <Parameter name="Kd" type="double" value="329406.0"/>
+            </ParameterList>
+            <ParameterList name="Th_230">
+              <Parameter name="Kd" type="double" value="1482327.0"/>
+            </ParameterList>
+            <ParameterList name="Ra_226">
+              <Parameter name="Kd" type="double" value="41175.75"/>
+            </ParameterList>
+            <ParameterList name="Pb_210">
+              <Parameter name="Kd" type="double" value="3294060.0"/>
+            </ParameterList>
+            <ParameterList name="Tc_99">
+              <Parameter name="Kd" type="double" value="988.218"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -147,10 +140,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -171,38 +164,38 @@
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -214,51 +207,51 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.983266e-6, 9.983266e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000009983266, 0.000009983266}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
@@ -270,9 +263,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -310,30 +303,30 @@
     <Parameter name="File Name Digits" type="int" value="7"/>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 1 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every 10 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every 100 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every 1000 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Time Macros">
       <ParameterList name="Every 0.05 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 0.5 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 10 years">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -344,129 +337,128 @@
       <Parameter name="File Name Base" type="string" value="amr_data/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100 steps}"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="amr_data/observations.txt"/>
       <ParameterList name="Pu 238 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pu 238 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pu 238 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="U 234 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Th 230 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Ra 226 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Pb 210 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
       <ParameterList name="Tc 99 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous Concentration"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Every year}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="ascem-2012-waste-tanks.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
-    <Parameter name="Max Time Step (s)" type="double" value="3.75686e5"/>
-  </ParameterList> <!-- Chemistry -->
+    <Parameter name="Max Time Step (s)" type="double" value="375686.0"/>
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase2/chemistry/waste-tanks/amanzi-u-waste-tanks-1d-benchmark.xml
+++ b/demos/phase2/chemistry/waste-tanks/amanzi-u-waste-tanks-1d-benchmark.xml
@@ -11,11 +11,11 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-<!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
-        <Parameter name="End" type="double" value="1.0e11"/>
+        <!--        <Parameter name="End" type="double" value="3.15576000e10"/> -->
+        <Parameter name="End" type="double" value="1.0e+11"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="3.15576000e7"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="3.15576000e7"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="31557600.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="31557600.0"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="Extreme"/>
@@ -26,7 +26,7 @@
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
-	<Parameter name="linear solver tolerance" type="double" value="1e-22"/>
+        <Parameter name="linear solver tolerance" type="double" value="1e-22"/>
         <Parameter name="steady max iterations" type="int" value="15"/>
         <Parameter name="steady min iterations" type="int" value="10"/>
         <Parameter name="steady limit iterations" type="int" value="20"/>
@@ -53,8 +53,8 @@
     <ParameterList name="Unstructured">
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 0.01, 0.01}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 0.01, 0.01}"/>
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
         </ParameterList>
       </ParameterList>
@@ -102,27 +102,27 @@
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	    <ParameterList name="Pu_238">
-	      <Parameter name="Kd" type="double" value="461168.4"/>
-	    </ParameterList>
-	    <ParameterList name="U_234">
-	      <Parameter name="Kd" type="double" value="329406.0"/>
-	    </ParameterList>
-	    <ParameterList name="Th_230">
-	      <Parameter name="Kd" type="double" value="1482327.0"/>
-	    </ParameterList>
-	    <ParameterList name="Ra_226">
-	      <Parameter name="Kd" type="double" value="41175.75"/>
-	    </ParameterList>
-	    <ParameterList name="Pb_210">
-	      <Parameter name="Kd" type="double" value="3294060.0"/>
-	    </ParameterList>
-	    <ParameterList name="Tc_99">
-	      <Parameter name="Kd" type="double" value="988.218"/> 
-	    </ParameterList> 
+        <ParameterList name="Pu_238">
+          <Parameter name="Kd" type="double" value="461168.4"/>
+        </ParameterList>
+        <ParameterList name="U_234">
+          <Parameter name="Kd" type="double" value="329406.0"/>
+        </ParameterList>
+        <ParameterList name="Th_230">
+          <Parameter name="Kd" type="double" value="1482327.0"/>
+        </ParameterList>
+        <ParameterList name="Ra_226">
+          <Parameter name="Kd" type="double" value="41175.75"/>
+        </ParameterList>
+        <ParameterList name="Pb_210">
+          <Parameter name="Kd" type="double" value="3294060.0"/>
+        </ParameterList>
+        <ParameterList name="Tc_99">
+          <Parameter name="Kd" type="double" value="988.218"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -130,10 +130,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -155,43 +155,43 @@
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
+                <Parameter name="Free Ion Guess" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -204,16 +204,16 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.983266e-6, 9.983266e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000009983266, 0.000009983266}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Pu_238">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
@@ -221,7 +221,7 @@
             </ParameterList>
             <ParameterList name="U_234">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -229,7 +229,7 @@
             </ParameterList>
             <ParameterList name="Th_230">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -237,7 +237,7 @@
             </ParameterList>
             <ParameterList name="Ra_226">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -245,7 +245,7 @@
             </ParameterList>
             <ParameterList name="Pb_210">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -253,7 +253,7 @@
             </ParameterList>
             <ParameterList name="Tc_99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e12}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+12}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0, 1.0}"/>
               </ParameterList>
@@ -266,9 +266,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -311,30 +311,30 @@
   <ParameterList name="Output">
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 1 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every 10 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every 100 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every 1000 steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Time Macros">
       <ParameterList name="Every 0.05 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1577880.00, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 0.5 year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 15778800.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31557600.0, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every 10 years">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 315576000.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -345,123 +345,123 @@
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="unstructured_observations.txt"/>
       <ParameterList name="Pu 238 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pu 238 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pu_238 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="U 234 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="U_234 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Th 230 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Th_230 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Ra 226 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Ra_226 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Pb 210 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Pb_210 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 West Well">
-	<Parameter name="Region" type="string" value="West Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="West Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 Center Well">
-	<Parameter name="Region" type="string" value="Center Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="Center Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
       <ParameterList name="Tc 99 East Well">
-	<Parameter name="Region" type="string" value="East Well"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
-	<Parameter name="Time Macro" type="string" value="Every year"/>
+        <Parameter name="Region" type="string" value="East Well"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Tc_99 Aqueous concentration"/>
+        <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
-    <Parameter name="Thermodynamic Database Format" type="string" value="simple" />
-    <Parameter name="Thermodynamic Database File" type="string" value="ascem-2012-waste-tanks.bgd" />
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose, debug}" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Thermodynamic Database Format" type="string" value="simple"/>
+    <Parameter name="Thermodynamic Database File" type="string" value="ascem-2012-waste-tanks.bgd"/>
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose, debug}"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="31557600.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase2/dvz/3_layer_1d-bcb-u/dvz_3_layer_1d-bcb.xml
+++ b/demos/phase2/dvz/3_layer_1d-bcb-u/dvz_3_layer_1d-bcb.xml
@@ -1,16 +1,16 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="On"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-	  <!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="On"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0           [s]
              Start transient:      t = 1956.0 [y] = 6.17266656e+10 [s]  
@@ -19,16 +19,16 @@
              Note that at 1956, the land use model changes, causing a change in the background infiltration rate.
              At the same time the first crib starts.
 
-          -->          
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e+10"/>
-	  <Parameter name="End" type="double" value="9.46728e+10"/>	  
-          <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="10"/>
-        </ParameterList>
+          -->
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="9.46728e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-	<!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -38,259 +38,258 @@
             t = 1956.2 [y] = 6.173705521E10 [s]   Crib 216-B-18 stops
             
 	-->
-        <Parameter name="Start Times" type="Array(double)" value="{6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="None"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-4"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-4"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+      <Parameter name="Start Times" type="Array(double)" value="{6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0}"/>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="None"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}" />
-	  </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.0001"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,0.0}"/>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.0001"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="Horizontal" type="double" value="1.9976E-12"/>
-          <Parameter name="Vertical" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="2.83180E-01"/>
-          <Parameter name="alpha" type="double" value="2.470612E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="Horizontal" type="double" value="6.9365E-11"/>
-          <Parameter name="Vertical" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="2.60990E-01"/>
-          <Parameter name="alpha" type="double" value="2.573475E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2400"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="Horizontal" type="double" value="2.0706E-09"/>
-          <Parameter name="Vertical" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="3.86968E-01"/>
-          <Parameter name="alpha" type="double" value="2.756137E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-              
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-	  <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.000330423, 1.48666E-6, 1.48666E-6}"/>	 		
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros">
-        <ParameterList name="Every_0.01_year">
-	       <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 315576, -1}"/>
-      	</ParameterList>
-	<ParameterList name="Every_1000_year">
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{0, 315576e+5, -1}"/>
-	</ParameterList>
-         <ParameterList name="Every 100 years">
-            <Parameter name="Start_Period_Stop" type="Array(double)" value="{0, 3155760000.,-1}"/>
-         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList> 
-
-
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
- 	<Parameter name="Time Macros" type="Array(string)" value="{Every 100 years}"/> 
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-	<Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="Horizontal" type="double" value="1.9976e-12"/>
+        <Parameter name="Vertical" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.283180"/>
+        <Parameter name="alpha" type="double" value="0.0002470612"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="Horizontal" type="double" value="6.9365e-11"/>
+        <Parameter name="Vertical" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.260990"/>
+        <Parameter name="alpha" type="double" value="0.002573475"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2400"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="Horizontal" type="double" value="2.0706e-9"/>
+        <Parameter name="Vertical" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.386968"/>
+        <Parameter name="alpha" type="double" value="0.002756137"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.000330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+      <ParameterList name="Every_0.01_year">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 315576.0, -1.0}"/>
+      </ParameterList>
+      <ParameterList name="Every_1000_year">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3.15576e+10, -1.0}"/>
+      </ParameterList>
+      <ParameterList name="Every 100 years">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3155760000.0, -1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Time Macros" type="Array(string)" value="{Every 100 years}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_1d-u/dvz_3_layer_1d-restart.xml
+++ b/demos/phase2/dvz/3_layer_1d-u/dvz_3_layer_1d-restart.xml
@@ -1,277 +1,279 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <ParameterList name="Restart from Checkpoint Data File">
+      <Parameter name="Checkpoint Data File Name" type="string" value="restart_steadystate.h5"/>
     </ParameterList>
-    <ParameterList name="Execution Control">
-      <ParameterList name="Restart from Checkpoint Data File">
-          <Parameter name="Checkpoint Data File Name" type="string" value="restart_steadystate.h5"/>
-      </ParameterList>
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <!--<ParameterList name="Initialize To Steady">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <!--<ParameterList name="Initialize To Steady">
           <Parameter name="Start" type="double" value="0.0"/>
           <Parameter name="Switch" type="double" value="6.17266656e+10"/>
 	  <Parameter name="End" type="double" value="9.46728e+10"/>	  
           <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
           <Parameter name="Transient Initial Time Step" type="double" value="10"/>
         </ParameterList>-->
-	 <ParameterList name="Transient">
-          <Parameter name="Start" type="double" value="6.17266656e+10"/>      
-	  <Parameter name="End" type="double" value="9.46728e+10"/>	  
-          <Parameter name="Initial Time Step" type="double" value="10"/>
-        </ParameterList>	
-      </ParameterList>
-      <ParameterList name="Time Period Control">
-        <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="Low"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
+      <ParameterList name="Transient">
+        <Parameter name="Start" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="9.46728e+10"/>
+        <Parameter name="Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
+    <ParameterList name="Time Period Control">
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="Low"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}" />
-	  </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,0.0}"/>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-09"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-	  <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.000330423, 1.48666E-6, 1.48666E-6}"/>	 		
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList> 
-      <ParameterList name="Time Macros">       
-	<ParameterList name="Every_100_year">
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{0, 315576e+7, -1}"/>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macros" type="Array(string)" value="Every_1.0_1000.0_-1"/>
-      </ParameterList> 
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_100_year"/> -->
-	<Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.000330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Time Macros">
+      <ParameterList name="Every_100_year">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3.15576e+12, -1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_100_year"/> -->
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_1d-u/dvz_3_layer_1d.xml
+++ b/demos/phase2/dvz/3_layer_1d-u/dvz_3_layer_1d.xml
@@ -1,16 +1,16 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-	  <!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0            [s]
              Start transient:      t = 1956.0 [y] = 6.17266656e+10 [s]  
@@ -19,16 +19,16 @@
              Note that at 1956, the land use model changes, causing a change in the background infiltration rate.
              At the same time the first crib starts.
 
-          -->          
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e+10"/>
-	  <Parameter name="End" type="double" value="9.46728e+10"/>	  
-          <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="10"/>
-        </ParameterList>
+          -->
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="9.46728e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-	<!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -38,265 +38,267 @@
             t = 1956.2 [y] = 6.173705521E10 [s]   Crib 216-B-18 stops
             
 	-->
-        <Parameter name="Start Times" type="Array(double)" value="{6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+      <Parameter name="Start Times" type="Array(double)" value="{6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0}"/>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}" />
-	  </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,0.0}"/>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-09"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-	  <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.000330423, 1.48666E-6, 1.48666E-6}"/>	 		
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros">
-        <ParameterList name="Every_0.01_year">
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 315576, -1}"/>
-	</ParameterList>
-	<ParameterList name="Every_1000_year">
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{0, 315576e+5, -1}"/>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList> 
-      <ParameterList name="Time Macros">
-         <ParameterList name="Every 100 years">
-            <Parameter name="Start_Period_Stop" type="Array(double)" value="{0, 3155760000.,-1}"/>
-         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-<!--	<Parameter name="Cycle Macros" type="Array(string)" value="Every_1.0_1000.0_-1"/> -->
- 	<Parameter name="Time Macros" type="Array(string)" value="{Every 100 years}"/> 
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_0.01_year"/> -->
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_1000_year"/> -->
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-	<Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
-<!-- 	<Parameter name="Time Macros" type="string" value="Every 100 years"/> -->
-<!--    <Parameter name="Time Macros" type="string" value="Every_0.01_year"/> -->
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_1000_year"/> -->
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{4, 1, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.000330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+      <ParameterList name="Every_0.01_year">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 315576.0, -1.0}"/>
+      </ParameterList>
+      <ParameterList name="Every_1000_year">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3.15576e+10, -1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Time Macros">
+      <ParameterList name="Every 100 years">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 3155760000.0, -1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <!--	<Parameter name="Cycle Macros" type="Array(string)" value="Every_1.0_1000.0_-1"/> -->
+      <Parameter name="Time Macros" type="Array(string)" value="{Every 100 years}"/>
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_0.01_year"/> -->
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_1000_year"/> -->
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every 100 years"/> -->
+      <!--    <Parameter name="Time Macros" type="string" value="Every_0.01_year"/> -->
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_1000_year"/> -->
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_2d-s/dvz_3_layer_2d_s.xml
+++ b/demos/phase2/dvz/3_layer_2d-s/dvz_3_layer_2d_s.xml
@@ -2,33 +2,27 @@
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="run_data/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="TBD"/>
     <Parameter name="Author" type="string" value="Chandrika"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-  
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216,107.52}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{432,256}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
     <Parameter name="Verbosity" type="string" value="Low"/>
-
-        <!--
+    <!--
            
            Start initalization:  t =    0.0 [y] = 0.0            [s]
            Start transient:      t = 1956.0 [y] = 6.17266656e+10 [s]  
@@ -43,14 +37,13 @@
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="Switch" type="double" value="6.17266656e+10"/>
         <Parameter name="End" type="double" value="9.46728e+10"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-        <Parameter name="Maximum Time Step Grow" type="double" value="2"/>
-        <Parameter name="Steady Maximum Time Step Size" type="double" value="1.e9"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Maximum Time Step Grow" type="double" value="2.0"/>
+        <Parameter name="Steady Maximum Time Step Size" type="double" value="1e+9"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
     </ParameterList>
-
-      <!--
+    <!--
    
             The time integrator is reset at Start time, and at the Switch time (1956 [y])
 
@@ -59,15 +52,13 @@
             t = 1956.2 [y] = 6.173178481e+10 [s]   Crib 216-B-18 starts (Tc-99 @ 2.266885 ppm)
             t = 1956.3 [y] = 6.173705521e+10 [s]   Crib 216-B-18 stops
 
-            -->                   
+            -->
     <ParameterList name="Time Period Control">
-      <Parameter name="Start Times" type="Array(double)" value="{6.17266656e+10, 6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-      <Parameter name="Maximum Time Step" type="Array(double)" value="{5.e7, 1.e9, 5.e7, 1.e10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10, 10}"/>
+      <Parameter name="Start Times" type="Array(double)" value="{6.17266656e+10, 6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Maximum Time Step" type="Array(double)" value="{5e+7, 1e+9, 5e+7, 1e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0, 10.0}"/>
     </ParameterList>
-
     <ParameterList name="Numerical Control Parameters">
-
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="max_n_subcycle_transport" type="int" value="20"/>
@@ -78,88 +69,84 @@
           <Parameter name="steady_max_num_consecutive_success" type="int" value="3"/>
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.4"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="5"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="5.0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="true"/>
           <Parameter name="verbose" type="int" value="2"/>
           <Parameter name="sum_interval" type="int" value="1"/>
         </ParameterList>
-      
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="1"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{16}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{128}"/>
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="1"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="1"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{16}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{128}"/>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="1"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-      
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Regions">
     <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,39.9}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 39.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,39.9}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,80.22}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 80.22}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,80.22}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Material Properties">
     <ParameterList name="Facies_1">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.4082"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.9976E-12"/>
-        <Parameter name="y" type="double" value="1.9976E-13"/>
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.9467E-04"/>
+        <Parameter name="alpha" type="double" value="0.00019467"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2294"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -171,11 +158,11 @@
         <Parameter name="Value" type="double" value="0.2206"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.9365E-11"/>
-        <Parameter name="y" type="double" value="6.9365E-12"/>
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0260E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020260"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2136"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -187,11 +174,11 @@
         <Parameter name="Value" type="double" value="0.2340"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0706E-09"/>
-        <Parameter name="y" type="double" value="2.0706E-10"/>
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -199,15 +186,14 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -221,16 +207,16 @@
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9793.5192 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -242,7 +228,7 @@
     <ParameterList name="BC For Bottom Surface Outside All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -258,18 +244,18 @@
     <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -279,18 +265,18 @@
     <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -300,16 +286,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -321,16 +307,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -342,16 +328,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -365,21 +351,22 @@
     <Parameter name="File Name Digits" type="int" value="5"/>
     <ParameterList name="Time Macros">
       <ParameterList name="Every_1_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10,3.15576e+7,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 3.15576e+7, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_100">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_step">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_step}"/>

--- a/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_2d.xml
+++ b/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_2d.xml
@@ -1,16 +1,16 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-	  <!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0            [s]
              Start transient:      t = 1956.0 [y] = 6.17266656e+10 [s]  
@@ -20,15 +20,15 @@
              At the same time the first crib starts.
 
           -->
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e+10"/>
-          <Parameter name="End" type="double" value="9.46728e+10"/>
-          <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="10"/>
-        </ParameterList>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="9.46728e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-	<!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -39,390 +39,393 @@
             t = 1956.2 [y] = 6.173178481E10 [s]   Crib 216-B-18 starts
             t = 1956.3 [y] = 6.173705521E10 [s]   Crib 216-B-18 stops
             
-	-->                   
-        <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="ML cycle applications" type="int" value="2"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+	-->
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}" />
-	  </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,0.0}"/>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-09"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="2"/>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Point" type="Array(double)" value="{0,0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_step">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
-        </ParameterList>
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-       <!-- <Parameter name="Regions" type="Array(string)" value="{Crib_216-B-17,Crib_216-B-18}"/> -->
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-        <Parameter name="Cycle Macros" type="Array(string)" value="{Every_step}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_step">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
+      </ParameterList>
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <!-- <Parameter name="Regions" type="Array(string)" value="{Crib_216-B-17,Crib_216-B-18}"/> -->
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_step}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_2d_tpfa_steady.xml
+++ b/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_2d_tpfa_steady.xml
@@ -1,16 +1,16 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-	  <!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0            [s]
              Start transient:      t = 1956.0 [y] = 6.17266656e+10 [s]  
@@ -20,16 +20,16 @@
              At the same time the first crib starts.
 
           -->
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e+10"/>
-          <Parameter name="End" type="double" value="6.17266656e+10"/> 
-<!--          <Parameter name="End" type="double" value="9.46728e+10"/>  -->
-          <Parameter name="Steady Initial Time Step" type="double" value="100000"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="10"/>
-        </ParameterList>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="6.17266656e+10"/>
+        <!--          <Parameter name="End" type="double" value="9.46728e+10"/>  -->
+        <Parameter name="Steady Initial Time Step" type="double" value="100000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-	<!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -40,372 +40,372 @@
             t = 1956.2 [y] = 6.173178481E10 [s]   Crib 216-B-18 starts
             t = 1956.3 [y] = 6.173705521E10 [s]   Crib 216-B-18 stops
             
-	-->                   
-        <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
+	-->
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
+    </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="12"/>
+          <Parameter name="steady min iterations" type="int" value="7"/>
+          <Parameter name="steady limit iterations" type="int" value="15"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.0000010"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+9"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
+        </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.0000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+        </ParameterList>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="2"/>
           </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="12"/>
-            <Parameter name="steady min iterations" type="int" value="7"/>
-            <Parameter name="steady limit iterations" type="int" value="15"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-6"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+9"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-6"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="ML cycle applications" type="int" value="2"/>
-            </ParameterList>
-          </ParameterList>
-    	  <ParameterList name="Nonlinear Solver">
-	        <Parameter name="Nonlinear Solver Type" type="string" value="Newton" />
-     	  </ParameterList>
+        </ParameterList>
+        <ParameterList name="Nonlinear Solver">
+          <Parameter name="Nonlinear Solver Type" type="string" value="Newton"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-        </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}" />
-	  </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,0.0}"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
       </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-09"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="Phase Components">
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-<!--
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <!--
     <ParameterList name="Output">
       <ParameterList name="Time Macros"/>
       <ParameterList name="Cycle Macros">
@@ -430,4 +430,4 @@
       </ParameterList>
     </ParameterList>
 -->
-  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_true_2d.xml
+++ b/demos/phase2/dvz/3_layer_2d-u/dvz_3_layer_true_2d.xml
@@ -1,400 +1,403 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="On"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e+10"/>
-          <Parameter name="End" type="double" value="9.46728e+10"/>
-          <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="10"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Time Period Control">
-        <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="steady nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="ML cycle applications" type="int" value="2"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="On"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="9.46728e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="2"/>
+    <ParameterList name="Time Period Control">
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,  0.0}" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}" />
-	  </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="steady nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface Outside All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,0.0}"/>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,106.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="2"/>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Phase" type="string" value="Aqueous"/>
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface Outside All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-        <Parameter name="Cycle Macros" type="Array(string)" value="Every_1.0_1000.0_-1"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="2"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface Outside All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 106.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface Outside All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/3_layer_gslib_2d-s/dvz_3_layer_gslib_2d-s.xml
+++ b/demos/phase2/dvz/3_layer_gslib_2d-s/dvz_3_layer_gslib_2d-s.xml
@@ -1,35 +1,27 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="TBD"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-  
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216,107.52}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{432,256}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
     <Parameter name="Verbosity" type="string" value="Low"/>
-
     <!-- <Parameter name="Restart from Checkpoint Data File" type="string" value="run_data/chk00300"/> -->
-
     <ParameterList name="Time Integration Mode">
-      
       <ParameterList name="Initialize To Steady">
         <!--
            
@@ -44,10 +36,10 @@
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="Switch" type="double" value="6.17266656e+10"/>
         <Parameter name="End" type="double" value="9.46728e+10"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1000"/>
-        <Parameter name="Maximum Time Step Grow" type="double" value="2"/>
-        <Parameter name="Transient Maximum Time Step Size" type="double" value="1.e9"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.0"/>
+        <Parameter name="Maximum Time Step Grow" type="double" value="2.0"/>
+        <Parameter name="Transient Maximum Time Step Size" type="double" value="1e+9"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0"/>
         <Parameter name="Maximum Cycle Number" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
@@ -61,81 +53,77 @@
             t = 1956.2 [y] = 6.173178481e+10 [s]   Crib 216-B-18 starts (Tc-99 @ 2.266885 ppm)
             t = 1956.3 [y] = 6.173705521e+10 [s]   Crib 216-B-18 stops
 
-            -->                   
-      <Parameter name="Start Times" type="Array(double)" value="{6.17266656e+10, 6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-      <Parameter name="Maximum Time Step" type="Array(double)" value="{5.e7, 1.e9, 5.e7, 1.e10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10, 10}"/>
+            -->
+      <Parameter name="Start Times" type="Array(double)" value="{6.17266656e+10, 6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Maximum Time Step" type="Array(double)" value="{5e+7, 1e+9, 5e+7, 1e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0, 10.0}"/>
     </ParameterList>
-
     <ParameterList name="Numerical Control Parameters">
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Regions">
     <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,39.9}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 39.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,39.9}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,80.22}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 80.22}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,80.22}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_westOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Outside Recharge_Boundary_eastOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Material Properties">
-    
     <ParameterList name="Facies_1">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.4082"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: GSLib">
-	<Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim1.par"/>
+        <Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim1.par"/>
         <Parameter name="GSLib Data File" type="string" value="run_data/permeability1_gslib"/>
-        <Parameter name="Value" type="double" value="2.e-12"/>
+        <Parameter name="Value" type="double" value="2e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
         <Parameter name="m" type="double" value="0.2294"/>
-        <Parameter name="alpha" type="double" value="1.9647E-4"/>
+        <Parameter name="alpha" type="double" value="0.00019647"/>
         <Parameter name="ell" type="double" value="2.0"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -147,12 +135,12 @@
         <Parameter name="Value" type="double" value="0.2206"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: GSLib">
-	<Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim2.par"/>
+        <Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim2.par"/>
         <Parameter name="GSLib Data File" type="string" value="run_data/permeability2_gslib"/>
-        <Parameter name="Value" type="double" value="7.e-11"/>
+        <Parameter name="Value" type="double" value="7e-11"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0260E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020260"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2136"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -164,12 +152,12 @@
         <Parameter name="Value" type="double" value="0.2340"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: GSLib">
-	<Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim3.par"/>
+        <Parameter name="GSLib Parameter File" type="string" value="material_data/sgsim3.par"/>
         <Parameter name="GSLib Data File" type="string" value="run_data/permeability3_gslib"/>
-        <Parameter name="Value" type="double" value="2.e-9"/>
+        <Parameter name="Value" type="double" value="2e-9"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -179,15 +167,14 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -201,16 +188,16 @@
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9793.5192 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -222,7 +209,7 @@
     <ParameterList name="BC For Bottom Surface Outside All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -238,18 +225,18 @@
     <ParameterList name="BC For Top Surface Outside Crib_216-B-17">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-17}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -259,18 +246,18 @@
     <ParameterList name="BC For Top Surface Outside Crib_216-B-18">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Crib_216-B-18}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -280,16 +267,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_westOfCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_westOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -301,16 +288,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_btwnCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_btwnCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -322,16 +309,16 @@
     <ParameterList name="BC For Top Surface Outside Recharge_Boundary_eastOfCribs">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Outside Recharge_Boundary_eastOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -345,21 +332,22 @@
     <Parameter name="File Name Digits" type="int" value="5"/>
     <ParameterList name="Time Macros">
       <ParameterList name="Every_1_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10,3.15576e+7,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 3.15576e+7, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_100">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_step">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_step}"/>

--- a/demos/phase2/dvz/8_layer-s/crib_richard_simplified.xml
+++ b/demos/phase2/dvz/8_layer-s/crib_richard_simplified.xml
@@ -1,5 +1,5 @@
 <ParameterList name="Main">
-  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>       
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="BC Cribs PE Template"/>
@@ -8,223 +8,218 @@
     <Parameter name="Creation date" type="string" value="11.30.11 01:28"/>
     <Parameter name="Last modified" type="string" value="11.30.11 01:28"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
-  <ParameterList name="Mesh">	   
+  <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{8, 128}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,  0.0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{64.5, 103.2}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{64.5, 103.2}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Verbosity" type="string" value="Low"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
-        <Parameter name="Start" type="double" value="0."/>
-        <Parameter name="End" type="double" value="1e8"/>   
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+8"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
     <Parameter name="Flow Model" type="string" value="Richards"/>
-
     <ParameterList name="Numerical Control Parameters">
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Bfr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 103.2}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 95.94375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 95.94375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="CCugr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 17.7375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 11.2875}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 11.2875}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="CCuzr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 22.575}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 17.7375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hcsr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 95.94375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 82.2375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 82.2375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hfsr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 82.2375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 23.38125}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 23.38125}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hgr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 23.38125}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 22.575}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 22.575}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Rlmr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 11.2875}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 5.64375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 5.64375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Rwiar">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 5.64375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Bfr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 96.0}"/>  
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 96.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Bfr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 99.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 99.6}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 11.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 11.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 14.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 14.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 17.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 17.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 17.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 20.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 20.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.5}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 82.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 82.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 98.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 98.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 95.9}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 95.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 23.4}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 23.4}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 52.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 52.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_t">
       <ParameterList name="Region: Point">
-      <Parameter name="Coordinate" type="Array(double)" value="{3., 81.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 81.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.6}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 23.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 23.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 5.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 5.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 8.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 8.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 11.2}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 11.2}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 0.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 0.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 3.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 5.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 5.6}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Material Properties">
     <ParameterList name="Bf">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.158"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.096e-13"/> <!-- m^2 -->
+        <Parameter name="x" type="double" value="6.096e-13"/>
+        <!-- m^2 -->
         <Parameter name="y" type="double" value="6.096e-13"/>
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.93e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000193"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.103"/>
         <Parameter name="m" type="double" value="0.28571"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Bfr}"/>
     </ParameterList>
-
-     <ParameterList name="CCug">
-      <Parameter name="Density" type="double" value="1000"/>
+    <ParameterList name="CCug">
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.237"/>
       </ParameterList>
@@ -234,16 +229,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.73e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000173"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.134"/>
         <Parameter name="m" type="double" value="0.42029"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{CCugr}"/>
     </ParameterList>
-
     <ParameterList name="CCuz">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.360"/>
       </ParameterList>
@@ -253,16 +248,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.08e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000508"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.097"/>
         <Parameter name="m" type="double" value="0.55536"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{CCuzr}"/>
     </ParameterList>
-
     <ParameterList name="Hcs">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.364"/>
       </ParameterList>
@@ -272,16 +267,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="7.32e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000732"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.074"/>
         <Parameter name="m" type="double" value="0.51138"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hcsr}"/>
-    </ParameterList>           
-
+    </ParameterList>
     <ParameterList name="Hfs">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.388"/>
       </ParameterList>
@@ -291,16 +286,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.13e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000213"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.089"/>
         <Parameter name="m" type="double" value="0.60112"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hfsr}"/>
     </ParameterList>
-
     <ParameterList name="Hg">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.237"/>
       </ParameterList>
@@ -310,16 +305,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.73e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000173"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.134"/>
         <Parameter name="m" type="double" value="0.42029"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hgr}"/>
     </ParameterList>
-
     <ParameterList name="Rlm">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.360"/>
       </ParameterList>
@@ -329,16 +324,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.08e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000508"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.097"/>
         <Parameter name="m" type="double" value="0.55536"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Rlmr}"/>
     </ParameterList>
-
     <ParameterList name="Rwia">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.267"/>
       </ParameterList>
@@ -348,24 +343,23 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="8.13e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000813"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.135"/>
         <Parameter name="m" type="double" value="0.39759"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Rwiar}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="8.9e-4"/>
+          <Parameter name="Viscosity" type="double" value="0.00089"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998."/>
+          <Parameter name="Density" type="double" value="998.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -375,16 +369,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325."/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0., 0.}"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
         <!-- GEH: Units of gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2-->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
@@ -393,19 +385,17 @@
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
-            </ParameterList>     
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC For Inflow">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{}"/>
         <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1091e-10}"/>
       </ParameterList>
@@ -414,23 +404,22 @@
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                  <!-- GEH: Throughout entire simulation, no solute enters through top surface -->
-                <Parameter name="Times" type="Array(double)" value="{0.}"/>
+                <!-- GEH: Throughout entire simulation, no solute enters through top surface -->
+                <Parameter name="Times" type="Array(double)" value="{0.0}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC For Scalar">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{}"/>
-        <Parameter name="Values" type="Array(double)" value="{101325.}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -443,7 +432,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC For No Flow">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, XHIBC}"/>
       <ParameterList name="BC: No Flow">
@@ -459,11 +447,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-100-steps">
@@ -473,18 +458,15 @@
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
     <ParameterList name="Time Macros">
       <ParameterList name="Long">
-        <Parameter name="Values" type="Array(double)" value="{1e8}"/>
+        <Parameter name="Values" type="Array(double)" value="{1e+8}"/>
       </ParameterList>
       <ParameterList name="Near-end">
-        <Parameter name="Values" type="Array(double)" value="{98000000, 98100000}"/>
+        <Parameter name="Values" type="Array(double)" value="{98000000.0, 98100000.0}"/>
       </ParameterList>
     </ParameterList>
-
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
@@ -626,19 +608,15 @@
         <Parameter name="Time Macros" type="Array(string)" value="{Long}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="viz-"/>
       <Parameter name="Cycle Macro" type="string" value="Every-100-steps"/>
       <Parameter name="Time Macro" type="string" value="Near-end"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="dump-"/>
       <Parameter name="Cycle Macro" type="string" value="Every-1000-steps"/>
     </ParameterList>
-
-  </ParameterList> <!-- End of Output -->
-
-</ParameterList> <!-- End of Main -->
-       
+  </ParameterList>
+  <!-- End of Output -->
+</ParameterList>

--- a/demos/phase2/dvz/8_layer-s/crib_richard_simplified_amr.xml
+++ b/demos/phase2/dvz/8_layer-s/crib_richard_simplified_amr.xml
@@ -1,7 +1,7 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="ppfile"/>
-  <Parameter name="Echo Inputs" type="bool" value="TRUE"/>
+  <Parameter name="Echo Inputs" type="bool" value="true"/>
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="BC Cribs PE Template"/>
@@ -10,242 +10,233 @@
     <Parameter name="Creation date" type="string" value="11.30.11 01:28"/>
     <Parameter name="Last modified" type="string" value="11.30.11 01:28"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
-  <ParameterList name="Mesh">	   
+  <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{8, 128}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,  0.0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{64.5, 103.2}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{64.5, 103.2}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Verbosity" type="string" value="Low"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
-        <Parameter name="Start" type="double" value="0."/>
-        <Parameter name="End" type="double" value="1e8"/>   
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+8"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
     <Parameter name="Flow Model" type="string" value="Richards"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{8, 8, 8}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{16, 16, 16}"/>
-	  <Parameter name="Numbers Error Buffer Cells" type="Array(int)" value="{2, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Region ref}"/>
-
-	  <ParameterList name="Region ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Hgr, CCugr}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	  </ParameterList>
-
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{8, 8, 8}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{16, 16, 16}"/>
+          <Parameter name="Numbers Error Buffer Cells" type="Array(int)" value="{2, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Region ref}"/>
+          <ParameterList name="Region ref">
+            <Parameter name="Regions" type="Array(string)" value="{Hgr, CCugr}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Bfr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 103.2}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 95.94375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 95.94375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="CCugr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 17.7375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 11.2875}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 11.2875}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="CCuzr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 22.575}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 17.7375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hcsr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 95.94375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 82.2375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 82.2375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hfsr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 82.2375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 23.38125}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 23.38125}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Hgr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 23.38125}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 22.575}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 22.575}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Rlmr">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 11.2875}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 5.64375}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 5.64375}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Rwiar">
       <ParameterList name="Region: Box">
         <Parameter name="High Coordinate" type="Array(double)" value="{64.5, 5.64375}"/>
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0, 0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Bfr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 96.0}"/>  
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 96.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Bfr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 99.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 99.6}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 11.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 11.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 14.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 14.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCugr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 17.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 17.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 17.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 20.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 20.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_CCuzr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.5}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 82.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 82.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 98.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 98.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hcsr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 95.9}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 95.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 23.4}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 23.4}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 52.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 52.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hfsr_t">
       <ParameterList name="Region: Point">
-      <Parameter name="Coordinate" type="Array(double)" value="{3., 81.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 81.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.6}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 22.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 22.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Hgr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 23.3}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 23.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 5.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 5.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 8.7}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 8.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rlmr_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 11.2}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 11.2}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_b">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 0.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 0.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_c">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 3.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="pt_Rwiar_t">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{3., 5.6}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.0, 5.6}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Material Properties">
     <ParameterList name="Bf">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.158"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.096e-13"/> <!-- m^2 -->
+        <Parameter name="x" type="double" value="6.096e-13"/>
+        <!-- m^2 -->
         <Parameter name="y" type="double" value="6.096e-13"/>
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.93e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000193"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.103"/>
         <Parameter name="m" type="double" value="0.28571"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Bfr}"/>
     </ParameterList>
-
-     <ParameterList name="CCug">
-      <Parameter name="Density" type="double" value="1000"/>
+    <ParameterList name="CCug">
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.237"/>
       </ParameterList>
@@ -255,16 +246,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.73e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000173"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.134"/>
         <Parameter name="m" type="double" value="0.42029"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{CCugr}"/>
     </ParameterList>
-
     <ParameterList name="CCuz">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.360"/>
       </ParameterList>
@@ -274,16 +265,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.08e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000508"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.097"/>
         <Parameter name="m" type="double" value="0.55536"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{CCuzr}"/>
     </ParameterList>
-
     <ParameterList name="Hcs">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.364"/>
       </ParameterList>
@@ -293,16 +284,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="7.32e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000732"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.074"/>
         <Parameter name="m" type="double" value="0.51138"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hcsr}"/>
-    </ParameterList>           
-
+    </ParameterList>
     <ParameterList name="Hfs">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.388"/>
       </ParameterList>
@@ -312,16 +303,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.13e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000213"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.089"/>
         <Parameter name="m" type="double" value="0.60112"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hfsr}"/>
     </ParameterList>
-
     <ParameterList name="Hg">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.237"/>
       </ParameterList>
@@ -331,16 +322,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.73e-4"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.000173"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.134"/>
         <Parameter name="m" type="double" value="0.42029"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Hgr}"/>
     </ParameterList>
-
     <ParameterList name="Rlm">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.360"/>
       </ParameterList>
@@ -350,16 +341,16 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.08e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000508"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.097"/>
         <Parameter name="m" type="double" value="0.55536"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Rlmr}"/>
     </ParameterList>
-
     <ParameterList name="Rwia">
-      <Parameter name="Density" type="double" value="1000"/>
+      <Parameter name="Density" type="double" value="1000.0"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.267"/>
       </ParameterList>
@@ -369,24 +360,23 @@
       </ParameterList>
       <!-- GEH: Pressure-saturation function: van Genuchten-->
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="8.13e-5"/> <!-- 0.021 cm^-1 -> Pa^-1 -->
+        <Parameter name="alpha" type="double" value="0.0000813"/>
+        <!-- 0.021 cm^-1 -> Pa^-1 -->
         <Parameter name="Sr" type="double" value="0.135"/>
         <Parameter name="m" type="double" value="0.39759"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Rwiar}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="8.9e-4"/>
+          <Parameter name="Viscosity" type="double" value="0.00089"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998."/>
+          <Parameter name="Density" type="double" value="998.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -396,16 +386,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325."/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0., 0.}"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
         <!-- GEH: Units of gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2-->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
@@ -414,15 +402,13 @@
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
-            </ParameterList>     
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC For Inflow">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
@@ -433,19 +419,18 @@
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                  <!-- GEH: Throughout entire simulation, no solute enters through top surface -->
-                <Parameter name="Values" type="Array(double)" value="{0.}"/>
+                <!-- GEH: Throughout entire simulation, no solute enters through top surface -->
+                <Parameter name="Values" type="Array(double)" value="{0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC For Scalar">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325.}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -458,7 +443,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC For No Flow">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, XHIBC}"/>
       <ParameterList name="BC: No Flow">
@@ -474,11 +458,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-1-step">
@@ -491,18 +472,15 @@
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
     <ParameterList name="Time Macros">
       <ParameterList name="Long">
-        <Parameter name="Values" type="Array(double)" value="{1e8}"/>
+        <Parameter name="Values" type="Array(double)" value="{1e+8}"/>
       </ParameterList>
       <ParameterList name="Near-end">
-        <Parameter name="Values" type="Array(double)" value="{98000000, 98100000}"/>
+        <Parameter name="Values" type="Array(double)" value="{98000000.0, 98100000.0}"/>
       </ParameterList>
     </ParameterList>
-
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
@@ -644,19 +622,15 @@
         <Parameter name="Time Macros" type="Array(string)" value="{Long}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="viz-"/>
       <Parameter name="Cycle Macro" type="string" value="Every-1-step"/>
       <Parameter name="Time Macro" type="string" value="Near-end"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="dump-"/>
       <Parameter name="Cycle Macro" type="string" value="Every-1000-steps"/>
     </ParameterList>
-
-  </ParameterList> <!-- End of Output -->
-
-</ParameterList> <!-- End of Main -->
-       
+  </ParameterList>
+  <!-- End of Output -->
+</ParameterList>

--- a/demos/phase2/dvz/8_layer-s/freedmans.xml
+++ b/demos/phase2/dvz/8_layer-s/freedmans.xml
@@ -1,331 +1,332 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Chandrika"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="On"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.17266656e10"/>
-          <Parameter name="End" type="double" value="6.17266656e10"/>
-          <!-- Parameter name="End" type="double" value="9.4672798E10"/-->
-          <Parameter name="Steady Initial Time Step" type="double" value="86400"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="1"/>
-        </ParameterList>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-	<ParameterList name="Structured Algorithm">
-	</ParameterList>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Chandrika"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="On"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="6.17266656e+10"/>
+        <!-- Parameter name="End" type="double" value="9.4672798E10"/-->
+        <Parameter name="Steady Initial Time Step" type="double" value="86400.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="2"/>
-    </ParameterList>
-
-    <ParameterList name="Mesh">	   
-      <ParameterList name="Structured">
-	<Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
-	<Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,  0.0}" />
-	<Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}" />
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="Regions">
-      <ParameterList name="Bottom Surface All">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,0.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,39.9}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,39.9}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,80.22}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,80.22}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Crib_216-B-17">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Crib_216-B-18">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Recharge_Boundary_westOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Recharge_Boundary_btwnCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Recharge_Boundary_eastOfCribs">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.9467E-04"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2294"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0260E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.2136"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2340"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-09"/>
-          <Parameter name="y" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="2.0674E-03"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="m" type="double" value="0.3006"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="Phase Components">
-          <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="ALL">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Linear Pressure">
-          <Parameter name="Reference Value" type="double" value="101325 "/>
-          <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-          <Parameter name="Gradient Value" type="Array(double)" value="{0,-9793.5192 }"/>
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface All}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Crib_216-B-17">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-17}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 6.1729346E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071E-10, 0.00254022E-3, 1.48666E-9, 1.48666E-9}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 6.1729346E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Crib_216-B-18">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-18}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 6.1731787E10, 6.1737054E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071E-10, 1.48666E-9, 0.00330423E-3, 1.48666E-9, 1.48666E-9}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 6.1731787E10, 6.1737054E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Recharge_Boundary_westOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_westOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Recharge_Boundary_btwnCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_btwnCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface Recharge_Boundary_eastOfCribs">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667E10, 9.4672798E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-        <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-        <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Structured Algorithm">
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="2"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Structured">
+      <Parameter name="Number of Cells" type="Array(int)" value="{432, 256}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Bottom Surface All">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 39.9}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 39.9}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 80.22}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 2 and Plane Surface 3">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 80.22}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Crib_216-B-17">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Crib_216-B-18">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Recharge_Boundary_westOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Recharge_Boundary_btwnCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Recharge_Boundary_eastOfCribs">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.00019467"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2294"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020260"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.2136"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2340"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="m" type="double" value="0.3006"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 2 and Plane Surface 3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="ALL">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface All}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Crib_216-B-17">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-17}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 6.1729346e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 0.00000254022, 1.48666e-9, 1.48666e-9}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 6.1729346e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Crib_216-B-18">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-18}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 6.1731787e+10, 6.1737054e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 0.00000330423, 1.48666e-9, 1.48666e-9}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 6.1731787e+10, 6.1737054e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Recharge_Boundary_westOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_westOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Recharge_Boundary_btwnCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_btwnCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Recharge_Boundary_eastOfCribs">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.1726667e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d-s.xml
+++ b/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d-s.xml
@@ -4,19 +4,16 @@
     <Parameter name="Model ID" type="string" value="TBD"/>
     <Parameter name="Author" type="string" value="Chandrika"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-  
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216,107.52}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{448,256}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{448, 256}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="On"/>
@@ -24,28 +21,22 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="Switch" type="double" value="6.17266656e10"/>
-	<!--        <Parameter name="End" type="double" value="61736132880.000"/> -->
-        <Parameter name="End" type="double" value="9.4672798E10"/> 
-        <Parameter name="Steady Initial Time Step" type="double" value="10000"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="100"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <!--        <Parameter name="End" type="double" value="61736132880.000"/> -->
+        <Parameter name="End" type="double" value="9.4672798e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="10000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Time Period Control">
-      <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Numerical Control Parameters">
-
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-
           <Parameter name="max_n_subcycle_transport" type="int" value="20"/>
-
           <Parameter name="do_multilevel_full" type="int" value="1"/>
           <Parameter name="do_richard_init_to_steady" type="int" value="0"/>
           <Parameter name="richard_init_to_steady_verbose" type="int" value="2"/>
@@ -55,7 +46,7 @@
           <Parameter name="steady_min_iterations" type="int" value="5"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.25"/>
           <Parameter name="steady_min_iterations_2" type="int" value="0"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="10.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.05"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="4"/>
@@ -63,52 +54,45 @@
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.001"/>
           <Parameter name="steady_max_time_steps" type="int" value="500"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e11"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+11"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
           <Parameter name="steady_do_grid_sequence" type="int" value="1"/>
-          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="double" value="1.e-3"/>
-
+          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="double" value="0.001"/>
           <Parameter name="richard_solver_verbose" type="int" value="3"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="5"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="5.0"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="0"/>
-
           <Parameter name="richard_use_fd_jac" type="int" value="1"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-8"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1e-8"/>
           <Parameter name="richard_use_dense_Jacobian" type="int" value="0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="3"/>
           <Parameter name="richard_scale_solution_before_solve" type="bool" value="true"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="false"/>
           <Parameter name="richard_variable_switch_saturation_threshold" type="double" value="0.9996"/>
-
           <Parameter name="verbose" type="int" value="2"/>
-
         </ParameterList>
-      
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="1"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{32, 32, 32, 32}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
-	</ParameterList>
-      
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="1"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{32, 32, 32, 32}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Bottom Surface All">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,0.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region 1">
@@ -137,32 +121,32 @@
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{78.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{147.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_westOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{74.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{143.5,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_eastOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -172,11 +156,11 @@
         <Parameter name="Value" type="double" value="0.4082"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.9976E-12"/>
-        <Parameter name="y" type="double" value="1.9976E-13"/>
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.9467E-04"/>
+        <Parameter name="alpha" type="double" value="0.00019467"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2294"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -188,11 +172,11 @@
         <Parameter name="Value" type="double" value="0.2206"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.9365E-11"/>
-        <Parameter name="y" type="double" value="6.9365E-12"/>
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0260E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020260"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3333"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -204,18 +188,18 @@
         <Parameter name="Value" type="double" value="0.2340"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0706E-09"/>
-        <Parameter name="y" type="double" value="2.0706E-10"/>
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 3}"/>
     </ParameterList>
-<!--    <ParameterList name="Gravel">
+    <!--    <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.422"/>
       </ParameterList>
@@ -231,33 +215,32 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
---> 
+-->
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.234"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0607E-09"/>
-        <Parameter name="y" type="double" value="2.06073E-09"/>
+        <Parameter name="x" type="double" value="2.0607e-9"/>
+        <Parameter name="y" type="double" value="2.06073e-9"/>
       </ParameterList>
-     <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
-
- </ParameterList>
+  </ParameterList>
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -270,13 +253,11 @@
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325 "/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9793.5192 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
-
       <!-- <ParameterList name="IC: File Pressure"> -->
       <!--   <Parameter name="File" type="string" value="ssCheckpt-72PE.h5"/> -->
       <!--   <Parameter name="Label" type="string" value="pressure"/> -->
@@ -286,7 +267,7 @@
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -298,16 +279,16 @@
     <ParameterList name="BC For Bottom Surface All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface All}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
@@ -319,22 +300,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-17">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-17}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-        <Parameter name="Inward Volumetric Flux" type="Array(double)"
-          value="{1.1071E-10, 0.00254022E-3, 1.48666E-9, 1.48666E-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 0.00000254022, 1.48666e-9, 1.48666e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -344,24 +321,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-18">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-18}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-        <Parameter name="Time Functions" type="Array(string)"
-          value="{Constant, Constant, Constant, Constant}"/>
-        <Parameter name="Inward Volumetric Flux" type="Array(double)"
-          value="{1.1071E-10, 1.48666E-9, 0.00330423E-3, 1.48666E-9, 1.48666E-9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 0.00000330423, 1.48666e-9, 1.48666e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)"
-                  value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -369,21 +340,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_westOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_westOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_westOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Volumetric Flux" type="Array(double)"
-          value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -393,21 +361,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_btwnCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_btwnCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_btwnCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Volumetric Flux" type="Array(double)"
-          value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -417,21 +382,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_eastOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Volumetric Flux" type="Array(double)"
-          value="{1.1071E-10, 1.48666E-9, 1.48666E-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.1071e-10, 1.48666e-9, 1.48666e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -442,19 +404,21 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Output">
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1.0_1000.0_-1">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_1">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="File Name Digits" type="int" value="5"/>

--- a/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d.xml
+++ b/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d.xml
@@ -11,13 +11,13 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="Switch" type="double" value="6.17266656e10"/>
-<!--        <Parameter name="End" type="double" value="61736132880.000"/> -->
-        <Parameter name="End" type="double" value="9.4672798E10"/> 
-        <Parameter name="Steady Initial Time Step" type="double" value="10000"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="100"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <!--        <Parameter name="End" type="double" value="61736132880.000"/> -->
+        <Parameter name="End" type="double" value="9.4672798e+10"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="10000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Steady">
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="End" type="double" value="6.17266656E10"/>
@@ -26,8 +26,8 @@
 -->
     </ParameterList>
     <ParameterList name="Time Period Control">
-      <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Numerical Control Parameters">
@@ -39,7 +39,7 @@
           <Parameter name="steady max iterations" type="int" value="20"/>
           <Parameter name="steady min iterations" type="int" value="7"/>
           <Parameter name="steady limit iterations" type="int" value="30"/>
-          <Parameter name="steady nonlinear tolerance" type="double" value="1e-5"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.00001"/>
           <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
           <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
           <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
@@ -49,7 +49,7 @@
           <Parameter name="transient max iterations" type="int" value="20"/>
           <Parameter name="transient min iterations" type="int" value="12"/>
           <Parameter name="transient limit iterations" type="int" value="30"/>
-          <Parameter name="transient nonlinear tolerance" type="double" value="1e-5"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.00001"/>
           <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
           <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
@@ -69,7 +69,7 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
           <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
         </ParameterList>
       </ParameterList>
@@ -84,8 +84,8 @@
   <ParameterList name="Regions">
     <ParameterList name="Bottom Surface All">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,0.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region 1">
@@ -114,32 +114,32 @@
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_westOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_eastOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -149,12 +149,12 @@
         <Parameter name="Value" type="double" value="0.4082"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.9976E-12"/>
-        <Parameter name="y" type="double" value="1.9976E-12"/>
-        <Parameter name="z" type="double" value="1.9976E-13"/>
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.9467E-04"/>
+        <Parameter name="alpha" type="double" value="0.00019467"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2294"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -166,12 +166,12 @@
         <Parameter name="Value" type="double" value="0.2206"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.9365E-11"/>
-        <Parameter name="y" type="double" value="6.9365E-11"/>
-        <Parameter name="z" type="double" value="6.9365E-12"/>
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0260E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020260"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3333"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -183,19 +183,19 @@
         <Parameter name="Value" type="double" value="0.2340"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0706E-09"/>
-        <Parameter name="y" type="double" value="2.0706E-09"/>
-        <Parameter name="z" type="double" value="2.0706E-10"/>
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 3}"/>
     </ParameterList>
-<!--    <ParameterList name="Gravel">
+    <!--    <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.422"/>
       </ParameterList>
@@ -211,34 +211,33 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
---> 
+-->
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.234"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0607E-09"/>
-        <Parameter name="y" type="double" value="2.0607E-09"/>
-        <Parameter name="z" type="double" value="2.06073E-09"/>
+        <Parameter name="x" type="double" value="2.0607e-9"/>
+        <Parameter name="y" type="double" value="2.0607e-9"/>
+        <Parameter name="z" type="double" value="2.06073e-9"/>
       </ParameterList>
-     <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
-
- </ParameterList>
+  </ParameterList>
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -253,22 +252,22 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Reference Value" type="double" value="101325 "/>
-        <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="IC: File Pressure">
         <Parameter name="File" type="string" value="ssCheckpt-72PE.h5"/>
         <Parameter name="Label" type="string" value="pressure"/>
       </ParameterList>
---> 
+-->
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -280,16 +279,16 @@
     <ParameterList name="BC For Bottom Surface All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface All}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
@@ -301,22 +300,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-17">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-17}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -326,24 +321,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-18">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-18}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-        <Parameter name="Time Functions" type="Array(string)"
-          value="{Constant, Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)"
-                  value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -351,21 +340,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_westOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_westOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_westOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -375,21 +361,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_btwnCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_btwnCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_btwnCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -399,21 +382,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_eastOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -424,21 +404,24 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Output">
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1.0_1000.0_-1">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Variable Macros"/>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
-      <Parameter name="Cycle Macros" type="Array(string)" value="Every_100"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_100}"/>
     </ParameterList>
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="checkpoint"/>

--- a/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d_tpfa_steady.xml
+++ b/demos/phase2/dvz/heterogeneous-2d/heterogeneous-2d_tpfa_steady.xml
@@ -11,13 +11,13 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="Switch" type="double" value="6.17266656e10"/>
-        <Parameter name="End" type="double" value="6.17266656e10"/>
-<!--        <Parameter name="End" type="double" value="9.4672798E10"/>    -->
-        <Parameter name="Steady Initial Time Step" type="double" value="10000"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="100"/>
+        <Parameter name="Switch" type="double" value="6.17266656e+10"/>
+        <Parameter name="End" type="double" value="6.17266656e+10"/>
+        <!--        <Parameter name="End" type="double" value="9.4672798E10"/>    -->
+        <Parameter name="Steady Initial Time Step" type="double" value="10000.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Steady">
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="End" type="double" value="6.17266656E10"/>
@@ -26,8 +26,8 @@
 -->
     </ParameterList>
     <ParameterList name="Time Period Control">
-      <Parameter name="Start Times" type="Array(double)" value="{6.1729344E10, 6.173178481E10, 6.173705521E10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{10, 10, 10}"/>
+      <Parameter name="Start Times" type="Array(double)" value="{6.1729344e+10, 6.173178481e+10, 6.173705521e+10}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Numerical Control Parameters">
@@ -39,7 +39,7 @@
           <Parameter name="steady max iterations" type="int" value="15"/>
           <Parameter name="steady min iterations" type="int" value="7"/>
           <Parameter name="steady limit iterations" type="int" value="20"/>
-          <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
           <Parameter name="steady max timestep" type="double" value="6.0e+9"/>
           <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
           <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
@@ -49,15 +49,15 @@
           <Parameter name="transient max iterations" type="int" value="20"/>
           <Parameter name="transient min iterations" type="int" value="12"/>
           <Parameter name="transient limit iterations" type="int" value="30"/>
-          <Parameter name="transient nonlinear tolerance" type="double" value="1e-6"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000001"/>
           <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
           <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
           <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-	<ParameterList name="Nonlinear Solver">
-	  <Parameter name="Nonlinear Solver Type" type="string" value="Newton" />
-	</ParameterList>
+        <ParameterList name="Nonlinear Solver">
+          <Parameter name="Nonlinear Solver Type" type="string" value="Newton"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -72,7 +72,7 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{432, 1, 256}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
           <Parameter name="Domain High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
         </ParameterList>
       </ParameterList>
@@ -87,8 +87,8 @@
   <ParameterList name="Regions">
     <ParameterList name="Bottom Surface All">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,0.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region 1">
@@ -117,32 +117,32 @@
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{78.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{147.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_westOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{74.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{143.5,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.5, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface Recharge_Boundary_eastOfCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5,0.0,107.52}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{216.0,1.0,107.52}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.5, 0.0, 107.52}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.0, 1.0, 107.52}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -152,12 +152,12 @@
         <Parameter name="Value" type="double" value="0.4082"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.9976E-12"/>
-        <Parameter name="y" type="double" value="1.9976E-12"/>
-        <Parameter name="z" type="double" value="1.9976E-13"/>
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.9467E-04"/>
+        <Parameter name="alpha" type="double" value="0.00019467"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.2294"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -169,12 +169,12 @@
         <Parameter name="Value" type="double" value="0.2206"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="6.9365E-11"/>
-        <Parameter name="y" type="double" value="6.9365E-11"/>
-        <Parameter name="z" type="double" value="6.9365E-12"/>
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0260E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020260"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3333"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -186,19 +186,19 @@
         <Parameter name="Value" type="double" value="0.2340"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0706E-09"/>
-        <Parameter name="y" type="double" value="2.0706E-09"/>
-        <Parameter name="z" type="double" value="2.0706E-10"/>
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 3}"/>
     </ParameterList>
-<!--    <ParameterList name="Gravel">
+    <!--    <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.422"/>
       </ParameterList>
@@ -214,34 +214,33 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
---> 
+-->
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.234"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.0607E-09"/>
-        <Parameter name="y" type="double" value="2.0607E-09"/>
-        <Parameter name="z" type="double" value="2.06073E-09"/>
+        <Parameter name="x" type="double" value="2.0607e-9"/>
+        <Parameter name="y" type="double" value="2.0607e-9"/>
+        <Parameter name="z" type="double" value="2.06073e-9"/>
       </ParameterList>
-     <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="2.0674E-03"/>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.0020674"/>
         <Parameter name="Sr" type="double" value="0.0"/>
         <Parameter name="m" type="double" value="0.3006"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Region 4}"/>
     </ParameterList>
-
- </ParameterList>
+  </ParameterList>
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -256,22 +255,22 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Reference Value" type="double" value="101325 "/>
-        <Parameter name="Reference Coordinate" type="Array(double)" value="{0,0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,0,-9793.5192 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="IC: File Pressure">
         <Parameter name="File" type="string" value="ssCheckpt-72PE.h5"/>
         <Parameter name="Label" type="string" value="pressure"/>
       </ParameterList>
---> 
+-->
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -283,16 +282,16 @@
     <ParameterList name="BC For Bottom Surface All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface All}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Values" type="Array(double)" value="{101325., 101325.}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0, 101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
@@ -304,22 +303,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-17">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-17}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 0.00254022, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00254022, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.1729344E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{0.0, 1.881389E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000001881389, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -329,24 +324,18 @@
     <ParameterList name="BC For Top Surface Crib_216-B-18">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Crib_216-B-18}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)"
-          value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-        <Parameter name="Time Functions" type="Array(string)"
-          value="{Constant, Constant, Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 0.00330423, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00330423, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 6.173178481E10, 6.173705521E10, 9.4672798E10}"/>
-                <Parameter name="Time Functions" type="Array(string)"
-                  value="{Constant, Constant, Constant, Constant}"/>
-                <Parameter name="Values" type="Array(double)"
-                  value="{0.0, 0.0, 2.266885E-06, 0.0, 0.0}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000002266885, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -354,21 +343,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_westOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_westOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_westOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -378,21 +364,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_btwnCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_btwnCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_btwnCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -402,21 +385,18 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="BC For Top Surface Recharge_Boundary_eastOfCribs">
-      <Parameter name="Assigned Regions" type="Array(string)"
-        value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Recharge_Boundary_eastOfCribs}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)"
-          value="{1.1071E-7, 1.48666E-6, 1.48666E-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.1071e-7, 0.00000148666, 0.00000148666}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)"
-                  value="{0.0, 6.17266656E10, 9.4672798E10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 9.4672798e+10}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
@@ -426,15 +406,15 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
-   <!--   <ParameterList name="Every_1.0_1000.0_-1">
+      <!--   <ParameterList name="Every_1.0_1000.0_-1">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
       </ParameterList> -->
       <ParameterList name="Every-100">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -442,7 +422,7 @@
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every-100}"/>
     </ParameterList>
-<!--
+    <!--
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="checkpoint"/>
       <Parameter name="File Name Digit" type="int" value="5"/>
@@ -450,5 +430,4 @@
     </ParameterList>
 -->
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase2/dvz/heterogeneous_3d-bcb/amanzi.xml
+++ b/demos/phase2/dvz/heterogeneous_3d-bcb/amanzi.xml
@@ -1,21 +1,21 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="ellen"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-<!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="ellen"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <!--
       <ParameterList name="Restart from Checkpoint Data File">
           <Parameter name="Checkpoint Data File Name" type="string" value="restart_steadystate.h5"/>
       </ParameterList>
 -->
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="On"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-          <!--
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="On"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0           [s]
              Start transient:      t = 1956.0 [y] = 6.17266656E10 [s]  
@@ -24,16 +24,16 @@
              Note that at 1956, the land use model changes, causing a change in the background infiltration rate.
              At the same time the first crib starts.
 
-          -->             
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.172666560000E10"/>
-          <Parameter name="End" type="double" value="6.33676608E10"/>
-          <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
-          <Parameter name="Steady Initial Time Step" type="double" value="100000.0"/>
-        </ParameterList>
+          -->
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="61726665600.00"/>
+        <Parameter name="End" type="double" value="6.33676608e+10"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="100000.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-        <!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -59,496 +59,496 @@
             version uses just 1957.0000, and it seems to run.
 
         -->
-        <Parameter name="Start Times" type="Array(double)" value="{6.172666560000E10,6.172925963472E10,6.172934484024E10,6.173176530816E10,6.173185366944E10,6.173453290968E10,6.173453290968E10,6.173704173888E10,6.174758828880E10,6.175269115272E10,6.175813799448E10,6.175822320000E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0}"/>
-        <Parameter name="Maximum Time Step" type="Array(double)" value="{864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
+      <Parameter name="Start Times" type="Array(double)" value="{61726665600.00, 61729259634.72, 61729344840.24, 61731765308.16, 61731853669.44, 61734532909.68, 61734532909.68, 61737041738.88, 61747588288.80, 61752691152.72, 61758137994.48, 61758223200.00}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}"/>
+      <Parameter name="Maximum Time Step" type="Array(double)" value="{864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0}"/>
+    </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="20"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="30"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
+        </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="20"/>
+          <Parameter name="transient min iterations" type="int" value="12"/>
+          <Parameter name="transient limit iterations" type="int" value="30"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.00001"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
+        </ParameterList>
+        <ParameterList name="Nonlinear Solver">
+          <Parameter name="Nonlinear Solver Type" type="string" value="Newton"/>
+          <Parameter name="modify correction" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="3"/>
           </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="20"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="30"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="20"/>
-            <Parameter name="transient min iterations" type="int" value="12"/>
-            <Parameter name="transient limit iterations" type="int" value="30"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
-          </ParameterList>
-          <ParameterList name="Nonlinear Solver">
-            <Parameter name="Nonlinear Solver Type" type="string" value="Newton"/>
-	    <Parameter name="modify correction" type="bool" value="true"/>
-          </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="ML cycle applications" type="int" value="3"/>
-            </ParameterList>
-            <ParameterList name="Hypre AMG">
-              <Parameter name="Hypre AMG cycle applications" type="int" value="10"/>
-              <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
-              <Parameter name="Hypre AMG tolerance" type="double" value="0.1"/>
-              <Parameter name="Hypre AMG strong threshold" type="double" value="0.8"/>
-            </ParameterList>
+          <ParameterList name="Hypre AMG">
+            <Parameter name="Hypre AMG cycle applications" type="int" value="10"/>
+            <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
+            <Parameter name="Hypre AMG tolerance" type="double" value="0.1"/>
+            <Parameter name="Hypre AMG strong threshold" type="double" value="0.8"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-	<ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-	</ParameterList>
-        <ParameterList name="Generate Mesh">
-          <ParameterList name="Uniform Structured">
-            <Parameter name="Number of Cells" type="Array(int)" value="{64, 56, 107}"/>
-            <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-            <Parameter name="Domain High Coordinate" type="Array(double)" value="{320.0,280.0,107.0}"/>
-          </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{64, 56, 107}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{320.0, 280.0, 107.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Region for facies1">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="1"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Region for facies1">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="1"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region for facies2">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="2"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region for facies3">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="3"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Vertical strip to the left of the cribs                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{110.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Vertical strip to the right of the cribs                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{205.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{320.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip above the two rows of cribs                              -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 165.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip below the two rows of cribs                            -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 115.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between the two rows of cribs                            -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 120.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 160.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-19 and 216-B-17                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{115.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{155.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-17 and 216-B-15                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{160.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{200.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-18 and 216-B-16                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{115.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{155.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-16 and 216-B-14                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{160.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{200.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-14                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{200.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-15                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{200.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-16                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{155.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{160.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-17                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{155.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{160.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-18                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{115.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{115.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
+      <!-- Entire bottom surface                                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{320.0, 280.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.2832"/>
+        <Parameter name="alpha" type="double" value="0.0002470612"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.261"/>
+        <Parameter name="alpha" type="double" value="0.002573475"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.234"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.387"/>
+        <Parameter name="alpha" type="double" value="0.002756137"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Region for facies2">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="2"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region for facies3">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="3"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Vertical strip to the left of the cribs                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{110.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Vertical strip to the right of the cribs                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{205.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{320.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip above the two rows of cribs                              -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,165.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip below the two rows of cribs                            -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,115.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between the two rows of cribs                            -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,120.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,160.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-19 and 216-B-17                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{115.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{155.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-17 and 216-B-15                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{160.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{200.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-18 and 216-B-16                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{115.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{155.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-16 and 216-B-14                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{160.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{200.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-14                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{200.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-15                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{200.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-16                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{155.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{160.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-17                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{155.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{160.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-18                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{115.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]                                --> 
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{115.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
-        <!-- Entire bottom surface                                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{320.0,280.0,0.0}"/>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.2832"/>
-          <Parameter name="alpha" type="double" value="2.470612E-04"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies1}"/>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
       </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.261"/>
-          <Parameter name="alpha" type="double" value="2.573475E-03"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.234"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-9"/>
-          <Parameter name="y" type="double" value="2.0706E-9"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.387"/>
-          <Parameter name="alpha" type="double" value="2.756137E-03"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-	  <ParameterList name="Viscosity: Uniform">
-	    <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-	  </ParameterList>
-	  <ParameterList name="Density: Uniform">
-	    <Parameter name="Density" type="double" value="998.2 "/>
-	  </ParameterList>
-	</ParameterList>
-        <ParameterList name="Phase Components">
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-	<ParameterList name="IC: Linear Pressure">
-	  <Parameter name="Phase" type="string" value="Aqueous"/>
-	  <Parameter name="Reference Value" type="double" value="101325 "/>
-	  <Parameter name="Reference Point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-	  <Parameter name="Gradient Value" type="Array(double)" value="{0.0,0.0,-9793.5192 }"/>
-	</ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0.0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-14                                                                     
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-14                                                                     
 
                 0.0000 [y] < t < 1956.0000 [y]          5.0 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.1616 [y]       2080.8 [m/y]       3.800e-6 [Ci/L]
@@ -567,28 +567,28 @@
                63.0 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [ kg/s/m^2 ]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731765308159996E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 0.06581788729180926, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731765308159996E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 3.8e-6, 0.0, 0.0}"/>
-                </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731765308.159996, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.06581788729180926, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731765308.159996, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0000038, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-15
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-15
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.2493 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -610,28 +610,28 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.175813799448E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.004569421375516516, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.175813799448E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.800e-6, 0.0, 0.0}"/>
-                </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61758137994.48, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.004569421375516516, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61758137994.48, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003800, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-16
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-16
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.2493 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -653,28 +653,28 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.17475882888E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.017004852080006082, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.17475882888E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.524e-6, 0.0, 0.0}"/>
-                </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61747588288.8, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.017004852080006082, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61747588288.8, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003524, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-17
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-17
 
                 0.0000 [y] < t < 1956.0000 [y]          5.0 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.0822 [y]       1636.0 [m/y]       2.886e-6 [Ci/L]
@@ -693,28 +693,28 @@
                63.0 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.9927561031257130e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.172925963472E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 0.05177370142216137, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.172925963472E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 2.886e-6, 0.0, 0.0}"/>
-                </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729259634.72, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.05177370142216137, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729259634.72, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000002886, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-18
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-18
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.1644 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -736,28 +736,28 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731853669439995E10, 6.173704173888E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.06467916951859456, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731853669439995E10, 6.173704173888E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.798e-6, 0.0, 0.0}"/>
-                </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731853669.439995, 61737041738.88, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.06467916951859456, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731853669.439995, 61737041738.88, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003798, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.0849 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -779,91 +779,90 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1729344840240005E10, 6.175269115271999E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.010712487451517224, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1729344840240005E10, 6.175269115271999E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.164e-6, 0.0, 0.0}"/>
-                </ParameterList>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729344840.240005, 61752691152.71999, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.010712487451517224, 0.0000019927561031257127, 0.0000019927561031257127}"/>
       </ParameterList>
-      <ParameterList name="BC For Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{106221.7596, 106221.7596}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729344840.240005, 61752691152.71999, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003164, 0.0, 0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros">
-	<ParameterList name="Steady-State Initalization">
-	  <!--
+    <ParameterList name="BC For Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{106221.7596, 106221.7596}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+      <ParameterList name="Steady-State Initalization">
+        <!--
 	      Start:    t=   0.0 [y] = 0 [s]
 	      Period:  dt= 300.0 [y] = 9.467280000e+9  [s]
 	      End:      t=1800.0 [y] = 5.680368000e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 9.467280000e+9, 5.680368000e+10}"/>
-	</ParameterList>
-        <ParameterList name="Cribs discharging">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 9467280000.0, 5.680368000e+10}"/>
+      </ParameterList>
+      <ParameterList name="Cribs discharging">
+        <!--
 	      Start:    t=1956.00  [y] = 6.172666560e+10 [s]
 	      Period:  dt=   0.05  [y] = 1.577880000e+6  [s]
 	      End:      t=1956.99  [y] = 6.1757907624e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 1.577880000e+6, 6.1757907624e+10}"/>
-	</ParameterList>
-        <ParameterList name="Plume evolution: every year">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 1577880.000, 61757907624.0}"/>
+      </ParameterList>
+      <ParameterList name="Plume evolution: every year">
+        <!--
 	      Start:    t=1957.00  [y] = 6.175822320e+10 [s]
 	      Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	      End:      t=1964.00  [y] = 6.197912640e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.175822320e+10, 3.155760000e+7, 6.197912640e+10}"/>
-        </ParameterList>
-        <ParameterList name="Plume evolution: every five years">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.175822320e+10, 31557600.00, 6.197912640e+10}"/>
+      </ParameterList>
+      <ParameterList name="Plume evolution: every five years">
+        <!--
 	      End:      t=1965.00  [y] = 6.201068400e+10 [s]
 	      Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	      End:      t=2010.00  [y] = 6.343077600e+10 [s] 
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.201068400e+10, 1.577880000e+8, 6.343077600e+10}"/>
-	</ParameterList>
-	<ParameterList name="Steady-State Time">
-          <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.201068400e+10, 157788000.0, 6.343077600e+10}"/>
+      </ParameterList>
+      <ParameterList name="Steady-State Time">
+        <!--
               t = 1956.0 [y] = 61726665600.0
-	  -->    
-	  <Parameter name="Values" type="Array(double)" value="{61726665600.0}"/>
-	</ParameterList>
-        <ParameterList name="Data Sequence">
-          <!--
+	  -->
+        <Parameter name="Values" type="Array(double)" value="{61726665600.0}"/>
+      </ParameterList>
+      <ParameterList name="Data Sequence">
+        <!--
               t = 1956.0 [y] = 61726665600.0
 	      t = 1956.1 [y] = 61729821360.0
               t = 1956.2 [y] = 61732977120.0
@@ -885,22 +884,24 @@
 	      t = 1959.0 [y] = 61821338400.0
               t = 1960.0 [y] = 61852896000.0
           -->
-	  <Parameter name="Values" type="Array(double)" value="{61726665600.0,61729821360.0,61732977120.0,61736132880.0,61739288640.0,61742444400.0,61745600160.0,61748755920.0,61751911680.0,61755067440.0,61758223200.0,61764534720.0,61770846240.0,61777157760.0,61783469280.0,61789780800.0,61821338400.0,61852896000.0}"/>
-	</ParameterList>
+        <Parameter name="Values" type="Array(double)" value="{61726665600.0, 61729821360.0, 61732977120.0, 61736132880.0, 61739288640.0, 61742444400.0, 61745600160.0, 61748755920.0, 61751911680.0, 61755067440.0, 61758223200.0, 61764534720.0, 61770846240.0, 61777157760.0, 61783469280.0, 61789780800.0, 61821338400.0, 61852896000.0}"/>
       </ParameterList>
-      <ParameterList name="Cycle Macros">
-	<ParameterList name="Every_1000_cycles">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
-	</ParameterList>
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1000_cycles">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
- 	<Parameter name="Time Macros" type="Array(string)" value="{Cribs discharging, Plume evolution: every year, Plume evolution: every five years}"/>
-      </ParameterList>
-      <ParameterList name="Observation Data"/>
-      <!--  Not ready for this yet, we need a region 
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Time Macros" type="Array(string)" value="{Cribs discharging, Plume evolution: every year, Plume evolution: every five years}"/>
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <!--  Not ready for this yet, we need a region 
       <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observations.out"/>
 	<ParameterList name="Gravimetric Water Content">
@@ -911,11 +912,10 @@
 	</ParameterList>
       </ParameterList>
       -->
-      <ParameterList name="Checkpoint Data">
-	<Parameter name="File Name Base" type="string" value="chk"/>
-	<Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macro" type="string" value="Every_1000_cycles"/>
-      </ParameterList>
-      
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="chk"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1000_cycles"/>
     </ParameterList>
   </ParameterList>
+</ParameterList>

--- a/demos/phase2/dvz/heterogeneous_3d-bcb/amanzi_tpfa_steady.xml
+++ b/demos/phase2/dvz/heterogeneous_3d-bcb/amanzi_tpfa_steady.xml
@@ -1,21 +1,21 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="ellen"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-<!--
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="ellen"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <!--
       <ParameterList name="Restart from Checkpoint Data File">
           <Parameter name="Checkpoint Data File Name" type="string" value="restart_steadystate.h5"/>
       </ParameterList>
 -->
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="On"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Initialize To Steady">
-          <!--
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="On"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Initialize To Steady">
+        <!--
 
              Start initalization:  t =    0.0 [y] = 0.0           [s]
              Start transient:      t = 1956.0 [y] = 6.17266656E10 [s]  
@@ -24,17 +24,17 @@
              Note that at 1956, the land use model changes, causing a change in the background infiltration rate.
              At the same time the first crib starts.
 
-          -->             
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="Switch" type="double" value="6.172666560000E10"/>
-          <Parameter name="End" type="double" value="6.172666560000E10"/>
+          -->
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="61726665600.00"/>
+        <Parameter name="End" type="double" value="61726665600.00"/>
         <!--  <Parameter name="End" type="double" value="6.33676608E10"/> -->
-          <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
-          <Parameter name="Steady Initial Time Step" type="double" value="100000.0"/>
-        </ParameterList>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="100000.0"/>
       </ParameterList>
-      <ParameterList name="Time Period Control">
-        <!--
+    </ParameterList>
+    <ParameterList name="Time Period Control">
+      <!--
 
             The time integrator is reset at Start time, and at the Switch time.  In addition,
             it is usually reset at abrupt changes in source term activity.  In this simulation
@@ -60,505 +60,505 @@
             version uses just 1957.0000, and it seems to run.
 
         -->
-        <Parameter name="Start Times" type="Array(double)" value="{6.172666560000E10,6.172925963472E10,6.172934484024E10,6.173176530816E10,6.173185366944E10,6.173453290968E10,6.173453290968E10,6.173704173888E10,6.174758828880E10,6.175269115272E10,6.175813799448E10,6.175822320000E10}"/>
-        <Parameter name="Initial Time Step" type="Array(double)" value="{100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0}"/>
-        <Parameter name="Maximum Time Step" type="Array(double)" value="{864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0,864000.0}"/>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
+      <Parameter name="Start Times" type="Array(double)" value="{61726665600.00, 61729259634.72, 61729344840.24, 61731765308.16, 61731853669.44, 61734532909.68, 61734532909.68, 61737041738.88, 61747588288.80, 61752691152.72, 61758137994.48, 61758223200.00}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0}"/>
+      <Parameter name="Maximum Time Step" type="Array(double)" value="{864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0, 864000.0}"/>
+    </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="12"/>
+          <Parameter name="steady min iterations" type="int" value="7"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
+        </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="20"/>
+          <Parameter name="transient min iterations" type="int" value="12"/>
+          <Parameter name="transient limit iterations" type="int" value="30"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
+        </ParameterList>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="3"/>
           </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="12"/>
-            <Parameter name="steady min iterations" type="int" value="7"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="10"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
+          <ParameterList name="Hypre AMG">
+            <Parameter name="Hypre AMG cycle applications" type="int" value="10"/>
+            <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
+            <Parameter name="Hypre AMG tolerance" type="double" value="0.1"/>
+            <Parameter name="Hypre AMG strong threshold" type="double" value="0.8"/>
           </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="20"/>
-            <Parameter name="transient min iterations" type="int" value="12"/>
-            <Parameter name="transient limit iterations" type="int" value="30"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-            <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
-          </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="ML cycle applications" type="int" value="3"/>
-            </ParameterList>
-            <ParameterList name="Hypre AMG">
-              <Parameter name="Hypre AMG cycle applications" type="int" value="10"/>
-              <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
-              <Parameter name="Hypre AMG tolerance" type="double" value="0.1"/>
-              <Parameter name="Hypre AMG strong threshold" type="double" value="0.8"/>
-            </ParameterList>
-          </ParameterList>
-	  <ParameterList name="Nonlinear Solver">
-	    <Parameter name="Nonlinear Solver Type" type="string" value="Newton" />
-	  </ParameterList>
+        </ParameterList>
+        <ParameterList name="Nonlinear Solver">
+          <Parameter name="Nonlinear Solver Type" type="string" value="Newton"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-	<ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-	</ParameterList>
-        <ParameterList name="Generate Mesh">
-          <ParameterList name="Uniform Structured">
-            <Parameter name="Number of Cells" type="Array(int)" value="{64, 56, 107}"/>
-            <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-            <Parameter name="Domain High Coordinate" type="Array(double)" value="{320.0,280.0,107.0}"/>
-          </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
+      </ParameterList>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{64, 56, 107}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{320.0, 280.0, 107.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Region for facies1">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="1"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Region for facies1">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="1"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region for facies2">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="2"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region for facies3">
+      <ParameterList name="Region: Color Function">
+        <Parameter name="File" type="string" value="mode-ups.tf3"/>
+        <Parameter name="Value" type="int" value="3"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Vertical strip to the left of the cribs                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{110.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Vertical strip to the right of the cribs                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{205.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{320.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip above the two rows of cribs                              -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 165.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 280.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip below the two rows of cribs                            -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 0.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 115.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between the two rows of cribs                            -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 120.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 160.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-19 and 216-B-17                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{115.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{155.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-17 and 216-B-15                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{160.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{200.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-18 and 216-B-16                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{115.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{155.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Horizontal strip between Cribs 216-B-16 and 216-B-14                      -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{160.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{200.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-14                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{200.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-15                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{200.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{205.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-16                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{155.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{160.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-17                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{155.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{160.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-18                                                             -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 115.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{115.0, 120.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{110.0, 160.0, 107.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{115.0, 165.0, 107.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
+      <!-- Entire bottom surface                                                -->
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{320.0, 280.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="Facies_1">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.4082"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.9976e-12"/>
+        <Parameter name="y" type="double" value="1.9976e-12"/>
+        <Parameter name="z" type="double" value="1.9976e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.2832"/>
+        <Parameter name="alpha" type="double" value="0.0002470612"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies1}"/>
+    </ParameterList>
+    <ParameterList name="Facies_2">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.2206"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="6.9365e-11"/>
+        <Parameter name="y" type="double" value="6.9365e-11"/>
+        <Parameter name="z" type="double" value="6.9365e-12"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.261"/>
+        <Parameter name="alpha" type="double" value="0.002573475"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies2}"/>
+    </ParameterList>
+    <ParameterList name="Facies_3">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.234"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="2.0706e-9"/>
+        <Parameter name="y" type="double" value="2.0706e-9"/>
+        <Parameter name="z" type="double" value="2.0706e-10"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: Brooks Corey">
+        <Parameter name="lambda" type="double" value="0.387"/>
+        <Parameter name="alpha" type="double" value="0.002756137"/>
+        <Parameter name="ell" type="double" value="2.0"/>
+        <Parameter name="Sr" type="double" value="0.0"/>
+        <Parameter name="Relative Permeability" type="string" value="Burdine"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies3}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
+        </ParameterList>
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="Region for facies2">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="2"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region for facies3">
-        <ParameterList name="Region: Color Function">
-          <Parameter name="File" type="string" value="mode-ups.tf3"/>
-          <Parameter name="Value" type="int" value="3"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Vertical strip to the left of the cribs                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{110.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Vertical strip to the right of the cribs                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{205.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{320.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip above the two rows of cribs                              -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,165.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,280.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip below the two rows of cribs                            -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,0.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,115.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between the two rows of cribs                            -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,120.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,160.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-19 and 216-B-17                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{115.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{155.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-17 and 216-B-15                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{160.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{200.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-18 and 216-B-16                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{115.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{155.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Horizontal strip between Cribs 216-B-16 and 216-B-14                      -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{160.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{200.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-14                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{200.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-15                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{200.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{205.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-16                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{155.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{160.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-17                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{155.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{160.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-18                                                             -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,115.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{115.0,120.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]                                --> 
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{110.0,160.0,107.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{115.0,165.0,107.0}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
-        <!-- Entire bottom surface                                                -->
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{320.0,280.0,0.0}"/>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="Facies_1">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.4082"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.9976E-12"/>
-          <Parameter name="y" type="double" value="1.9976E-12"/>
-          <Parameter name="z" type="double" value="1.9976E-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.2832"/>
-          <Parameter name="alpha" type="double" value="2.470612E-04"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies1}"/>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Linear Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
       </ParameterList>
-      <ParameterList name="Facies_2">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.2206"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="6.9365E-11"/>
-          <Parameter name="y" type="double" value="6.9365E-11"/>
-          <Parameter name="z" type="double" value="6.9365E-12"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.261"/>
-          <Parameter name="alpha" type="double" value="2.573475E-03"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies2}"/>
-      </ParameterList>
-      <ParameterList name="Facies_3">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.234"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="2.0706E-9"/>
-          <Parameter name="y" type="double" value="2.0706E-9"/>
-          <Parameter name="z" type="double" value="2.0706E-10"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: Brooks Corey">
-          <Parameter name="lambda" type="double" value="0.387"/>
-          <Parameter name="alpha" type="double" value="2.756137E-03"/>
-          <Parameter name="ell" type="double" value="2.0"/>
-          <Parameter name="Sr" type="double" value="0.0"/>
-          <Parameter name="Relative Permeability" type="string" value="Burdine"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region for facies3}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-	  <ParameterList name="Viscosity: Uniform">
-	    <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-	  </ParameterList>
-	  <ParameterList name="Density: Uniform">
-	    <Parameter name="Density" type="double" value="998.2 "/>
-	  </ParameterList>
-	</ParameterList>
-        <ParameterList name="Phase Components">
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-	<ParameterList name="IC: Linear Pressure">
-	  <Parameter name="Phase" type="string" value="Aqueous"/>
-	  <Parameter name="Reference Value" type="double" value="101325 "/>
-	  <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-	  <Parameter name="Gradient Value" type="Array(double)" value="{0.0,0.0,-9793.5192 }"/>
-	</ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0.0"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="TBC"/>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (0.0_ 110.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (205.0_ 320.0_ 0.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 165.0_ 280.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 0.0_ 115.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 205.0_ 120.0_ 160.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (115.0_ 155.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (160.0_ 200.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-14                                                                     
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-14                                                                     
 
                 0.0000 [y] < t < 1956.0000 [y]          5.0 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.1616 [y]       2080.8 [m/y]       3.800e-6 [Ci/L]
@@ -577,29 +577,29 @@
                63.0 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [ kg/s/m^2 ]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731765308159996E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 0.06581788729180926, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731765308159996E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 3.8e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731765308.159996, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.06581788729180926, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731765308.159996, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0000038, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-15
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-15
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.2493 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -621,29 +621,29 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.175813799448E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.004569421375516516, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.175813799448E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.800e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (200.0_ 205.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61758137994.48, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.004569421375516516, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61758137994.48, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003800, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-16
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-16
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.2493 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -665,29 +665,29 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.17475882888E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.017004852080006082, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.173453290968E10, 6.17475882888E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.524e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61747588288.8, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.017004852080006082, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61734532909.68, 61747588288.8, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003524, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-17
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-17
 
                 0.0000 [y] < t < 1956.0000 [y]          5.0 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.0822 [y]       1636.0 [m/y]       2.886e-6 [Ci/L]
@@ -706,29 +706,29 @@
                63.0 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.9927561031257130e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.172925963472E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 0.05177370142216137, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.172925963472E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 2.886e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (155.0_ 160.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729259634.72, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.05177370142216137, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729259634.72, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.000002886, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-18
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-18
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.1644 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -750,29 +750,29 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731853669439995E10, 6.173704173888E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.06467916951859456, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1731853669439995E10, 6.173704173888E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.798e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 115.0_ 120.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731853669.439995, 61737041738.88, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.06467916951859456, 0.0000019927561031257127, 0.0000019927561031257127}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61731853669.439995, 61737041738.88, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003798, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
-        <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]
+    </ParameterList>
+    <ParameterList name="BC For Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)">
+      <!-- Crib 216-B-19: [110.0,115.0]x[160.0,165.0]
 
                 0.0000 [y] < t < 1956.0000 [y]          5.00 [mm/y]      0.000e-6 [Ci/L]
              1956.0000 [y] < t < 1956.0849 [y]         63.00 [mm/y]      0.000e-6 [Ci/L]
@@ -794,93 +794,92 @@
                63.00 [mm/y] * 998.20 [kg/s] / [s pey year] / 1000 = 1.992756103125713e-06 [kg/s/m^2]            
 
         -->
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1729344840240005E10, 6.175269115271999E10, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847E-7, 1.9927561031257127E-6, 0.010712487451517224, 1.9927561031257127E-6, 1.9927561031257127E-6}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656E10, 6.1729344840240005E10, 6.175269115271999E10, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 3.164e-6, 0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface Region (110.0_ 115.0_ 160.0_ 165.0_ 106.0_ 107.0)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729344840.240005, 61752691152.71999, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{1.5815524627981847e-7, 0.0000019927561031257127, 0.010712487451517224, 0.0000019927561031257127, 0.0000019927561031257127}"/>
       </ParameterList>
-      <ParameterList name="BC For Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)}"/>
-        <ParameterList name="BC: Uniform Pressure">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Values" type="Array(double)" value="{106221.7596, 106221.7596}"/>
-        </ParameterList>
-        <ParameterList name="Solute BC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="BC: Uniform Concentration">
-                  <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656E10}"/>
-                  <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                  <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
-                </ParameterList>
-                <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.17266656e+10, 61729344840.240005, 61752691152.71999, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant, Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0, 0.000003164, 0.0, 0.0}"/>
               </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros">
-	<ParameterList name="Steady-State Initalization">
-	  <!--
+    <ParameterList name="BC For Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface Region (0.0_ 320.0_ 0.0_ 280.0_ 0.0_ 1.0)}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{106221.7596, 106221.7596}"/>
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tc-99">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.5008656e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+              <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+      <ParameterList name="Steady-State Initalization">
+        <!--
 	      Start:    t=   0.0 [y] = 0 [s]
 	      Period:  dt= 300.0 [y] = 9.467280000e+9  [s]
 	      End:      t=1800.0 [y] = 5.680368000e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 9.467280000e+9, 5.680368000e+10}"/>
-	</ParameterList>
-        <ParameterList name="Cribs discharging">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 9467280000.0, 5.680368000e+10}"/>
+      </ParameterList>
+      <ParameterList name="Cribs discharging">
+        <!--
 	      Start:    t=1956.00  [y] = 6.172666560e+10 [s]
 	      Period:  dt=   0.05  [y] = 1.577880000e+6  [s]
 	      End:      t=1956.99  [y] = 6.1757907624e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 1.577880000e+6, 6.1757907624e+10}"/>
-	</ParameterList>
-        <ParameterList name="Plume evolution: every year">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.17266656e+10, 1577880.000, 61757907624.0}"/>
+      </ParameterList>
+      <ParameterList name="Plume evolution: every year">
+        <!--
 	      Start:    t=1957.00  [y] = 6.175822320e+10 [s]
 	      Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	      End:      t=1964.00  [y] = 6.197912640e+10 [s]
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.175822320e+10, 3.155760000e+7, 6.197912640e+10}"/>
-        </ParameterList>
-        <ParameterList name="Plume evolution: every five years">
-	  <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.175822320e+10, 31557600.00, 6.197912640e+10}"/>
+      </ParameterList>
+      <ParameterList name="Plume evolution: every five years">
+        <!--
 	      End:      t=1965.00  [y] = 6.201068400e+10 [s]
 	      Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	      End:      t=2010.00  [y] = 6.343077600e+10 [s] 
 	  -->
-	  <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.201068400e+10, 1.577880000e+8, 6.343077600e+10}"/>
-	</ParameterList>
-	<ParameterList name="Steady-State Time">
-          <!--
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.201068400e+10, 157788000.0, 6.343077600e+10}"/>
+      </ParameterList>
+      <ParameterList name="Steady-State Time">
+        <!--
               t = 1956.0 [y] = 61726665600.0
-	  -->    
-	  <Parameter name="Values" type="Array(double)" value="{61726665600.0}"/>
-	</ParameterList>
-        <ParameterList name="Data Sequence">
-          <!--
+	  -->
+        <Parameter name="Values" type="Array(double)" value="{61726665600.0}"/>
+      </ParameterList>
+      <ParameterList name="Data Sequence">
+        <!--
               t = 1956.0 [y] = 61726665600.0
 	      t = 1956.1 [y] = 61729821360.0
               t = 1956.2 [y] = 61732977120.0
@@ -902,33 +901,34 @@
 	      t = 1959.0 [y] = 61821338400.0
               t = 1960.0 [y] = 61852896000.0
           -->
-	  <Parameter name="Values" type="Array(double)" value="{61726665600.0,61729821360.0,61732977120.0,61736132880.0,61739288640.0,61742444400.0,61745600160.0,61748755920.0,61751911680.0,61755067440.0,61758223200.0,61764534720.0,61770846240.0,61777157760.0,61783469280.0,61789780800.0,61821338400.0,61852896000.0}"/>
-	</ParameterList>
+        <Parameter name="Values" type="Array(double)" value="{61726665600.0, 61729821360.0, 61732977120.0, 61736132880.0, 61739288640.0, 61742444400.0, 61745600160.0, 61748755920.0, 61751911680.0, 61755067440.0, 61758223200.0, 61764534720.0, 61770846240.0, 61777157760.0, 61783469280.0, 61789780800.0, 61821338400.0, 61852896000.0}"/>
       </ParameterList>
-      <ParameterList name="Cycle Macros">
-	<ParameterList name="Every_1000_cycles">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
-	</ParameterList>
-	<ParameterList name="Every_10_cycles">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
-	</ParameterList>
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1000_cycles">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
-      <ParameterList name="Variable Macros"/>
-<!--
+      <ParameterList name="Every_10_cycles">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <!--
       <ParameterList name="Visualization Data">
         <Parameter name="File Name Base" type="string" value="plot"/>
         <Parameter name="File Name Digits" type="string" value="5"/>
     	<Parameter name="Time Macro" type="Array(string)" value="{Cribs discharging, Plume evolution: every year, Plume evolution: every five years}"/>
       </ParameterList>
 -->
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot_tpfa_steady"/>
-        <Parameter name="File Name Digits" type="string" value="5"/>
-    	<Parameter name="Cycle Macros" type="Array(string)" value="{Every_10_cycles}"/>
-      </ParameterList>
-
-      <ParameterList name="Observation Data"/>
-      <!--  Not ready for this yet, we need a region 
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot_tpfa_steady"/>
+      <Parameter name="File Name Digits" type="string" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_10_cycles}"/>
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <!--  Not ready for this yet, we need a region 
       <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observations.out"/>
 	<ParameterList name="Gravimetric Water Content">
@@ -939,11 +939,10 @@
 	</ParameterList>
       </ParameterList>
       -->
-      <ParameterList name="Checkpoint Data">
-	<Parameter name="File Name Base" type="string" value="chk"/>
-	<Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macro" type="string" value="Every_1000_cycles"/>
-      </ParameterList>
-      
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="chk"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1000_cycles"/>
     </ParameterList>
   </ParameterList>
+</ParameterList>

--- a/demos/phase2/f-area/2d-flow-full-chem-no-gordon/2d_f-area_flow_full_chem_no_gordon.xml
+++ b/demos/phase2/f-area/2d-flow-full-chem-no-gordon/2d_f-area_flow_full_chem_no_gordon.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="ASCEM-F-Area"/>
@@ -9,82 +8,80 @@
     <Parameter name="Creation date" type="string" value="06.15.12"/>
     <Parameter name="Last modified" type="string" value="06.15.12"/>
   </ParameterList>
-
   <!-- Execution control -->
   <ParameterList name="Execution Control">
-
     <Parameter name="Flow Model" type="string" value="Richards"/>
-    <Parameter name="Transport Model" type="string" value="On"/> 
+    <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Amanzi"/>
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="5.85697e10"/>
-	<Parameter name="Switch" type="double" value="6.16635504e+10"/> <!-- Jan 1955 -->
-	<Parameter name="End" type="double" value="6.48508680e+10"/> <!-- Jan 2055 -->
-   	<Parameter name="Steady Initial Time Step" type="double" value="1.0e6"/>
-	<Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Start" type="double" value="5.85697e+10"/>
+        <Parameter name="Switch" type="double" value="6.16635504e+10"/>
+        <!-- Jan 1955 -->
+        <Parameter name="End" type="double" value="6.48508680e+10"/>
+        <!-- Jan 2055 -->
+        <Parameter name="Steady Initial Time Step" type="double" value="1.0e+6"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
         <Parameter name="Use Picard" type="bool" value="false"/>
       </ParameterList>
-    </ParameterList> <!-- Time Integration Mode -->
-
+    </ParameterList>
+    <!-- Time Integration Mode -->
     <!--ParameterList name="Restart from Checkpoint Data File">
       <Parameter name="Checkpoint Data File Name" type="string" value="chkpoint00134.h5"/>
     </ParameterList-->
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
-          </ParameterList>
-          <ParameterList name="Chemistry Process Kernel">
-            <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max iterations" type="int" value="50"/>
-            <Parameter name="steady min iterations" type="int" value="8"/>
-            <Parameter name="steady limit iterations" type="int" value="100"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Pseudo-Time Implicit Solver">
-            <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/>
-            <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
-            <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/>
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Chemistry Process Kernel">
+          <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max iterations" type="int" value="50"/>
+          <Parameter name="steady min iterations" type="int" value="8"/>
+          <Parameter name="steady limit iterations" type="int" value="100"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
+        </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Pseudo-Time Implicit Solver">
+          <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/>
+          <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
+          <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/>
+          <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
+          <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/>
+          <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
+          <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-10"/>
+          <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/>
+        </ParameterList>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
             <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
-            <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/>
-            <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
-            <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-10"/>
-            <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/>
+            <Parameter name="ML cycle applications" type="int" value="6"/>
           </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
-              <Parameter name="ML cycle applications" type="int" value="6"/>
-            </ParameterList>
-          </ParameterList>
+        </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- Numerical Control Parameters -->
-  </ParameterList> <!-- Execution Control -->
-
+    </ParameterList>
+    <!-- Numerical Control Parameters -->
+  </ParameterList>
+  <!-- Execution Control -->
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-         
   <!-- Mesh in exodus format -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
@@ -98,95 +95,93 @@
         <Parameter name="Verify Mesh" type="bool" value="false"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList> <!-- Mesh -->
-               
+  </ParameterList>
+  <!-- Mesh -->
   <!-- Regions: Each region is coincident  with those specified in the exodus II format. -->
   <ParameterList name="Regions">
-
     <ParameterList name="Upper aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="50000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="50000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="30000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="30000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tan clay">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="40000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="40000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
-
-<!-- This face is corresponding to natural recharge (left side) (Bc1) -->
+    <!-- This face is corresponding to natural recharge (left side) (Bc1) -->
     <ParameterList name="Natural recharge (left)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="1"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="1"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to natural recharge (right side) (Bc3) -->
+    <!-- This face is corresponding to natural recharge (right side) (Bc3) -->
     <ParameterList name="Natural recharge (right)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="3"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="3"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Seepage basin (Bc2) -->
+    <!-- This face is corresponding to Seepage basin (Bc2) -->
     <ParameterList name="Seepage basin">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="2"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="2"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to seepage face (Bc4) -->
+    <!-- This face is corresponding to seepage face (Bc4) -->
     <ParameterList name="Seepage face">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="4"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="4"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
     <ParameterList name="UTRA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="8"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="8"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
     <ParameterList name="UTRA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="5"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="5"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to vadose zone (Bc9, no flux) -->
+    <!-- This face is corresponding to vadose zone (Bc9, no flux) -->
     <ParameterList name="VZ">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="9"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="9"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
@@ -196,35 +191,34 @@
     -->
     <ParameterList name="Well_1">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1866, 58.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1866.0, 58.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well_2">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1866, 43.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1866.0, 43.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well_3">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{2072, 58.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{2072.0, 58.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Basin_point">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1721, 84.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1721.0, 84.8}"/>
       </ParameterList>
     </ParameterList>
-    
-  </ParameterList> <!-- Regions -->
-
+  </ParameterList>
+  <!-- Regions -->
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="997.16e0"/>
+          <Parameter name="Density" type="double" value="997.16"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -232,15 +226,15 @@
           <Parameter name="Component Solutes" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- Aqueous Phase -->
-    
+    </ParameterList>
+    <!-- Aqueous Phase -->
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Quartz, Goethite, Kaolinite, Schoepite, Gibbsite, Jurbanite, Basaluminite, Opal}"/>
-      <Parameter name="Sorption Sites" type="Array(string)" value="{>davis_OH}"/>
-    </ParameterList> <!-- Solid Phase -->
-  </ParameterList> <!-- Phase Definitions -->
-
-
+      <Parameter name="Sorption Sites" type="Array(string)" value="{&gt;davis_OH}"/>
+    </ParameterList>
+    <!-- Solid Phase -->
+  </ParameterList>
+  <!-- Phase Definitions -->
   <ParameterList name="Material Properties">
     <!-- Upper aquifer (UUTRA) -->
     <ParameterList name="Mesh block 1">
@@ -249,146 +243,120 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="4.0e-4"/> 
+        <Parameter name="alpha" type="double" value="0.00040"/>
         <Parameter name="Sr" type="double" value="0.18"/>
         <Parameter name="m" type="double" value="0.27"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-	<!--Parameter name="krel smoothing interval" type="double" value="100.0"/-->
+        <!--Parameter name="krel smoothing interval" type="double" value="100.0"/-->
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Upper aquifer (UUTRA) -->
-
-    <!-- Lower aquifer (LUTRA) -->           
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Upper aquifer (UUTRA) -->
+    <!-- Lower aquifer (LUTRA) -->
     <ParameterList name="Mesh block 2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Lower aquifer}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.41"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Lower aquifer (LUTRA) -->           
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Lower aquifer (LUTRA) -->
     <!-- Tan clay (TCCZ) -->
     <ParameterList name="Mesh block 3">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Tan clay}"/>
@@ -396,783 +364,690 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.98e-14"/> 
-        <Parameter name="y" type="double" value="1.98e-14"/> 
+        <Parameter name="x" type="double" value="1.98e-14"/>
+        <Parameter name="y" type="double" value="1.98e-14"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Tan clay (TCCZ) -->
-
-    
-  </ParameterList> <!-- Material Properties -->
- 
-     
-  
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Tan clay (TCCZ) -->
+  </ParameterList>
+  <!-- Material Properties -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Reference Value" type="double" value="101325.0"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0., 60.0}"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 60.0}"/>
         <!-- SABEA: Units for the gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2 -->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.9578630770689822E-06"/>
-                <Parameter name="Free Ion Guess" type="double" value="4.4349219948232250E-06"/>
+                <Parameter name="Value" type="double" value="0.0000029578630770689822"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0000044349219948232250"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2134319178343449E-08"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030E-09"/>
+                <Parameter name="Value" type="double" value="2.2134319178343449e-8"/>
+                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030e-9"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028381797381277E-05"/>
+                <Parameter name="Value" type="double" value="0.000010000000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010028381797381277"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="9.9892245160353443E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0017671789459564E-02"/>
+                <Parameter name="Value" type="double" value="0.0099892245160353443"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.010017671789459564"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.5231281704019796E-16"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987E-16"/>
+                <Parameter name="Value" type="double" value="2.5231281704019796e-16"/>
+                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987e-16"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2146187645233065E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0742367360218137E-05"/>
+                <Parameter name="Value" type="double" value="0.000012146187645233065"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010742367360218137"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="3.3200000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.3294546826549702E-05"/>
+                <Parameter name="Value" type="double" value="0.000033200000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000033294546826549702"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="5.3499999999999997E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.3651825870676614E-03"/>
+                <Parameter name="Value" type="double" value="0.0053499999999999997"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0053651825870676614"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.7799999999999998E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.7879126028761809E-04"/>
+                <Parameter name="Value" type="double" value="0.00027799999999999998"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00027879126028761809"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.7728213902597242E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.7778699932375911E-04"/>
+                <Parameter name="Value" type="double" value="0.00017728213902597242"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00017778699932375911"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2500000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.2564075409559286E-05"/>
+                <Parameter name="Value" type="double" value="0.000022500000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000022564075409559286"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-15"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128E-15"/>
+                <Parameter name="Value" type="double" value="1.0000000000000001e-15"/>
+                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128e-15"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000000E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959449073E-03"/>
+                <Parameter name="Value" type="double" value="0.0010000000000000000"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0010028477959449073"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2499999999951748E-10"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163E-11"/>
+                <Parameter name="Value" type="double" value="1.2499999999951748e-10"/>
+                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163e-11"/>
               </ParameterList>
             </ParameterList>
-	    
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- IC For Domain -->
-  </ParameterList> <!-- Initial Conditions -->
-  
-
+    </ParameterList>
+    <!-- IC For Domain -->
+  </ParameterList>
+  <!-- Initial Conditions -->
   <!-- Boundary conditions -->
   <ParameterList name="Boundary Conditions">
     <!-- Boundary corresponding to the Natural recharge (left side) -->
     <ParameterList name="BC for natural  recharge (left)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (left)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-	    
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the Natural recharge (left side) -->
-    
-<!-- Boundary corresponding to the Natural recharge (right side) -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the Natural recharge (left side) -->
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
     <ParameterList name="BC for natural  recharge (right)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (right)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the Natural recharge (right side) -->
-       
-<!-- Boundary corresponding to the seepage basin -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
+    <!-- Boundary corresponding to the seepage basin -->
     <ParameterList name="BC for F-3 basin">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage basin}"/>
       <ParameterList name="BC: Flux">
         <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-        <Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-	<!-- less than 4 [m3 m-2 yr-1], mean recalculated by Haruko (8/7/12) -->
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 1.11e-4, 4.743e-6}"/> 
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <!-- less than 4 [m3 m-2 yr-1], mean recalculated by Haruko (8/7/12) -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000111, 0.000004743}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 9.7317820303283020E-03, 2.9578630770689822E-06}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0097317820303283020, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 1.0000000000000002E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 1.0000000000000002e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 3.3899999999999997E-05, 9.9892245160353443E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.000033899999999999997, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.4142508014351454E-06, 2.5231281704019796E-16}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 0.0000024142508014351454, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.0712465873417377E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000010712465873417377, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 1.7200000000000000E-06, 3.3200000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.0000017200000000000000, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 2.4700000000000001E-06, 5.3499999999999997E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0000024700000000000001, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 3.0398521726429520E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00030398521726429520, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.1800000000000000E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00011800000000000000, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 4.8000000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000048000000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 2.1700000000000002E-09, 1.0000000000000001E-15}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 2.1700000000000002e-9, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-02, 1.0000000000000000E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 3.0099999999999854E-05, 1.2499999999951748E-10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 0.000030099999999999854, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the seepage basin -->
-
-<!-- Boundary corresponding to the seepage face -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the seepage basin -->
+    <!-- Boundary corresponding to the seepage face -->
     <ParameterList name="BC for seepage face">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage face}"/>
       <ParameterList name="BC: Seepage">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
+      </ParameterList>
+      <!-- Solute BC -->
     </ParameterList>
-  </ParameterList> <!-- Boundary Conditions -->
-
+  </ParameterList>
+  <!-- Boundary Conditions -->
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
       <Parameter name="Format" type="string" value="simple"/>
       <Parameter name="File" type="string" value="ascem-2012-farea.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
     <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-10"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="864000.0"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
   </ParameterList>
-       
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-5000-steps">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 5000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
     <ParameterList name="Time Macros">
-
       <ParameterList name="Every two months">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+06, 6.6271e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+6, 6.6271e+10}"/>
       </ParameterList>
-
       <ParameterList name="Every year">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7 [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 3.155760000e+7, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 31557600.00, 6.627096000e+10}"/>
       </ParameterList>
-
       <ParameterList name="Active Basin">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7 [s]
 	    End:      t=1988.00  [y] = 6.27365088e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 3.155760000e+7, 6.27365088e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 31557600.00, 6.27365088e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every year">
-	<!--
+        <!--
 	    Start:    t=1989.00  [y] = 6.276806640e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	    End:      t=2010.00  [y] = 6.343077600e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 3.155760000e+7, 6.343077600e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 31557600.00, 6.343077600e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every five years">
-	<!--
+        <!--
 	    Start:    t=2015.00  [y] = 6.358856400e+10 [s]
 	    Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 1.577880000e+8, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 157788000.0, 6.627096000e+10}"/>
       </ParameterList>
-
     </ParameterList>
-
     <ParameterList name="Observation Data">
-
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
         <Parameter name="Region" type="string" value="Well_1"/>
@@ -1180,54 +1055,44 @@
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output02">
         <Parameter name="Region" type="string" value="Well_2"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output03">
         <Parameter name="Region" type="string" value="Well_3"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output04">
         <Parameter name="Region" type="string" value="Well_1"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output05">
         <Parameter name="Region" type="string" value="Well_2"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-	  
       <ParameterList name="output06">
         <Parameter name="Region" type="string" value="Well_3"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Active Basin, Plume evolution: every year, Plume evolution: every five years}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="chkpoint"/>
       <Parameter name="Cycle Macro" type="string" value="Every-5000-steps"/>
     </ParameterList>
-
-  </ParameterList>     
-</ParameterList> 
-       
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/f-area/2d-flow-full-chem/2d_f-area_flow_full_chem.xml
+++ b/demos/phase2/f-area/2d-flow-full-chem/2d_f-area_flow_full_chem.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="ASCEM-F-Area"/>
@@ -9,89 +8,86 @@
     <Parameter name="Creation date" type="string" value="06.15.12"/>
     <Parameter name="Last modified" type="string" value="06.15.12"/>
   </ParameterList>
-
   <!-- Execution control -->
   <ParameterList name="Execution Control">
-
     <Parameter name="Flow Model" type="string" value="Richards"/>
-    <Parameter name="Transport Model" type="string" value="On"/> 
+    <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Amanzi"/>
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-	<Parameter name="Switch" type="double" value="6.16635504e+10"/> <!-- Jan 1955 -->
-	<Parameter name="End" type="double" value="6.48508680e+10"/> <!-- Jan 2055 -->
-   	<Parameter name="Steady Initial Time Step" type="double" value="1.0e6"/>
-	<Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Switch" type="double" value="6.16635504e+10"/>
+        <!-- Jan 1955 -->
+        <Parameter name="End" type="double" value="6.48508680e+10"/>
+        <!-- Jan 2055 -->
+        <Parameter name="Steady Initial Time Step" type="double" value="1.0e+6"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
         <Parameter name="Use Picard" type="bool" value="true"/>
       </ParameterList>
-    </ParameterList> <!-- Time Integration Mode -->
-
+    </ParameterList>
+    <!-- Time Integration Mode -->
     <!--ParameterList name="Restart from Checkpoint Data File">
       <Parameter name="Checkpoint Data File Name" type="string" value="chkpoint00134.h5"/>
     </ParameterList-->
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Transport Process Kernel">
-           <Parameter name="Transport Integration Algorithm" type="string" value="Explicit Second-Order"/>
-	   <Parameter name="transport subcycling" type="bool" value="true"/>
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit Second-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
         </ParameterList>
         <ParameterList name="Chemistry Process Kernel">
-	   <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
+          <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
         </ParameterList>
         <ParameterList name="Steady-State Psuedo-Time Implicit Solver">
-           <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/> 
-           <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
-           <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/> 
-           <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/> 
-           <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/> 
-           <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
-           <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-10"/>
-           <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/> 
+          <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/>
+          <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
+          <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/>
+          <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
+          <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/>
+          <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
+          <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-10"/>
+          <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/>
         </ParameterList>
         <ParameterList name="Steady-State Implicit Time Integration">
-           <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-           <Parameter name="steady max iterations" type="int" value="50"/>
-           <Parameter name="steady min iterations" type="int" value="8"/>
-           <Parameter name="steady limit iterations" type="int" value="100"/>
-           <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
-           <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
-           <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max iterations" type="int" value="50"/>
+          <Parameter name="steady min iterations" type="int" value="8"/>
+          <Parameter name="steady limit iterations" type="int" value="100"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
         </ParameterList>
         <ParameterList name="Transient Implicit Time Integration">
-           <Parameter name="transient max iterations" type="int" value="15"/>
-           <Parameter name="transient min iterations" type="int" value="10"/>
-           <Parameter name="transient limit iterations" type="int" value="20"/>
-           <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
-           <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-           <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-           <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-           <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-           <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+          <Parameter name="transient preconditioner" type="string" value="Hypre AMG"/>
         </ParameterList>
         <ParameterList name="Preconditioners">
-           <ParameterList name="Trilinos ML">
-               <Parameter name="ML cycle applications" type="int" value="6"/>
-           </ParameterList>
-           <ParameterList name="Hypre AMG">
-               <Parameter name="Hypre AMG cycle applications" type="int" value="6"/>
-           </ParameterList>
-           <ParameterList name="Block ILU">
-               <Parameter name="Block ILU level of fill" type="int" value="1"/>
-           </ParameterList>
+          <ParameterList name="Trilinos ML">
+            <Parameter name="ML cycle applications" type="int" value="6"/>
+          </ParameterList>
+          <ParameterList name="Hypre AMG">
+            <Parameter name="Hypre AMG cycle applications" type="int" value="6"/>
+          </ParameterList>
+          <ParameterList name="Block ILU">
+            <Parameter name="Block ILU level of fill" type="int" value="1"/>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- Numerical Control Parameters -->
-
-  </ParameterList> <!-- Execution Control -->
-
+    </ParameterList>
+    <!-- Numerical Control Parameters -->
+  </ParameterList>
+  <!-- Execution Control -->
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-         
   <!-- Mesh in exodus format -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
@@ -105,129 +101,127 @@
         <Parameter name="Verify Mesh" type="bool" value="false"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList> <!-- Mesh -->
-               
+  </ParameterList>
+  <!-- Mesh -->
   <!-- Regions: Each region is coincident  with those specified in the exodus II format. -->
   <ParameterList name="Regions">
-
     <ParameterList name="Upper aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="50000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="50000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="30000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="30000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tan clay">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="40000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="40000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon confining">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="20000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="20000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="10000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="10000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
-
-<!-- This face is corresponding to natural recharge (left side) (Bc1) -->
+    <!-- This face is corresponding to natural recharge (left side) (Bc1) -->
     <ParameterList name="Natural recharge (left)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="1"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="1"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to natural recharge (right side) (Bc3) -->
+    <!-- This face is corresponding to natural recharge (right side) (Bc3) -->
     <ParameterList name="Natural recharge (right)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="3"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="3"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Seepage basin (Bc2) -->
+    <!-- This face is corresponding to Seepage basin (Bc2) -->
     <ParameterList name="Seepage basin">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="2"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="2"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to seepage face (Bc4) -->
+    <!-- This face is corresponding to seepage face (Bc4) -->
     <ParameterList name="Seepage face">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="4"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="4"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
     <ParameterList name="UTRA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="8"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="8"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
     <ParameterList name="UTRA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="5"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="5"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
     <ParameterList name="GA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="7"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="7"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
     <ParameterList name="GA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="6"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="6"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to vadose zone (Bc9, no flux) -->
+    <!-- This face is corresponding to vadose zone (Bc9, no flux) -->
     <ParameterList name="VZ">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="9"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="9"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
@@ -237,35 +231,34 @@
     -->
     <ParameterList name="Well_1">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1866, 58.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1866.0, 58.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well_2">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1866, 43.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1866.0, 43.8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well_3">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{2072, 58.1}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{2072.0, 58.1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Basin_point">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{1721, 84.8}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{1721.0, 84.8}"/>
       </ParameterList>
     </ParameterList>
-    
-  </ParameterList> <!-- Regions -->
-
+  </ParameterList>
+  <!-- Regions -->
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="997.16e0"/>
+          <Parameter name="Density" type="double" value="997.16"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -273,15 +266,15 @@
           <Parameter name="Component Solutes" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- Aqueous Phase -->
-    
+    </ParameterList>
+    <!-- Aqueous Phase -->
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Quartz, Goethite, Kaolinite, Schoepite, Gibbsite, Jurbanite, Basaluminite, Opal}"/>
-      <Parameter name="Sorption Sites" type="Array(string)" value="{>davis_OH}"/>
-    </ParameterList> <!-- Solid Phase -->
-  </ParameterList> <!-- Phase Definitions -->
-
-
+      <Parameter name="Sorption Sites" type="Array(string)" value="{&gt;davis_OH}"/>
+    </ParameterList>
+    <!-- Solid Phase -->
+  </ParameterList>
+  <!-- Phase Definitions -->
   <ParameterList name="Material Properties">
     <!-- Upper aquifer (UUTRA) -->
     <ParameterList name="Mesh block 1">
@@ -290,146 +283,120 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="4.0e-4"/> 
+        <Parameter name="alpha" type="double" value="0.00040"/>
         <Parameter name="Sr" type="double" value="0.18"/>
         <Parameter name="m" type="double" value="0.27"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-	<!--Parameter name="krel smoothing interval" type="double" value="100.0"/-->
+        <!--Parameter name="krel smoothing interval" type="double" value="100.0"/-->
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Upper aquifer (UUTRA) -->
-
-    <!-- Lower aquifer (LUTRA) -->           
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Upper aquifer (UUTRA) -->
+    <!-- Lower aquifer (LUTRA) -->
     <ParameterList name="Mesh block 2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Lower aquifer}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.41"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Lower aquifer (LUTRA) -->           
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Lower aquifer (LUTRA) -->
     <!-- Tan clay (TCCZ) -->
     <ParameterList name="Mesh block 3">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Tan clay}"/>
@@ -437,72 +404,59 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.98e-14"/> 
-        <Parameter name="y" type="double" value="1.98e-14"/> 
+        <Parameter name="x" type="double" value="1.98e-14"/>
+        <Parameter name="y" type="double" value="1.98e-14"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Tan clay (TCCZ) -->
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Tan clay (TCCZ) -->
     <!-- Gordon confining (GC) -->
     <ParameterList name="Mesh block 4">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon confining}"/>
@@ -510,72 +464,59 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.0e-17"/> 
+        <Parameter name="x" type="double" value="1.0e-17"/>
         <Parameter name="y" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Gordon confining (GC) -->
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Gordon confining (GC) -->
     <!-- Gordon aquifer (GA) -->
     <ParameterList name="Mesh block 5">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon aquifer}"/>
@@ -583,782 +524,690 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.0e-17"/> 
-      <Parameter name="y" type="double" value="1.0e-17"/>
+        <Parameter name="x" type="double" value="1.0e-17"/>
+        <Parameter name="y" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-	
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-	
-      </ParameterList> <!-- Surface Complexation Sites -->
-    </ParameterList> <!-- Gordon aquifer (GA) -->
-    
-  </ParameterList> <!-- Material Properties -->
-  
-     
-  
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
+    </ParameterList>
+    <!-- Gordon aquifer (GA) -->
+  </ParameterList>
+  <!-- Material Properties -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Reference Value" type="double" value="101325.0"/>
-        <Parameter name="Reference Coordinate" type="Array(double)" value="{0., 60.0}"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 60.0}"/>
         <!-- SABEA: Units for the gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2 -->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.9578630770689822E-06"/>
-                <Parameter name="Free Ion Guess" type="double" value="4.4349219948232250E-06"/>
+                <Parameter name="Value" type="double" value="0.0000029578630770689822"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0000044349219948232250"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2134319178343449E-08"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030E-09"/>
+                <Parameter name="Value" type="double" value="2.2134319178343449e-8"/>
+                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030e-9"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028381797381277E-05"/>
+                <Parameter name="Value" type="double" value="0.000010000000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010028381797381277"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="9.9892245160353443E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0017671789459564E-02"/>
+                <Parameter name="Value" type="double" value="0.0099892245160353443"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.010017671789459564"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.5231281704019796E-16"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987E-16"/>
+                <Parameter name="Value" type="double" value="2.5231281704019796e-16"/>
+                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987e-16"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2146187645233065E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0742367360218137E-05"/>
+                <Parameter name="Value" type="double" value="0.000012146187645233065"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010742367360218137"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="3.3200000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.3294546826549702E-05"/>
+                <Parameter name="Value" type="double" value="0.000033200000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000033294546826549702"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="5.3499999999999997E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.3651825870676614E-03"/>
+                <Parameter name="Value" type="double" value="0.0053499999999999997"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0053651825870676614"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.7799999999999998E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.7879126028761809E-04"/>
+                <Parameter name="Value" type="double" value="0.00027799999999999998"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00027879126028761809"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.7728213902597242E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.7778699932375911E-04"/>
+                <Parameter name="Value" type="double" value="0.00017728213902597242"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00017778699932375911"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2500000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.2564075409559286E-05"/>
+                <Parameter name="Value" type="double" value="0.000022500000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000022564075409559286"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-15"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128E-15"/>
+                <Parameter name="Value" type="double" value="1.0000000000000001e-15"/>
+                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128e-15"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000000E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959449073E-03"/>
+                <Parameter name="Value" type="double" value="0.0010000000000000000"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0010028477959449073"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2499999999951748E-10"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163E-11"/>
+                <Parameter name="Value" type="double" value="1.2499999999951748e-10"/>
+                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163e-11"/>
               </ParameterList>
             </ParameterList>
-	    
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- IC For Domain -->
-  </ParameterList> <!-- Initial Conditions -->
-  
-
+    </ParameterList>
+    <!-- IC For Domain -->
+  </ParameterList>
+  <!-- Initial Conditions -->
   <!-- Boundary conditions -->
   <ParameterList name="Boundary Conditions">
     <!-- Boundary corresponding to the Natural recharge (left side) -->
     <ParameterList name="BC for natural  recharge (left)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (left)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-	    
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the Natural recharge (left side) -->
-    
-<!-- Boundary corresponding to the Natural recharge (right side) -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the Natural recharge (left side) -->
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
     <ParameterList name="BC for natural  recharge (right)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (right)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the Natural recharge (right side) -->
-       
-<!-- Boundary corresponding to the seepage basin -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
+    <!-- Boundary corresponding to the seepage basin -->
     <ParameterList name="BC for F-3 basin">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage basin}"/>
       <ParameterList name="BC: Flux">
         <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-        <Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-	<!-- less than 4 [m3 m-2 yr-1], mean recalculated by Haruko (8/7/12) -->
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 1.11e-4, 4.743e-6}"/> 
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <!-- less than 4 [m3 m-2 yr-1], mean recalculated by Haruko (8/7/12) -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000111, 0.000004743}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 9.7317820303283020E-03, 2.9578630770689822E-06}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0097317820303283020, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 1.0000000000000002E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 1.0000000000000002e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 3.3899999999999997E-05, 9.9892245160353443E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.000033899999999999997, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.4142508014351454E-06, 2.5231281704019796E-16}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 0.0000024142508014351454, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.0712465873417377E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000010712465873417377, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 1.7200000000000000E-06, 3.3200000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.0000017200000000000000, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 2.4700000000000001E-06, 5.3499999999999997E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0000024700000000000001, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 3.0398521726429520E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00030398521726429520, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.1800000000000000E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00011800000000000000, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 4.8000000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000048000000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 2.1700000000000002E-09, 1.0000000000000001E-15}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 2.1700000000000002e-9, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-02, 1.0000000000000000E-03}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-		<Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-		<Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 3.0099999999999854E-05, 1.2499999999951748E-10}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 0.000030099999999999854, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-    </ParameterList> <!-- Boundary corresponding to the seepage basin -->
-
-<!-- Boundary corresponding to the seepage face -->
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- Boundary corresponding to the seepage basin -->
+    <!-- Boundary corresponding to the seepage face -->
     <ParameterList name="BC for seepage face">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage face}"/>
       <ParameterList name="BC: Seepage">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.9578630770689822E-06, 2.9578630770689822E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000029578630770689822, 0.0000029578630770689822}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449E-08, 2.2134319178343449E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.2134319178343449e-8, 2.2134319178343449e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05, 1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001, 0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9892245160353443E-03, 9.9892245160353443E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0099892245160353443, 0.0099892245160353443}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796E-16, 2.5231281704019796E-16}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.5231281704019796e-16, 2.5231281704019796e-16}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2146187645233065E-05, 1.2146187645233065E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000012146187645233065, 0.000012146187645233065}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{3.3200000000000001E-05, 3.3200000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033200000000000001, 0.000033200000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{5.3499999999999997E-03, 5.3499999999999997E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0053499999999999997, 0.0053499999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.7799999999999998E-04, 2.7799999999999998E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00027799999999999998, 0.00027799999999999998}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.7728213902597242E-04, 1.7728213902597242E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00017728213902597242, 0.00017728213902597242}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{2.2500000000000001E-05, 2.2500000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000022500000000000001, 0.000022500000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-15, 1.0000000000000001E-15}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001e-15, 1.0000000000000001e-15}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-03, 1.0000000000000000E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010000000000000000, 0.0010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748E-10, 1.2499999999951748E-10}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.2499999999951748e-10, 1.2499999999951748e-10}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
+      </ParameterList>
+      <!-- Solute BC -->
     </ParameterList>
-  </ParameterList> <!-- Boundary Conditions -->
-
+  </ParameterList>
+  <!-- Boundary Conditions -->
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
       <Parameter name="Format" type="string" value="simple"/>
       <Parameter name="File" type="string" value="ascem-2012-farea.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
     <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-10"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="864000.0"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
   </ParameterList>
-       
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-5000-steps">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 5000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
     <ParameterList name="Time Macros">
-
       <ParameterList name="Every two months">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+06, 6.6271e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+6, 6.6271e+10}"/>
       </ParameterList>
-
       <ParameterList name="Every year">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7 [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 3.155760000e+7, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 31557600.00, 6.627096000e+10}"/>
       </ParameterList>
-
       <ParameterList name="Active Basin">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7 [s]
 	    End:      t=1988.00  [y] = 6.27365088e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 3.155760000e+7, 6.27365088e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 31557600.00, 6.27365088e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every year">
-	<!--
+        <!--
 	    Start:    t=1989.00  [y] = 6.276806640e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	    End:      t=2010.00  [y] = 6.343077600e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 3.155760000e+7, 6.343077600e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 31557600.00, 6.343077600e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every five years">
-	<!--
+        <!--
 	    Start:    t=2015.00  [y] = 6.358856400e+10 [s]
 	    Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 1.577880000e+8, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 157788000.0, 6.627096000e+10}"/>
       </ParameterList>
-
     </ParameterList>
-
     <ParameterList name="Observation Data">
-
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
         <Parameter name="Region" type="string" value="Well_1"/>
@@ -1366,54 +1215,44 @@
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output02">
         <Parameter name="Region" type="string" value="Well_2"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output03">
         <Parameter name="Region" type="string" value="Well_3"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="H+ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output04">
         <Parameter name="Region" type="string" value="Well_1"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
       <ParameterList name="output05">
         <Parameter name="Region" type="string" value="Well_2"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-	  
       <ParameterList name="output06">
         <Parameter name="Region" type="string" value="Well_3"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
         <Parameter name="Variable" type="string" value="UO2++ Aqueous concentration"/>
         <Parameter name="Time Macro" type="string" value="Every year"/>
       </ParameterList>
-
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Active Basin, Plume evolution: every year, Plume evolution: every five years}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="chkpoint"/>
       <Parameter name="Cycle Macro" type="string" value="Every-5000-steps"/>
     </ParameterList>
-
-  </ParameterList>     
-</ParameterList> 
-       
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/f-area/2d-flow-tracer/2d_f-area_flow-tracer.xml
+++ b/demos/phase2/f-area/2d-flow-tracer/2d_f-area_flow-tracer.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="ASCEM-F-Area"/>
@@ -9,24 +8,24 @@
     <Parameter name="Creation date" type="string" value="06.15.12"/>
     <Parameter name="Last modified" type="string" value="06.15.12"/>
   </ParameterList>
-
   <!-- Execution control -->
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
-    <Parameter name="Transport Model" type="string" value="On"/> 
+    <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-	<Parameter name="Switch" type="double" value="6.16635504e+10"/> <!-- Jan 1955 -->
-	<Parameter name="End" type="double" value="6.6271e+10"/> <!-- 2100 year-->
-   	<Parameter name="Steady Initial Time Step" type="double" value="100.0"/>
-	<Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Switch" type="double" value="6.16635504e+10"/>
+        <!-- Jan 1955 -->
+        <Parameter name="End" type="double" value="6.6271e+10"/>
+        <!-- 2100 year-->
+        <Parameter name="Steady Initial Time Step" type="double" value="100.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="100.0"/>
         <Parameter name="Use Picard" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Transport Process Kernel">
@@ -38,7 +37,7 @@
           <Parameter name="steady max iterations" type="int" value="50"/>
           <Parameter name="steady min iterations" type="int" value="8"/>
           <Parameter name="steady limit iterations" type="int" value="100"/>
-          <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
           <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
           <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
         </ParameterList>
@@ -46,7 +45,7 @@
           <Parameter name="transient max iterations" type="int" value="15"/>
           <Parameter name="transient min iterations" type="int" value="10"/>
           <Parameter name="transient limit iterations" type="int" value="20"/>
-          <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
           <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
           <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
           <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
@@ -62,7 +61,7 @@
           <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-9"/>
           <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="400"/>
         </ParameterList>
-          <ParameterList name="Preconditioners">
+        <ParameterList name="Preconditioners">
           <ParameterList name="Trilinos ML">
             <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
             <Parameter name="ML cycle applications" type="int" value="3"/>
@@ -71,11 +70,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-         
   <!-- Mesh in exodus format -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
@@ -90,133 +87,130 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-               
   <!-- Regions: Each region is coincident  with those specified in the exodus II format. -->
   <ParameterList name="Regions">
     <ParameterList name="Upper aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="50000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="50000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="30000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="30000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tan clay">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="40000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="40000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon confining">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="20000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="20000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="10000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="10000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
-
-<!-- This face is corresponding to natural recharge (left side) (Bc1) -->
+    <!-- This face is corresponding to natural recharge (left side) (Bc1) -->
     <ParameterList name="Natural recharge (left)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="1"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="1"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to natural recharge (right side) (Bc3) -->
+    <!-- This face is corresponding to natural recharge (right side) (Bc3) -->
     <ParameterList name="Natural recharge (right)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="3"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="3"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Seepage basin (Bc2) -->
+    <!-- This face is corresponding to Seepage basin (Bc2) -->
     <ParameterList name="Seepage basin">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="2"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="2"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to seepage face (Bc4) -->
+    <!-- This face is corresponding to seepage face (Bc4) -->
     <ParameterList name="Seepage face">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="4"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="4"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
     <ParameterList name="UTRA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="8"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="8"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
     <ParameterList name="UTRA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="5"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="5"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
     <ParameterList name="GA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="7"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="7"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
     <ParameterList name="GA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="6"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="6"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to vadose zone (Bc9, no flux) -->
+    <!-- This face is corresponding to vadose zone (Bc9, no flux) -->
     <ParameterList name="VZ">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="9"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="9"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <!-- Upper aquifer (UUTRA) -->
     <ParameterList name="Mesh block 1">
@@ -224,83 +218,79 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="y" type="double" value="5.0e-12"/> 
+        <Parameter name="y" type="double" value="5.0e-12"/>
         <Parameter name="x" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="4.0e-4"/> 
+        <Parameter name="alpha" type="double" value="0.00040"/>
         <Parameter name="Sr" type="double" value="0.18"/>
         <Parameter name="m" type="double" value="0.27"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Upper aquifer}"/>
     </ParameterList>
-
-    <!-- Lower aquifer (LUTRA) -->           
+    <!-- Lower aquifer (LUTRA) -->
     <ParameterList name="Mesh block 2">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="y" type="double" value="5.0e-12"/> 
+        <Parameter name="y" type="double" value="5.0e-12"/>
         <Parameter name="x" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.41"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Lower aquifer}"/>
     </ParameterList>
-
     <!-- Tan clay (TCCZ) -->
     <ParameterList name="Mesh block 3">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="y" type="double" value="1.98e-14"/> 
-        <Parameter name="x" type="double" value="1.98e-14"/> 
+        <Parameter name="y" type="double" value="1.98e-14"/>
+        <Parameter name="x" type="double" value="1.98e-14"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Tan clay}"/>
     </ParameterList>
-
     <!-- Gordon confining (GC) -->
     <ParameterList name="Mesh block 4">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="y" type="double" value="1.0e-17"/> 
+        <Parameter name="y" type="double" value="1.0e-17"/>
         <Parameter name="x" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon confining}"/>
     </ParameterList>
-
     <!-- Gordon aquifer (GA) -->
     <ParameterList name="Mesh block 5">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="y" type="double" value="1.0e-17"/> 
+        <Parameter name="y" type="double" value="1.0e-17"/>
         <Parameter name="x" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -308,16 +298,14 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon aquifer}"/>
     </ParameterList>
   </ParameterList>
-  
-     
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="997.16e0"/>
+          <Parameter name="Density" type="double" value="997.16"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -327,17 +315,15 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-  
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Reference Value" type="double" value="101325.0"/>
-        <Parameter name="Reference Coordinate" type="Array(double)" value="{0., 60.0}"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 60.0}"/>
         <!-- SABEA: Units for the gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2 -->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
@@ -346,30 +332,29 @@
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
-            </ParameterList>     
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
-<!-- Boundary conditions -->
+  <!-- Boundary conditions -->
   <ParameterList name="Boundary Conditions">
-<!-- Boundary corresponding to the Natural recharge (left side) -->
+    <!-- Boundary corresponding to the Natural recharge (left side) -->
     <ParameterList name="BC for natural  recharge (left)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (left)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="3H">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
@@ -378,21 +363,21 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!-- Boundary corresponding to the Natural recharge (right side) -->
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
     <ParameterList name="BC for natural  recharge (right)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (right)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="3H">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.0, 0.0}"/>
               </ParameterList>
@@ -401,25 +386,25 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-       
-<!-- Boundary corresponding to the seepage basin -->
+    <!-- Boundary corresponding to the seepage basin -->
     <ParameterList name="BC for F-3 basin">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage basin}"/>
       <ParameterList name="BC: Flux">
-         <!-- 
+        <!-- 
              1955.0 [y] = 6.16635504e+10 [s]   - basin turns on
              1988.0 [y] = 6.27365088e+10 [s]   - basin turns off 
         -->
         <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-        <Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 1.2648e-4, 4.743e-6}"/>  <!-- 4 [m3 m-2 yr-1] -->
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.00012648, 0.000004743}"/>
+        <!-- 4 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="3H">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{2.17e-9, 2.17e-9}"/>
               </ParameterList>
@@ -428,21 +413,21 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!-- Boundary corresponding to the seepage face -->
+    <!-- Boundary corresponding to the seepage face -->
     <ParameterList name="BC for seepage face">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage face, Natural recharge (right)}"/>
       <ParameterList name="BC: Seepage">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="3H">
               <ParameterList name="BC: Outflow">
-                <Parameter name="Times" type="Array(double)" value="{0., 0.}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 0.0}"/>
                 <Parameter name="Time functions" type="Array(string)" value="{Constant}"/>
               </ParameterList>
             </ParameterList>
@@ -451,53 +436,45 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-       
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-1000-steps">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
     <ParameterList name="Time Macros">
-
       <ParameterList name="Every-two-month">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+06, 6.6271e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+6, 6.6271e+10}"/>
       </ParameterList>
-
       <ParameterList name="Active Basin">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   2.00  [m] = 5.18400000e+06 [s]
 	    End:      t=1988.00  [y] = 6.27365088e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.18400000e+06, 6.27365088e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5184000.00, 6.27365088e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every year">
-	<!--
+        <!--
 	    Start:    t=1989.00  [y] = 6.276806640e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	    End:      t=2010.00  [y] = 6.343077600e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 3.155760000e+7, 6.343077600e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 31557600.00, 6.343077600e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every five years">
-	<!--
+        <!--
 	    Start:    t=2015.00  [y] = 6.358856400e+10 [s]
 	    Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 1.577880000e+8, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 157788000.0, 6.627096000e+10}"/>
       </ParameterList>
-      
     </ParameterList>
-
-<!-- For now we have desactivated the observation data -->
-<!--
+    <!-- For now we have desactivated the observation data -->
+    <!--
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
@@ -508,16 +485,13 @@
       </ParameterList>
     </ParameterList>
 -->
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Active Basin, Plume evolution: every year, Plume evolution: every five years}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="chkpoint"/>
       <Parameter name="Cycle Macro" type="string" value="Every-1000-steps"/>
     </ParameterList>
-  </ParameterList>     
-</ParameterList> 
-       
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/f-area/2d-flow-tritium/2d_f-area_flow-tritium.xml
+++ b/demos/phase2/f-area/2d-flow-tritium/2d_f-area_flow-tritium.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.1"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="Transient Richards"/>
     <Parameter name="Model name" type="string" value="ASCEM-F-Area"/>
@@ -9,82 +8,79 @@
     <Parameter name="Creation date" type="string" value="06.15.12"/>
     <Parameter name="Last modified" type="string" value="06.15.12"/>
   </ParameterList>
-
   <!-- Execution control -->
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
-    <Parameter name="Transport Model" type="string" value="On"/> 
+    <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Amanzi"/>
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-	<Parameter name="Switch" type="double" value="6.16635504e+10"/> <!-- Jan 1955 -->
-	<Parameter name="End" type="double" value="6.6271e+10"/> <!-- 2100 year-->
-   	<Parameter name="Steady Initial Time Step" type="double" value="1.0"/>
-	<Parameter name="Transient Initial Time Step" type="double" value="1.0"/>
+        <Parameter name="Switch" type="double" value="6.16635504e+10"/>
+        <!-- Jan 1955 -->
+        <Parameter name="End" type="double" value="6.6271e+10"/>
+        <!-- 2100 year-->
+        <Parameter name="Steady Initial Time Step" type="double" value="1.0"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1.0"/>
         <Parameter name="Use Picard" type="bool" value="false"/>
       </ParameterList>
     </ParameterList>
-
     <!--ParameterList name="Restart from Checkpoint Data File">
       <Parameter name="Checkpoint Data File Name" type="string" value="chkpoint00134.h5"/>
     </ParameterList-->
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Transport Process Kernel">
-            <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
-            <Parameter name="transport subcycling" type="bool" value="true"/>
-          </ParameterList>
-          <ParameterList name="Chemistry Process Kernel">
-            <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="steady max iterations" type="int" value="50"/>
-            <Parameter name="steady min iterations" type="int" value="8"/>
-            <Parameter name="steady limit iterations" type="int" value="100"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
-            <Parameter name="steady restart tolerance relaxation factor" type="double" value="100.0"/>
-            <Parameter name="steady restart tolerance relaxation factor damping" type="double" value="0.9"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1.0e-5"/>
-            <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Steady-State Pseudo-Time Implicit Solver">
-            <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/>
-            <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
-            <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/>
+        <ParameterList name="Transport Process Kernel">
+          <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
+          <Parameter name="transport subcycling" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="Chemistry Process Kernel">
+          <Parameter name="max chemistry to transport timestep ratio" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="steady max iterations" type="int" value="50"/>
+          <Parameter name="steady min iterations" type="int" value="8"/>
+          <Parameter name="steady limit iterations" type="int" value="100"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="steady timestep increase factor" type="double" value="2.0"/>
+          <Parameter name="steady restart tolerance relaxation factor" type="double" value="100.0"/>
+          <Parameter name="steady restart tolerance relaxation factor damping" type="double" value="0.9"/>
+        </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000010"/>
+          <Parameter name="transient max timestep" type="double" value="6.0e+10"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
+        </ParameterList>
+        <ParameterList name="Steady-State Pseudo-Time Implicit Solver">
+          <Parameter name="pseudo time integrator initialize with darcy" type="bool" value="true"/>
+          <Parameter name="pseudo time integrator clipping saturation value" type="double" value="0.9"/>
+          <Parameter name="pseudo time integrator time integration method" type="string" value="Picard"/>
+          <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
+          <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/>
+          <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
+          <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-9"/>
+          <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/>
+        </ParameterList>
+        <ParameterList name="Preconditioners">
+          <ParameterList name="Trilinos ML">
             <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
-            <Parameter name="pseudo time integrator linear solver" type="string" value="AztecOO"/>
-            <Parameter name="pseudo time integrator error control options" type="Array(string)" value="{pressure}"/>
-            <Parameter name="pseudo time integrator picard convergence tolerance" type="double" value="1e-9"/>
-            <Parameter name="pseudo time integrator picard maximum number of iterations" type="int" value="1200"/>
+            <Parameter name="ML cycle applications" type="int" value="3"/>
           </ParameterList>
-          <ParameterList name="Preconditioners">
-            <ParameterList name="Trilinos ML">
-              <Parameter name="pseudo time integrator preconditioner" type="string" value="Trilinos ML"/>
-              <Parameter name="ML cycle applications" type="int" value="3"/>
-            </ParameterList>
-          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-         
   <!-- Mesh in exodus format -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
@@ -99,133 +95,130 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-               
   <!-- Regions: Each region is coincident  with those specified in the exodus II format. -->
   <ParameterList name="Regions">
     <ParameterList name="Upper aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="50000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="50000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="30000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="30000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tan clay">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="40000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="40000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon confining">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="20000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="20000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Gordon aquifer">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="10000"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="10000"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Cell"/>
       </ParameterList>
     </ParameterList>
-
-<!-- This face is corresponding to natural recharge (left side) (Bc1) -->
+    <!-- This face is corresponding to natural recharge (left side) (Bc1) -->
     <ParameterList name="Natural recharge (left)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="1"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="1"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to natural recharge (right side) (Bc3) -->
+    <!-- This face is corresponding to natural recharge (right side) (Bc3) -->
     <ParameterList name="Natural recharge (right)">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="3"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="3"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Seepage basin (Bc2) -->
+    <!-- This face is corresponding to Seepage basin (Bc2) -->
     <ParameterList name="Seepage basin">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="2"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="2"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to seepage face (Bc4) -->
+    <!-- This face is corresponding to seepage face (Bc4) -->
     <ParameterList name="Seepage face">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="4"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="4"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) upstream side (Bc8) -->
     <ParameterList name="UTRA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="8"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="8"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
+    <!-- This face is corresponding to UTRA (UUTRA + TCCZ + LUTRA) downstream side (Bc5) -->
     <ParameterList name="UTRA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="5"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="5"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) upstream side (Bc7) -->
     <ParameterList name="GA upstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="7"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="7"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
+    <!-- This face is corresponding to Gordon aquifer (GA) downstream side (Bc6) -->
     <ParameterList name="GA downstream">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="6"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="6"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
-<!-- This face is corresponding to vadose zone (Bc9, no flux) -->
+    <!-- This face is corresponding to vadose zone (Bc9, no flux) -->
     <ParameterList name="VZ">
       <ParameterList name="Region: Labeled Set">
-        <Parameter name="Label"  type="string" value="9"/>
-        <Parameter name="File"   type="string" value="f_area_mesh_2D.exo"/>
+        <Parameter name="Label" type="string" value="9"/>
+        <Parameter name="File" type="string" value="f_area_mesh_2D.exo"/>
         <Parameter name="Format" type="string" value="Exodus II"/>
         <Parameter name="Entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <!-- Upper aquifer (UUTRA) -->
     <ParameterList name="Mesh block 1">
@@ -233,83 +226,79 @@
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="4.0e-4"/> 
+        <Parameter name="alpha" type="double" value="0.00040"/>
         <Parameter name="Sr" type="double" value="0.18"/>
         <Parameter name="m" type="double" value="0.27"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Upper aquifer}"/>
     </ParameterList>
-
-    <!-- Lower aquifer (LUTRA) -->           
+    <!-- Lower aquifer (LUTRA) -->
     <ParameterList name="Mesh block 2">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="5.0e-12"/> 
+        <Parameter name="x" type="double" value="5.0e-12"/>
         <Parameter name="y" type="double" value="5.0e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.41"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Lower aquifer}"/>
     </ParameterList>
-
     <!-- Tan clay (TCCZ) -->
     <ParameterList name="Mesh block 3">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.98e-14"/> 
-        <Parameter name="y" type="double" value="1.98e-14"/> 
+        <Parameter name="x" type="double" value="1.98e-14"/>
+        <Parameter name="y" type="double" value="1.98e-14"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/> 
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Tan clay}"/>
     </ParameterList>
-
     <!-- Gordon confining (GC) -->
     <ParameterList name="Mesh block 4">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.0e-17"/> 
+        <Parameter name="x" type="double" value="1.0e-17"/>
         <Parameter name="y" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon confining}"/>
     </ParameterList>
-
     <!-- Gordon aquifer (GA) -->
     <ParameterList name="Mesh block 5">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.39"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="1.0e-17"/> 
-      <Parameter name="y" type="double" value="1.0e-17"/>
+        <Parameter name="x" type="double" value="1.0e-17"/>
+        <Parameter name="y" type="double" value="1.0e-17"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.1e-5"/>
+        <Parameter name="alpha" type="double" value="0.000051"/>
         <Parameter name="Sr" type="double" value="0.39"/>
         <Parameter name="m" type="double" value="0.5"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
@@ -317,16 +306,14 @@
       <Parameter name="Assigned Regions" type="Array(string)" value="{Gordon aquifer}"/>
     </ParameterList>
   </ParameterList>
-  
-     
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="997.16e0"/>
+          <Parameter name="Density" type="double" value="997.16"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -336,24 +323,22 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-  
   <ParameterList name="Initial Conditions">
     <ParameterList name="IC For Domain">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Reference Value" type="double" value="101325.0"/>
-        <Parameter name="Reference Coordinate" type="Array(double)" value="{0., 60.0}"/>
+        <Parameter name="Reference Coordinate" type="Array(double)" value="{0.0, 60.0}"/>
         <!-- SABEA: Units for the gradient are Pa/m = rho*g = 998.32 kg/m^3 * 9.81 m/s^2 -->
-        <Parameter name="Gradient Value" type="Array(double)" value="{0., -9793.5192}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9793.5192}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tritium">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -361,47 +346,23 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
-<!-- Boundary conditions -->
+  <!-- Boundary conditions -->
   <ParameterList name="Boundary Conditions">
-<!-- Boundary corresponding to the Natural recharge (left side) -->
+    <!-- Boundary corresponding to the Natural recharge (left side) -->
     <ParameterList name="BC for natural  recharge (left)">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (left)}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] => [kg m-2 s-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e9}"/>
-                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}}"/>
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-<!-- Boundary corresponding to the Natural recharge (right side) -->
-    <ParameterList name="BC for natural  recharge (right)">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (right)}"/>
-      <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
-        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
-      </ParameterList>
-      <ParameterList name="Solute BC">
-        <ParameterList name="Aqueous">
-          <ParameterList name="Water">
-            <ParameterList name="Tritium">
-              <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -410,48 +371,71 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-       
-<!-- Boundary corresponding to the seepage basin -->
+    <!-- Boundary corresponding to the Natural recharge (right side) -->
+    <ParameterList name="BC for natural  recharge (right)">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Natural recharge (right)}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
+      </ParameterList>
+      <ParameterList name="Solute BC">
+        <ParameterList name="Aqueous">
+          <ParameterList name="Water">
+            <ParameterList name="Tritium">
+              <ParameterList name="BC: Uniform Concentration">
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
+                <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <!-- Boundary corresponding to the seepage basin -->
     <ParameterList name="BC for F-3 basin">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage basin}"/>
       <ParameterList name="BC: Flux">
-         <!-- 
+        <!-- 
              1955.0 [y] = 6.16635504e+10 [s]   - basin turns on
              1988.0 [y] = 6.27365088e+10 [s]   - basin turns off 
         -->
         <Parameter name="Times" type="Array(double)" value="{0.0, 6.16635504e+10, 6.27365088e+10}"/>
-        <Parameter name="Time Functions" type="Array(string)" value="{Constant,Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 1.2648e-4, 4.743e-6}"/>  <!-- 4 [m3 m-2 yr-1] -->
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant, Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.00012648, 0.000004743}"/>
+        <!-- 4 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.0e-3, 1.0e-3}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0010, 0.0010}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!-- Boundary corresponding to the seepage face -->
+    <!-- Boundary corresponding to the seepage face -->
     <ParameterList name="BC for seepage face">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Seepage face}"/>
       <ParameterList name="BC: Seepage">
-        <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{4.743e-6, 4.743e-6}"/>  <!-- 0.15 [m3 m-2 yr-1] -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.000004743, 0.000004743}"/>
+        <!-- 0.15 [m3 m-2 yr-1] -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0., 3.1536e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 3.1536e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{1.0e-20, 1.0e-20}"/>
               </ParameterList>
@@ -461,65 +445,56 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
       <Parameter name="Format" type="string" value="simple"/>
       <Parameter name="File" type="string" value="tritium.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
     <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="25"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
   </ParameterList>
-       
   <ParameterList name="Output">
-
     <!-- define some handy cycle macros -->
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every-5000-steps">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 5000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- define some handy time macros -->
-
     <ParameterList name="Time Macros">
-
       <ParameterList name="Every-two-month">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+06, 6.6271e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.184e+6, 6.6271e+10}"/>
       </ParameterList>
-
       <ParameterList name="Active Basin">
-	<!--
+        <!--
 	    Start:    t=1955.00  [y] = 6.16635504e+10 [s]
 	    Period:  dt=   2.00  [m] = 5.18400000e+06 [s]
 	    End:      t=1988.00  [y] = 6.27365088e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5.18400000e+06, 6.27365088e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.16635504e+10, 5184000.00, 6.27365088e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every year">
-	<!--
+        <!--
 	    Start:    t=1989.00  [y] = 6.276806640e+10 [s]
 	    Period:  dt=   1.00  [y] = 3.155760000e+7  [s]
 	    End:      t=2010.00  [y] = 6.343077600e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 3.155760000e+7, 6.343077600e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.276806640e+10, 31557600.00, 6.343077600e+10}"/>
       </ParameterList>
       <ParameterList name="Plume evolution: every five years">
-	<!--
+        <!--
 	    Start:    t=2015.00  [y] = 6.358856400e+10 [s]
 	    Period:  dt=   5.00  [y] = 1.577880000e+8  [s]
 	    End:      t=2100.00  [y] = 6.627096000e+10 [s]
 	  -->
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 1.577880000e+8, 6.627096000e+10}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{6.358856400e+10, 157788000.0, 6.627096000e+10}"/>
       </ParameterList>
-
     </ParameterList>
-
-<!-- For now we have desactivated the observation data -->
-<!--
+    <!-- For now we have desactivated the observation data -->
+    <!--
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="output01">
@@ -530,18 +505,13 @@
       </ParameterList>
     </ParameterList>
 -->
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Active Basin, Plume evolution: every year, Plume evolution: every five years}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="chkpoint"/>
       <Parameter name="Cycle Macro" type="string" value="Every-5000-steps"/>
     </ParameterList>
-
-  </ParameterList>     
-
-</ParameterList> 
-       
+  </ParameterList>
+</ParameterList>

--- a/demos/phase2/tanks/TI/PhaseII_Flow_TI01.xml
+++ b/demos/phase2/tanks/TI/PhaseII_Flow_TI01.xml
@@ -1,46 +1,40 @@
 <ParameterList name="Main">
   <!--Phase II demo, Flow simulation, Flow period 01-->
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="flow01/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="PhaseII_Flow01"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Richards equation unsaturated flow"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
-    <Parameter name="Simulation transient mode"  type="string" value="steady-state"/>
+    <Parameter name="Simulation transient mode" type="string" value="steady-state"/>
     <Parameter name="Simulation materials" type="string" value="soil+concrete+more"/>
   </ParameterList>
-
   <ParameterList name="Domain">
-     <!--Cartesian coordinates implied-->
+    <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40,24}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{40,24}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{40, 24}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="Switch" type="double" value="1.e11"/>
-        <Parameter name="End" type="double" value="1.e11"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="1.e5"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.e7"/>
-        <Parameter name="Steady Maximum Time Step Size" type="double" value="1.e9"/>
-        <Parameter name="Transient Maximum Time Step Size" type="double" value="1.e9"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="1e+11"/>
+        <Parameter name="End" type="double" value="1e+11"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+7"/>
+        <Parameter name="Steady Maximum Time Step Size" type="double" value="1e+9"/>
+        <Parameter name="Transient Maximum Time Step Size" type="double" value="1e+9"/>
         <Parameter name="Maximum Cycle Number" type="int" value="100000"/>
         <Parameter name="Initial Time Step Multiplier" type="double" value="1.0"/>
       </ParameterList>
@@ -50,9 +44,7 @@
       <!--   <Parameter name="Initial Time Step" type="double" value="1.e5"/> -->
       <!-- </ParameterList> -->
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Medium"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
@@ -64,165 +56,159 @@
           <Parameter name="steady_time_step_reduction_factor" type="double" value="0.7"/>
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.8"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e11"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+11"/>
           <Parameter name="richard_solver_verbose" type="int" value="2"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="200"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-11"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="200.0"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1e-11"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_scale_solution_before_solve" type="bool" value="true"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="true"/>
           <Parameter name="steady_do_grid_sequence" type="int" value="1"/>
-          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{1.e-3, 1.e-3, 1.e-3, 1.e-3, 1.e-3}"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e8"/>
+          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{0.001, 0.001, 0.001, 0.001, 0.001}"/>
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+8"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="2"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2, 2, 2}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
-
-	  <ParameterList name="Soil ref">
-	    <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-	  <ParameterList name="wasteFF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="5"/>
-	  </ParameterList>
-	  <ParameterList name="Conc ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-	  <ParameterList name="Liner ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="5"/>
-	  </ParameterList>
-	  <ParameterList name="Grout ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="2"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2, 2, 2}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
+          <ParameterList name="Soil ref">
+            <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="wasteFF ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="5"/>
+          </ParameterList>
+          <ParameterList name="Conc ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liner ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="5"/>
+          </ParameterList>
+          <ParameterList name="Grout ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="SoilLower">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,10}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilUpper">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,18}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,24}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilRight">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{12,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{12.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFfloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFwall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankWaste">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,10.33}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 10.33}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,10.3}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 10.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerRoof">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.69}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.69}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankGrout">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.69}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.69}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation point at bottom of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,18}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point in middle of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,10}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point at top of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,14}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 14.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
@@ -232,17 +218,16 @@
         <Parameter name="y" type="double" value="2.87e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="3.02e-4"/>
+        <Parameter name="alpha" type="double" value="0.000302"/>
         <Parameter name="Sr" type="double" value="0.354"/>
         <Parameter name="m" type="double" value="0.291"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        <Parameter name="krel smoothing interval" type="double" value=".00035"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.00035"/>
         <!-- <Parameter name="WRM Plot File" type="string" value="flow01/kr_soil.dat"/> -->
         <!-- <Parameter name="WRM Plot File Number Of Points" type="int" value="1000001"/> -->
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{SoilLower, SoilUpper, SoilRight}"/>
     </ParameterList>
-
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.30"/>
@@ -252,17 +237,16 @@
         <Parameter name="y" type="double" value="1.54e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        <Parameter name="krel smoothing interval" type="double" value=".000081"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.000081"/>
         <!-- <Parameter name="WRM Plot File" type="string" value="flow01/kr_gravel.dat"/> -->
         <!-- <Parameter name="WRM Plot File Number Of Points" type="int" value="1000001"/> -->
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankWaste}"/>
     </ParameterList>
-
     <ParameterList name="Concrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -282,7 +266,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
     </ParameterList>
-
     <ParameterList name="Liner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -302,7 +285,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.266"/>
@@ -322,9 +304,7 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankGrout, TankFFfloor, TankFFwall}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -342,21 +322,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9789.3474 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9789.3474}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -364,13 +343,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC lower">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -383,7 +360,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC upper">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
@@ -400,27 +376,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="flow01/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
@@ -430,5 +406,4 @@
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase2/tanks/TI/PhaseII_Flow_TI02.xml
+++ b/demos/phase2/tanks/TI/PhaseII_Flow_TI02.xml
@@ -1,48 +1,40 @@
 <ParameterList name="Main">
   <!--Phase II demo, Flow simulation, Flow period 02-->
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="flow02/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc"/>
   <!-- <Parameter name="Pause For Debug" type="bool" value="true"/> -->
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="PhaseII_Flow02"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Richards equation unsaturated flow"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
-    <Parameter name="Simulation transient mode"  type="string" value="steady-state"/>
+    <Parameter name="Simulation transient mode" type="string" value="steady-state"/>
     <Parameter name="Simulation materials" type="string" value="soil+concrete+more"/>
   </ParameterList>
-
   <ParameterList name="Domain">
-     <!--Cartesian coordinates implied-->
+    <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40,24}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{40,24}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{40, 24}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.e11"/>
-        <Parameter name="Initial Time Step" type="double" value="1.e5"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+11"/>
+        <Parameter name="Initial Time Step" type="double" value="1e+5"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Medium"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
@@ -54,169 +46,162 @@
           <Parameter name="steady_time_step_reduction_factor" type="double" value="0.7"/>
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.8"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e11"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+11"/>
           <Parameter name="richard_solver_verbose" type="int" value="2"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="200"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-11"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="200.0"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1e-11"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_scale_solution_before_solve" type="bool" value="true"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="true"/>
           <Parameter name="steady_do_grid_sequence" type="int" value="1"/>
-          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{1.e-5, 1.e-5, 1.e-7}"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e9"/>
+          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{0.00001, 0.00001, 1e-7}"/>
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+9"/>
           <!-- <Parameter name="richard_variable_switch_saturation_threshold" type="double" value="0.9995"/> -->
-
-          <Parameter name="verbose" type="double" value="2"/>
+          <Parameter name="verbose" type="double" value="2.0"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{8, 8, 8, 8}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
-
-	  <ParameterList name="Soil ref">
-	    <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-	  <ParameterList name="wasteFF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Conc ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-	  <ParameterList name="Liner ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Grout ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	    <Parameter name="refine_grid_layout" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{8, 8, 8, 8}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
+          <ParameterList name="Soil ref">
+            <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="wasteFF ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Conc ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liner ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Grout ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+            <Parameter name="refine_grid_layout" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="SoilLower">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,10}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilUpper">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,18}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,24}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilRight">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{12,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{12.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFfloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFwall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankWaste">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,10.33}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 10.33}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,10.3}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 10.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerRoof">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.69}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.69}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankGrout">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.69}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.69}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation point at bottom of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,18}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point in middle of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,10}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point at top of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,14}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 14.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
@@ -226,17 +211,16 @@
         <Parameter name="y" type="double" value="2.87e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="3.02e-4"/>
+        <Parameter name="alpha" type="double" value="0.000302"/>
         <Parameter name="Sr" type="double" value="0.354"/>
         <Parameter name="m" type="double" value="0.291"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        <Parameter name="krel smoothing interval" type="double" value=".00035"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.00035"/>
         <!-- <Parameter name="WRM Plot File" type="string" value="flow01/kr_soil.dat"/> -->
         <!-- <Parameter name="WRM Plot File Number Of Points" type="int" value="1000001"/> -->
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{SoilLower, SoilUpper, SoilRight}"/>
     </ParameterList>
-
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.30"/>
@@ -246,17 +230,16 @@
         <Parameter name="y" type="double" value="1.54e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        <Parameter name="krel smoothing interval" type="double" value=".000081"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.000081"/>
         <!-- <Parameter name="WRM Plot File" type="string" value="flow01/kr_gravel.dat"/> -->
         <!-- <Parameter name="WRM Plot File Number Of Points" type="int" value="1000001"/> -->
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
     </ParameterList>
-
     <ParameterList name="Concrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -276,7 +259,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
     </ParameterList>
-
     <ParameterList name="Liner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -296,7 +278,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.266"/>
@@ -316,9 +297,7 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankGrout}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -336,21 +315,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9789.3474 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9789.3474}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -358,13 +336,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC lower">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -377,7 +353,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC upper">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
@@ -394,27 +369,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="flow02/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
@@ -424,5 +399,4 @@
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase2/tanks/TI/PhaseII_Flow_TI03.xml
+++ b/demos/phase2/tanks/TI/PhaseII_Flow_TI03.xml
@@ -1,37 +1,31 @@
 <ParameterList name="Main">
   <!--Phase II demo, Flow simulation, Flow period 03-->
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="flow03/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="PhaseII_Flow03"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Richards equation unsaturated flow"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
-    <Parameter name="Simulation transient mode"  type="string" value="steady-state"/>
+    <Parameter name="Simulation transient mode" type="string" value="steady-state"/>
     <Parameter name="Simulation materials" type="string" value="soil+concrete+more"/>
   </ParameterList>
-
   <ParameterList name="Domain">
-     <!--Cartesian coordinates implied-->
+    <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40,24}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{40,24}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{40, 24}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
- 
     <ParameterList name="Time Integration Mode">
       <!-- <ParameterList name="Initialize To Steady"> -->
       <!--   <Parameter name="Start" type="double" value="0"/> -->
@@ -45,14 +39,12 @@
       <!--   <Parameter name="Initial Time Step Multiplier" type="double" value="1.0"/> -->
       <!-- </ParameterList> -->
       <ParameterList name="Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.e11"/>
-        <Parameter name="Initial Time Step" type="double" value="1.e5"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+11"/>
+        <Parameter name="Initial Time Step" type="double" value="1e+5"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Medium"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
@@ -65,187 +57,178 @@
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.6"/>
           <Parameter name="steady_min_iterations_2" type="int" value="4"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="5"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="5.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.05"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="4"/>
           <Parameter name="steady_time_step_retry_factor_2" type="double" value="0.01"/>
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.001"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e11"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+11"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
-
           <Parameter name="richard_solver_verbose" type="int" value="2"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="200"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="200.0"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="1"/>
-
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-8"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1e-8"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="3"/>
           <Parameter name="richard_scale_solution_before_solve" type="bool" value="false"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="true"/>
           <Parameter name="steady_do_grid_sequence" type="int" value="1"/>
-          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{1.e-5, 1.e-5, 1.e-6}"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e8"/>
-
+          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{0.00001, 0.00001, 0.000001}"/>
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+8"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="2"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
-
-	  <ParameterList name="Soil ref">
-	    <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-	  <ParameterList name="wasteFF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Conc ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-	  <ParameterList name="Liner ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Grout ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="2"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
+          <ParameterList name="Soil ref">
+            <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="wasteFF ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Conc ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liner ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Grout ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="SoilLower">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,10}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilUpper">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,18}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,24}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilRight">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{12,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{12.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFfloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFwall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankWaste">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,10.33}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 10.33}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,10.3}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 10.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerRoof">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.69}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.69}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankGrout">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.69}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.69}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation point at bottom of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,18}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point in middle of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,10}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point at top of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,14}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 14.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
@@ -255,14 +238,13 @@
         <Parameter name="y" type="double" value="2.87e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="3.02e-4"/>
+        <Parameter name="alpha" type="double" value="0.000302"/>
         <Parameter name="Sr" type="double" value="0.354"/>
         <Parameter name="m" type="double" value="0.291"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{SoilLower, SoilUpper, SoilRight}"/>
     </ParameterList>
-
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.30"/>
@@ -272,14 +254,13 @@
         <Parameter name="y" type="double" value="1.54e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
     </ParameterList>
-
     <ParameterList name="Concrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -296,7 +277,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
     </ParameterList>
-
     <ParameterList name="Liner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -313,7 +293,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.266"/>
@@ -330,9 +309,7 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankGrout}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -350,21 +327,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9789.3474 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9789.3474}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -372,13 +348,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC lower">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -391,7 +365,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC upper">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
@@ -408,27 +381,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="flow03/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
@@ -438,5 +411,4 @@
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase2/tanks/TI/PhaseII_Flow_TI04.xml
+++ b/demos/phase2/tanks/TI/PhaseII_Flow_TI04.xml
@@ -1,38 +1,31 @@
 <ParameterList name="Main">
   <!--Phase II demo, Flow simulation, Flow period 04-->
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="flow04/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="PhaseII_Flow04"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Richards equation unsaturated flow"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
-    <Parameter name="Simulation transient mode"  type="string" value="steady-state"/>
+    <Parameter name="Simulation transient mode" type="string" value="steady-state"/>
     <Parameter name="Simulation materials" type="string" value="soil+concrete+more"/>
   </ParameterList>
-
   <ParameterList name="Domain">
-     <!--Cartesian coordinates implied-->
+    <!--Cartesian coordinates implied-->
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40,24}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{40,24}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{40, 24}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
-
     <ParameterList name="Time Integration Mode">
       <!-- <ParameterList name="Initialize To Steady"> -->
       <!--   <Parameter name="Start" type="double" value="0"/> -->
@@ -46,14 +39,12 @@
       <!--   <Parameter name="Initial Time Step Multiplier" type="double" value="1.0"/> -->
       <!-- </ParameterList> -->
       <ParameterList name="Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.e11"/>
-        <Parameter name="Initial Time Step" type="double" value="1.e5"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+11"/>
+        <Parameter name="Initial Time Step" type="double" value="1e+5"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Medium"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
@@ -66,187 +57,180 @@
           <Parameter name="steady_min_iterations" type="int" value="10"/>
           <Parameter name="steady_time_step_increase_factor" type="double" value="1.8"/>
           <Parameter name="steady_min_iterations_2" type="int" value="2"/>
-          <Parameter name="steady_time_step_increase_factor_2" type="double" value="3"/>
+          <Parameter name="steady_time_step_increase_factor_2" type="double" value="3.0"/>
           <Parameter name="steady_max_consecutive_failures_1" type="int" value="3"/>
           <Parameter name="steady_time_step_retry_factor_1" type="double" value="0.05"/>
           <Parameter name="steady_max_consecutive_failures_2" type="int" value="4"/>
           <Parameter name="steady_time_step_retry_factor_2" type="double" value="0.01"/>
           <Parameter name="steady_time_step_retry_factor_f" type="double" value="0.001"/>
           <Parameter name="steady_max_num_consecutive_success" type="int" value="0"/>
-          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10."/>
+          <Parameter name="steady_extra_time_step_increase_factor" type="double" value="10.0"/>
           <Parameter name="steady_max_num_consecutive_increases" type="int" value="15"/>
           <Parameter name="steady_consecutive_increase_reduction_factor" type="double" value="0.4"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e11"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="3.15576e+11"/>
           <Parameter name="steady_abort_on_psuedo_timestep_failure" type="int" value="0"/>
           <Parameter name="steady_use_PETSc_snes" type="bool" value="true"/>
           <Parameter name="steady_limit_function_evals" type="int" value="100000000"/>
-
           <Parameter name="richard_solver_verbose" type="int" value="2"/>
           <Parameter name="richard_max_ls_iterations" type="int" value="10"/>
-          <Parameter name="richard_min_ls_factor" type="double" value="1.e-8"/>
-          <Parameter name="richard_ls_acceptance_factor" type="double" value="200"/>
+          <Parameter name="richard_min_ls_factor" type="double" value="1e-8"/>
+          <Parameter name="richard_ls_acceptance_factor" type="double" value="200.0"/>
           <Parameter name="richard_ls_reduction_factor" type="double" value="0.1"/>
           <Parameter name="richard_monitor_linear_solve" type="int" value="0"/>
           <Parameter name="richard_monitor_line_search" type="int" value="1"/>
-
           <Parameter name="richard_use_fd_jac" type="int" value="1"/>
-          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1.e-10"/>
+          <Parameter name="richard_perturbation_scale_for_J" type="double" value="1e-10"/>
           <Parameter name="richard_use_dense_Jacobian" type="int" value="0"/>
           <Parameter name="richard_upwind_krel" type="int" value="1"/>
           <Parameter name="richard_pressure_maxorder" type="int" value="3"/>
           <Parameter name="richard_scale_solution_before_solve" type="bool" value="false"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="true"/>
           <Parameter name="steady_do_grid_sequence" type="int" value="1"/>
-          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{1.e-5, 1.e-5, 1.e-7}"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e14"/>
-
-          <Parameter name="verbose" type="double" value="2"/>
+          <Parameter name="steady_grid_sequence_new_level_dt_factor" type="Array(double)" value="{0.00001, 0.00001, 1e-7}"/>
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+14"/>
+          <Parameter name="verbose" type="double" value="2.0"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="2"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>        
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
-	  <ParameterList name="Soil ref">
-	    <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-	  <ParameterList name="wasteFF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Conc ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-	  <ParameterList name="Liner ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-	  <ParameterList name="Grout ref">
-	    <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="2"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{200000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 2, 2, 2}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{64, 64, 64, 64}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Soil ref, wasteFF ref, Conc ref, Liner ref, Grout ref}"/>
+          <ParameterList name="Soil ref">
+            <Parameter name="Regions" type="Array(string)" value="{SoilLower}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="wasteFF ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Conc ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liner ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Grout ref">
+            <Parameter name="Regions" type="Array(string)" value="{TankGrout}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="SoilLower">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,10}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilUpper">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,18}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,24}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 24.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilRight">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{12,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{40,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{12.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{40.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFfloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.5,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankFFwall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.67, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankWaste">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.69,10.33}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.69, 10.33}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,10.3}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 10.3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.7, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankConcRoof2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,17.7}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{12,18}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 17.7}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{12.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerFloor">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5,10.3}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,10.31}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.5, 10.3}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 10.31}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerWall">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69,10.31}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.7,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{11.69, 10.31}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.7, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankLinerRoof">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,17.69}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.7}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 17.69}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.7}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TankGrout">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0,10.33}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{11.67,17.69}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 10.33}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{11.67, 17.69}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation point at bottom of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,18}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 18.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point in middle of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,10}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Observation point at top of concrete">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,14}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 14.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
@@ -257,14 +241,13 @@
         <Parameter name="y" type="double" value="2.87e-13"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="3.02e-4"/>
+        <Parameter name="alpha" type="double" value="0.000302"/>
         <Parameter name="Sr" type="double" value="0.354"/>
         <Parameter name="m" type="double" value="0.291"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{SoilLower, SoilUpper, SoilRight}"/>
     </ParameterList>
-
     <ParameterList name="Gravel">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.30"/>
@@ -274,14 +257,13 @@
         <Parameter name="y" type="double" value="1.54e-10"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankWaste, TankFFfloor, TankFFwall}"/>
     </ParameterList>
-
     <ParameterList name="DegradedConcrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -298,7 +280,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankConcFloor, TankConcWall, TankConcRoof1, TankConcRoof2}"/>
     </ParameterList>
-
     <ParameterList name="DegradedLiner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.168"/>
@@ -315,7 +296,6 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankLinerFloor, TankLinerWall, TankLinerRoof}"/>
     </ParameterList>
-
     <ParameterList name="DegradedGrout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.266"/>
@@ -332,9 +312,7 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{TankGrout}"/>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -352,21 +330,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="101325"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{0,0}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,-9789.3474 }"/>
+        <Parameter name="Reference Value" type="double" value="101325.0"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, -9789.3474}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="0"/>
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -374,13 +351,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="BC lower">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{101325}"/>
+        <Parameter name="Values" type="Array(double)" value="{101325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -393,11 +368,10 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="BC upper">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YHIBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{9.513e-09}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{9.513e-9}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -410,27 +384,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-    <ParameterList name="Time Macros"/>
+    <ParameterList name="Time Macros">
+    </ParameterList>
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Observation Data"/>
+    <ParameterList name="Observation Data">
+    </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="flow04/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
@@ -440,5 +414,4 @@
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase3/rifle2D-bio/rifle-long_oldspec-modified.xml
+++ b/demos/phase3/rifle2D-bio/rifle-long_oldspec-modified.xml
@@ -27,32 +27,36 @@
     <Parameter name="Verbosity" type="string" value="high"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="Switch" type="double" value="8.64000000000000000e+06"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.00000000000000000e+03"/>
-        <Parameter name="End" type="double" value="6.6262E+08"/> <!--"4.74421e8"/> --><!--6.6262E+08 sec = 20 years --> <!--"8.75e+06"/>--> <!-- "4.73364000000000000e+08"/> -->
-        <Parameter name="Transient Initial Time Step" type="double" value="1.00000000000000000e+01"/>
+        <Parameter name="Start" type="double" value="0e-17"/>
+        <Parameter name="Switch" type="double" value="8640000.00000000000"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.00000000000000"/>
+        <Parameter name="End" type="double" value="6.6262e+8"/>
+        <!--"4.74421e8"/> -->
+        <!--6.6262E+08 sec = 20 years -->
+        <!--"8.75e+06"/>-->
+        <!-- "4.73364000000000000e+08"/> -->
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0000000000000000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Steady-State Implicit Time Integration">
-          <Parameter name="steady timestep reduction factor" type="double" value="1.00000000000000006e-01"/>
-          <Parameter name="steady timestep increase factor" type="double" value="1.25000000000000000e+00"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.100000000000000006"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25000000000000000"/>
           <Parameter name="steady min iterations" type="int" value="10"/>
           <Parameter name="steady max iterations" type="int" value="15"/>
           <Parameter name="steady max preconditioner lag iterations" type="int" value="30"/>
-          <Parameter name="steady nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-          <Parameter name="steady max timestep" type="double" value="3.15575999999999953e+06"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+          <Parameter name="steady max timestep" type="double" value="3155759.99999999953"/>
           <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
         </ParameterList>
         <ParameterList name="Transient Implicit Time Integration">
           <Parameter name="transient min iterations" type="int" value="10"/>
           <Parameter name="transient max iterations" type="int" value="15"/>
           <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
-          <Parameter name="transient timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-          <Parameter name="transient timestep reduction factor" type="double" value="5.00000000000000000e-01"/>
-          <Parameter name="transient max timestep" type="double" value="1.00000000000000000e+07"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25000000000000000"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.500000000000000000"/>
+          <Parameter name="transient max timestep" type="double" value="10000000.0000000000"/>
         </ParameterList>
         <ParameterList name="Linear Solver">
           <Parameter name="linear solver preconditioner" type="string" value="gmres"/>
@@ -63,18 +67,19 @@
           <ParameterList name="Hypre AMG">
             <Parameter name="Hypre AMG cycle applications" type="int" value="5"/>
             <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
-            <Parameter name="Hypre AMG tolerance" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="Hypre AMG strong threshold" type="double" value="4.00000000000000022e-01"/>
+            <Parameter name="Hypre AMG tolerance" type="double" value="0e-17"/>
+            <Parameter name="Hypre AMG strong threshold" type="double" value="0.400000000000000022"/>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="Flow Process Kernel"/>
+        <ParameterList name="Flow Process Kernel">
+        </ParameterList>
         <ParameterList name="Transport Process Kernel">
           <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
           <Parameter name="transport subcycling" type="bool" value="true"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
- <!--   <ParameterList name="Restart from Checkpoint Data File">
+    <!--   <ParameterList name="Restart from Checkpoint Data File">
       <Parameter name="Checkpoint Data File Name" type="string" value="chk00145.h5"/>
     </ParameterList> -->
   </ParameterList>
@@ -82,17 +87,17 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.00200000000000007e-03"/>
+          <Parameter name="Viscosity" type="double" value="0.00100200000000000007"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="9.98200000000000045e+02"/>
+          <Parameter name="Density" type="double" value="998.200000000000045"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
         <ParameterList name="water">
-          <Parameter name="Component Solutes" type="Array(string)" value="{H+,Cl-,SO4--,HCO3-,SiO2(aq),Al+++,Ca++,Mg++,Fe++,Fe+++,K+,Na+,O2(aq),HS-,NO3-,NO2-,N2(aq),Ac-,NH3(aq),Tracer}"/>
+          <Parameter name="Component Solutes" type="Array(string)" value="{H+, Cl-, SO4--, HCO3-, SiO2(aq), Al+++, Ca++, Mg++, Fe++, Fe+++, K+, Na+, O2(aq), HS-, NO3-, NO2-, N2(aq), Ac-, NH3(aq), Tracer}"/>
         </ParameterList>
-      </ParameterList> 
+      </ParameterList>
     </ParameterList>
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Goethite, Calcite, Siderite, Pyrite, Cellulose}"/>
@@ -143,58 +148,51 @@
   <ParameterList name="Material Properties">
     <ParameterList name="loam">
       <ParameterList name="Porosity: Uniform">
-        <Parameter name="Value" type="double" value="2.05999999999999989e-01"/>
+        <Parameter name="Value" type="double" value="0.205999999999999989"/>
       </ParameterList>
       <ParameterList name="Particle Density: Uniform">
-        <Parameter name="Value" type="double" value="2.72000000000000000e+03"/>
+        <Parameter name="Value" type="double" value="2720.00000000000000"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="4.52399999999999971e-12"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{fill}"/>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.06999999999999964e-04"/>
-        <Parameter name="m" type="double" value="1.77999999999999992e-01"/>
-        <Parameter name="Sr" type="double" value="7.28000000000000036e-02"/>
+        <Parameter name="alpha" type="double" value="0.000506999999999999964"/>
+        <Parameter name="m" type="double" value="0.177999999999999992"/>
+        <Parameter name="Sr" type="double" value="0.0728000000000000036"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
-
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Siderite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Pyrite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Cellulose">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Siderite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Pyrite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Cellulose">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
     </ParameterList>
     <ParameterList name="sand">
       <ParameterList name="Porosity: Uniform">
-        <Parameter name="Value" type="double" value="1.97899999999999993e-01"/>
+        <Parameter name="Value" type="double" value="0.197899999999999993"/>
       </ParameterList>
       <ParameterList name="Particle Density: Uniform">
-        <Parameter name="Value" type="double" value="2.72000000000000000e+03"/>
+        <Parameter name="Value" type="double" value="2720.00000000000000"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
         <Parameter name="x" type="double" value="9.67000000000000060e-12"/>
@@ -202,56 +200,46 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{alluvium}"/>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="8.46100000000000020e-04"/>
-        <Parameter name="m" type="double" value="3.05999999999999994e-01"/>
-        <Parameter name="Sr" type="double" value="1.26299999999999996e-01"/>
+        <Parameter name="alpha" type="double" value="0.000846100000000000020"/>
+        <Parameter name="m" type="double" value="0.305999999999999994"/>
+        <Parameter name="Sr" type="double" value="0.126299999999999996"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
-
-     <ParameterList name="Mineralogy">
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Siderite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Pyrite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Cellulose">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
+      <ParameterList name="Mineralogy">
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Siderite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Pyrite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Cellulose">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
     </ParameterList>
   </ParameterList>
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Pressure and concentration for fill">
-
       <Parameter name="Assigned Regions" type="Array(string)" value="{fill}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="Value" type="double" value="101325.000000000000"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="oxidized"/>
@@ -372,24 +360,20 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
-    </ParameterList> <!--fill-->
-
+    </ParameterList>
+    <!--fill-->
     <ParameterList name="Pressure and concentration for alluvium">
-
       <Parameter name="Assigned Regions" type="Array(string)" value="{alluvium}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="Value" type="double" value="101325.000000000000"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="reduced"/>
@@ -510,27 +494,24 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
-    </ParameterList> <!--alluvium-->
-
-  </ParameterList> <!-- Initial conditions -->
-
+    </ParameterList>
+    <!--alluvium-->
+  </ParameterList>
+  <!-- Initial conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Recharge at top of the domain with ponding">
       <Parameter name="Assigned Regions" type="Array(string)" value="{surface}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.49599999999999980e-07, 9.49599999999999980e-07}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.49599999999999980e-7, 9.49599999999999980e-7}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="atmosphere"/>
@@ -651,15 +632,13 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
-<!--            <ParameterList name="tracer">
+            <!--            <ParameterList name="tracer">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00}"/>
               </ParameterList>
             </ParameterList> -->
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -667,14 +646,13 @@
     <ParameterList name="upstream">
       <Parameter name="Assigned Regions" type="Array(string)" value="{right}"/>
       <ParameterList name="BC: Hydrostatic">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Water Table Height" type="Array(double)" value="{5.23190000000000044e+00, 5.23190000000000044e+00}"/>
+        <Parameter name="Water Table Height" type="Array(double)" value="{5.23190000000000044, 5.23190000000000044}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="oxidizedtracer"/>
@@ -795,7 +773,6 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -803,14 +780,13 @@
     <ParameterList name="downstream">
       <Parameter name="Assigned Regions" type="Array(string)" value="{left}"/>
       <ParameterList name="BC: Hydrostatic">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Water Table Height" type="Array(double)" value="{4.56250000000000000e+00, 4.56250000000000000e+00}"/>
+        <Parameter name="Water Table Height" type="Array(double)" value="{4.56250000000000000, 4.56250000000000000}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="reduced"/>
@@ -931,17 +907,17 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  <ParameterList name="Sources"/>
+  <ParameterList name="Sources">
+  </ParameterList>
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Time Output">
-        <Parameter name="Values" type="Array(double)" value="{8.63713e6, 6.31100000000000000e+07, 1.26200000000000000e+08, 1.89300000000000000e+08, 2.52500000000000000e+08, 3.15600000000000000e+08, 3.78700000000000000e+08, 4.41800000000000000e+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{8.63713e+6, 63110000.0000000000, 126200000.000000000, 189300000.000000000, 252500000.000000000, 315600000.000000000, 378700000.000000000, 441800000.000000000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -950,9 +926,9 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="Checkpoint Data">
-       <Parameter name="File Name Base" type="string" value="chk"/>
-       <Parameter name="File Name Digits" type="int" value="5"/>
-       <Parameter name="Cycle Macro" type="string" value="Every_50_timesteps"/>
+      <Parameter name="File Name Base" type="string" value="chk"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_50_timesteps"/>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot_new"/>
@@ -960,21 +936,23 @@
       <Parameter name="Time Macros" type="Array(string)" value="{Time Output}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="rifle-arora-spycher.in"/>
     <Parameter name="Verbosity" type="string" value="high"/>
-
     <!-- timestep control -->
     <Parameter name="Initial Time Step (s)" type="double" value="5.0"/>
-    <Parameter name="Time Step Control Method" type="string" value="simple"/>  <!-- default is fixed -->
-    <Parameter name="Time Step Cut Threshold" type="int" value="8"/>           <!-- default is 8     -->
-    <Parameter name="Time Step Cut Factor" type="double" value="2.0"/>         <!-- default is 2.0   -->
-    <Parameter name="Time Step Increase Threshold" type="int" value="4"/>      <!-- default is 4     -->
-    <Parameter name="Time Step Increase Factor" type="double" value="1.2"/>    <!-- default is 1.2   -->
-    <Parameter name="Max Time Step (s)" type="double" value="1e5"/> -->
-
-  </ParameterList> <!-- Chemistry -->
-
+    <Parameter name="Time Step Control Method" type="string" value="simple"/>
+    <!-- default is fixed -->
+    <Parameter name="Time Step Cut Threshold" type="int" value="8"/>
+    <!-- default is 8     -->
+    <Parameter name="Time Step Cut Factor" type="double" value="2.0"/>
+    <!-- default is 2.0   -->
+    <Parameter name="Time Step Increase Threshold" type="int" value="4"/>
+    <!-- default is 4     -->
+    <Parameter name="Time Step Increase Factor" type="double" value="1.2"/>
+    <!-- default is 1.2   -->
+    <Parameter name="Max Time Step (s)" type="double" value="1e+5"/>
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase3/rifle2D-nobio/rifle-long_oldspec-modified.xml
+++ b/demos/phase3/rifle2D-nobio/rifle-long_oldspec-modified.xml
@@ -27,32 +27,34 @@
     <Parameter name="Verbosity" type="string" value="high"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="Switch" type="double" value="8.64000000000000000e+06"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.00000000000000000e+03"/>
-        <Parameter name="End" type="double" value="4.7e+08"/> <!--"8.75e+06"/>--> <!-- "4.73364000000000000e+08"/> -->
-        <Parameter name="Transient Initial Time Step" type="double" value="1.00000000000000000e+01"/>
+        <Parameter name="Start" type="double" value="0e-17"/>
+        <Parameter name="Switch" type="double" value="8640000.00000000000"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1000.00000000000000"/>
+        <Parameter name="End" type="double" value="4.7e+8"/>
+        <!--"8.75e+06"/>-->
+        <!-- "4.73364000000000000e+08"/> -->
+        <Parameter name="Transient Initial Time Step" type="double" value="10.0000000000000000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Steady-State Implicit Time Integration">
-          <Parameter name="steady timestep reduction factor" type="double" value="1.00000000000000006e-01"/>
-          <Parameter name="steady timestep increase factor" type="double" value="1.25000000000000000e+00"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.100000000000000006"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25000000000000000"/>
           <Parameter name="steady min iterations" type="int" value="10"/>
           <Parameter name="steady max iterations" type="int" value="15"/>
           <Parameter name="steady max preconditioner lag iterations" type="int" value="30"/>
-          <Parameter name="steady nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-          <Parameter name="steady max timestep" type="double" value="3.15575999999999953e+06"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+          <Parameter name="steady max timestep" type="double" value="3155759.99999999953"/>
           <Parameter name="steady preconditioner" type="string" value="Hypre AMG"/>
         </ParameterList>
         <ParameterList name="Transient Implicit Time Integration">
           <Parameter name="transient min iterations" type="int" value="10"/>
           <Parameter name="transient max iterations" type="int" value="15"/>
           <Parameter name="transient max preconditioner lag iterations" type="int" value="5"/>
-          <Parameter name="transient timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-          <Parameter name="transient timestep reduction factor" type="double" value="5.00000000000000000e-01"/>
-          <Parameter name="transient max timestep" type="double" value="1.00000000000000000e+07"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25000000000000000"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.500000000000000000"/>
+          <Parameter name="transient max timestep" type="double" value="10000000.0000000000"/>
         </ParameterList>
         <ParameterList name="Linear Solver">
           <Parameter name="linear solver preconditioner" type="string" value="gmres"/>
@@ -63,11 +65,12 @@
           <ParameterList name="Hypre AMG">
             <Parameter name="Hypre AMG cycle applications" type="int" value="5"/>
             <Parameter name="Hypre AMG smoother sweeps" type="int" value="3"/>
-            <Parameter name="Hypre AMG tolerance" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="Hypre AMG strong threshold" type="double" value="4.00000000000000022e-01"/>
+            <Parameter name="Hypre AMG tolerance" type="double" value="0e-17"/>
+            <Parameter name="Hypre AMG strong threshold" type="double" value="0.400000000000000022"/>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="Flow Process Kernel"/>
+        <ParameterList name="Flow Process Kernel">
+        </ParameterList>
         <ParameterList name="Transport Process Kernel">
           <Parameter name="Transport Integration Algorithm" type="string" value="Explicit First-Order"/>
           <Parameter name="transport subcycling" type="bool" value="true"/>
@@ -79,17 +82,17 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.00200000000000007e-03"/>
+          <Parameter name="Viscosity" type="double" value="0.00100200000000000007"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="9.98200000000000045e+02"/>
+          <Parameter name="Density" type="double" value="998.200000000000045"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
         <ParameterList name="water">
-          <Parameter name="Component Solutes" type="Array(string)" value="{H+,Cl-,SO4--,HCO3-,SiO2(aq),Al+++,Ca++,Mg++,Fe++,Fe+++,K+,Na+,O2(aq),HS-,NO3-,NO2-,N2(aq),Ac-,NH3(aq),Tracer}"/>
+          <Parameter name="Component Solutes" type="Array(string)" value="{H+, Cl-, SO4--, HCO3-, SiO2(aq), Al+++, Ca++, Mg++, Fe++, Fe+++, K+, Na+, O2(aq), HS-, NO3-, NO2-, N2(aq), Ac-, NH3(aq), Tracer}"/>
         </ParameterList>
-      </ParameterList> 
+      </ParameterList>
     </ParameterList>
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Goethite, Calcite, Siderite, Pyrite, Cellulose}"/>
@@ -140,58 +143,51 @@
   <ParameterList name="Material Properties">
     <ParameterList name="loam">
       <ParameterList name="Porosity: Uniform">
-        <Parameter name="Value" type="double" value="2.05999999999999989e-01"/>
+        <Parameter name="Value" type="double" value="0.205999999999999989"/>
       </ParameterList>
       <ParameterList name="Particle Density: Uniform">
-        <Parameter name="Value" type="double" value="2.72000000000000000e+03"/>
+        <Parameter name="Value" type="double" value="2720.00000000000000"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="4.52399999999999971e-12"/>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{fill}"/>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="5.06999999999999964e-04"/>
-        <Parameter name="m" type="double" value="1.77999999999999992e-01"/>
-        <Parameter name="Sr" type="double" value="7.28000000000000036e-02"/>
+        <Parameter name="alpha" type="double" value="0.000506999999999999964"/>
+        <Parameter name="m" type="double" value="0.177999999999999992"/>
+        <Parameter name="Sr" type="double" value="0.0728000000000000036"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
-
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Siderite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Pyrite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Cellulose">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Siderite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Pyrite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Cellulose">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
     </ParameterList>
     <ParameterList name="sand">
       <ParameterList name="Porosity: Uniform">
-        <Parameter name="Value" type="double" value="1.97899999999999993e-01"/>
+        <Parameter name="Value" type="double" value="0.197899999999999993"/>
       </ParameterList>
       <ParameterList name="Particle Density: Uniform">
-        <Parameter name="Value" type="double" value="2.72000000000000000e+03"/>
+        <Parameter name="Value" type="double" value="2720.00000000000000"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
         <Parameter name="x" type="double" value="9.67000000000000060e-12"/>
@@ -199,56 +195,46 @@
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{alluvium}"/>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="8.46100000000000020e-04"/>
-        <Parameter name="m" type="double" value="3.05999999999999994e-01"/>
-        <Parameter name="Sr" type="double" value="1.26299999999999996e-01"/>
+        <Parameter name="alpha" type="double" value="0.000846100000000000020"/>
+        <Parameter name="m" type="double" value="0.305999999999999994"/>
+        <Parameter name="Sr" type="double" value="0.126299999999999996"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
-
-     <ParameterList name="Mineralogy">
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Siderite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Pyrite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Cellulose">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
+      <ParameterList name="Mineralogy">
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Siderite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Pyrite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Cellulose">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
     </ParameterList>
   </ParameterList>
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Pressure and concentration for fill">
-
       <Parameter name="Assigned Regions" type="Array(string)" value="{fill}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="Value" type="double" value="101325.000000000000"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="oxidized"/>
@@ -369,24 +355,20 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
-    </ParameterList> <!--fill-->
-
+    </ParameterList>
+    <!--fill-->
     <ParameterList name="Pressure and concentration for alluvium">
-
       <Parameter name="Assigned Regions" type="Array(string)" value="{alluvium}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
-        <Parameter name="Value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="Value" type="double" value="101325.000000000000"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="reduced"/>
@@ -507,27 +489,24 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
-    </ParameterList> <!--alluvium-->
-
-  </ParameterList> <!-- Initial conditions -->
-
+    </ParameterList>
+    <!--alluvium-->
+  </ParameterList>
+  <!-- Initial conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Recharge at top of the domain with ponding">
       <Parameter name="Assigned Regions" type="Array(string)" value="{surface}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.49599999999999980e-07, 9.49599999999999980e-07}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{9.49599999999999980e-7, 9.49599999999999980e-7}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="atmosphere"/>
@@ -648,15 +627,13 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
-<!--            <ParameterList name="tracer">
+            <!--            <ParameterList name="tracer">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
                 <Parameter name="Values" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00}"/>
               </ParameterList>
             </ParameterList> -->
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -664,14 +641,13 @@
     <ParameterList name="upstream">
       <Parameter name="Assigned Regions" type="Array(string)" value="{right}"/>
       <ParameterList name="BC: Hydrostatic">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Water Table Height" type="Array(double)" value="{5.23190000000000044e+00, 5.23190000000000044e+00}"/>
+        <Parameter name="Water Table Height" type="Array(double)" value="{5.23190000000000044, 5.23190000000000044}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="oxidizedtracer"/>
@@ -792,7 +768,6 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -800,14 +775,13 @@
     <ParameterList name="downstream">
       <Parameter name="Assigned Regions" type="Array(string)" value="{left}"/>
       <ParameterList name="BC: Hydrostatic">
-        <Parameter name="Times" type="Array(double)" value="{0.00000000000000000e+00, 4.73364001000000000e+08}"/>
+        <Parameter name="Times" type="Array(double)" value="{0e-17, 473364001.000000000}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Water Table Height" type="Array(double)" value="{4.56250000000000000e+00, 4.56250000000000000e+00}"/>
+        <Parameter name="Water Table Height" type="Array(double)" value="{4.56250000000000000, 4.56250000000000000}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="reduced"/>
@@ -928,17 +902,17 @@
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molarity"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  <ParameterList name="Sources"/>
+  <ParameterList name="Sources">
+  </ParameterList>
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Time Output">
-        <Parameter name="Values" type="Array(double)" value="{6.31100000000000000e+07, 1.26200000000000000e+08, 1.89300000000000000e+08, 2.52500000000000000e+08, 3.15600000000000000e+08, 3.78700000000000000e+08, 4.41800000000000000e+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{63110000.0000000000, 126200000.000000000, 189300000.000000000, 252500000.000000000, 315600000.000000000, 378700000.000000000, 441800000.000000000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -947,9 +921,9 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="Checkpoint Data">
-       <Parameter name="File Name Base" type="string" value="chk"/>
-       <Parameter name="File Name Digits" type="int" value="5"/>
-       <Parameter name="Cycle Macro" type="string" value="Every_50_timesteps"/>
+      <Parameter name="File Name Base" type="string" value="chk"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_50_timesteps"/>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot_new"/>
@@ -957,11 +931,10 @@
       <Parameter name="Time Macros" type="Array(string)" value="{Time Output}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="rifle-arora-spycher.in"/>
-    <Parameter name="Max Time Step (s)" type="double" value="31556926.0"/> 
-  </ParameterList> <!-- Chemistry -->
-
+    <Parameter name="Max Time Step (s)" type="double" value="31556926.0"/>
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/demos/phase3/tank/Tank-alq.xml
+++ b/demos/phase3/tank/Tank-alq.xml
@@ -1,237 +1,215 @@
 <ParameterList name="Main">
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="run_data_v1/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc_hypre"/>
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="Phase 3 Tank Test"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Saturated lateral flow and transport"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-24.8,-10}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{24.8,20.4}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{62,38}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-24.8, -10.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{24.8, 20.4}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{62, 38}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Alquimia"/>
-
     <!-- <ParameterList name="Restart"> -->
     <!--   <Parameter name="File Name" type="string" value="run_data_v1/chk00004"/> -->
     <!-- </ParameterList> -->
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="Switch" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.5778463e8"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="1.e3"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.e1"/>
-        <Parameter name="Steady Maximum Time Step Size" type="double" value="1.e9"/>
-        <Parameter name="Transient Maximum Time Step Size" type="double" value="1.e9"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1.5778463e+8"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1e+3"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+1"/>
+        <Parameter name="Steady Maximum Time Step Size" type="double" value="1e+9"/>
+        <Parameter name="Transient Maximum Time Step Size" type="double" value="1e+9"/>
         <Parameter name="Maximum Cycle Number" type="int" value="20"/>
         <Parameter name="Initial Time Step Multiplier" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-
     <!-- <Parameter name="Verbosity" type="string" value="Extreme"/> -->
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="richard_semi_analytic_J" type="bool" value="false"/>
           <Parameter name="max_n_subcycle_transport" type="int" value="4"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="4"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 2, 2}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 16, 16, 16, 16, 16}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Tank ref, Wall ref, FF ref, Liners ref, InletOutlet ref, Sorbed ref, Tracer ref}"/>
-
-	  <ParameterList name="Tank ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Tank}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-
-	  <ParameterList name="Wall ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Wall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-
-	  <ParameterList name="FF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{FF, Sand, Waste}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-
-	  <ParameterList name="Liners ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Liners}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-
-	  <ParameterList name="InletOutlet ref">
-	    <Parameter name="Regions" type="Array(string)" value="{InletOutlet}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Sorbed ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Cs137 Sorbed Concentration"/>
-	    <Parameter name="Value Greater" type="double" value="1.e-4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Tracer ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Tracer Aqueous Concentration"/>
-	    <Parameter name="Value Greater" type="double" value="1.e-2"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
-
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="4"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 2, 2}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 16, 16, 16, 16, 16}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Tank ref, Wall ref, FF ref, Liners ref, InletOutlet ref, Sorbed ref, Tracer ref}"/>
+          <ParameterList name="Tank ref">
+            <Parameter name="Regions" type="Array(string)" value="{Tank}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="Wall ref">
+            <Parameter name="Regions" type="Array(string)" value="{Wall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="FF ref">
+            <Parameter name="Regions" type="Array(string)" value="{FF, Sand, Waste}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liners ref">
+            <Parameter name="Regions" type="Array(string)" value="{Liners}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="InletOutlet ref">
+            <Parameter name="Regions" type="Array(string)" value="{InletOutlet}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Sorbed ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Cs137 Sorbed Concentration"/>
+            <Parameter name="Value Greater" type="double" value="0.0001"/>
+          </ParameterList>
+          <ParameterList name="Tracer ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Tracer Aqueous Concentration"/>
+            <Parameter name="Value Greater" type="double" value="0.01"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
-
     <ParameterList name="Wall Top">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 9.0,9.0,9.9,9.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{9.0, 9.0, 9.9, 9.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Bottom">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0,0,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.75,13.05,13.05,13.075,13.075,13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 9.0,9.0,2.475,2.475,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.75, 13.05, 13.05, 13.075, 13.075, 13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{9.0, 9.0, 2.475, 2.475, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,-13.075,-13.075,-13.05,-13.05,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.475,2.475,9.0,9.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, -13.075, -13.075, -13.05, -13.05, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.475, 2.475, 9.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,-13.05,-13.05,-13.025,-13.025,-13.0,-13.0,-13.075,-13.075,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.9,0.9,2.45,2.45,0.975,0.975,2.475,2.475,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, -13.05, -13.05, -13.025, -13.025, -13.0, -13.0, -13.075, -13.075, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.9, 0.9, 2.45, 2.45, 0.975, 0.975, 2.475, 2.475, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.75,13.075,13.075,13.0,13.0,13.025,13.025,13.05,13.05,13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.475,2.475,0.975,0.975,2.45,2.45,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.75, 13.075, 13.075, 13.0, 13.0, 13.025, 13.025, 13.05, 13.05, 13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.475, 2.475, 0.975, 0.975, 2.45, 2.45, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Sand Pad">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.95,0.95,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.95, 0.95, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Secondary Sand Pad">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.05,13.05,13.05,-13.05 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.9,0.9,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.05, 13.05, 13.05, -13.05}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.9, 0.9, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Liner Floor">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,1.0,1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Liner">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.275,-12.25,-12.25,12.25,12.25,12.275,12.275,-12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.025,1.025,8.975,8.975,1.025,1.025,9.0,9.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.275, -12.25, -12.25, 12.25, 12.25, 12.275, 12.275, -12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.025, 1.025, 8.975, 8.975, 1.025, 1.025, 9.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Secondary Liner">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.05,13.05,13.05,13.025,13.025,-13.025,-13.025,-13.05 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.45,2.45,0.95,0.95,2.45,2.45 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.05, 13.05, 13.05, 13.025, 13.025, -13.025, -13.025, -13.05}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.45, 2.45, 0.95, 0.95, 2.45, 2.45}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Floor">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.0,1.0,1.025,1.025 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.0, 1.0, 1.025, 1.025}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.025,-12.25,-12.25,-13.025 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.95,0.95,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.025, -12.25, -12.25, -13.025}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.95, 0.95, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.025,12.25,12.25,13.025 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,0.95,0.95 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.025, 12.25, 12.25, 13.025}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 0.95, 0.95}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Left 1">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.275,-12.25,-12.25,-12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,1.025,1.025 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.275, -12.25, -12.25, -12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 1.025, 1.025}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Right 1">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 12.275,12.25,12.25,12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.025,1.025,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{12.275, 12.25, 12.25, 12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.025, 1.025, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tank Block">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0,0,9.9,9.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 9.9, 9.9}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Inlet">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.775,-13.75,-13.75,-13.775 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.775, -13.75, -13.75, -13.775}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Outlet">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.775,13.75,13.75,13.775 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.775, 13.75, 13.75, 13.775}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="InletOutlet">
@@ -240,71 +218,60 @@
         <Parameter name="Regions" type="Array(string)" value="{Inlet, Outlet}"/>
       </ParameterList>
     </ParameterList>
-
-
     <ParameterList name="Wall">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Wall Right, Wall Left, Wall Top, Wall Bottom}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="FF">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{FF Right,FF Left,FF Right 1,FF Left 1}"/>
+        <Parameter name="Regions" type="Array(string)" value="{FF Right, FF Left, FF Right 1, FF Left 1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Sand">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{Primary Sand Pad,Secondary Sand Pad}"/>
+        <Parameter name="Regions" type="Array(string)" value="{Primary Sand Pad, Secondary Sand Pad}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Liners">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Primary Liner, Primary Liner Floor, Secondary Liner}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Waste">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Subtraction"/>
         <Parameter name="Regions" type="Array(string)" value="{Tank Block, Wall, FF, Sand, Liners, Waste}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Tank">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Wall, FF, Sand, Liners, Waste, Grout}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Soil">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Complement"/>
         <Parameter name="Region" type="string" value="Tank"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Sources">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right, Primary Sand Pad,Secondary Sand Pad}"/>
+        <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right, Primary Sand Pad, Secondary Sand Pad}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="NonSources">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Complement"/>
@@ -312,202 +279,192 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Concrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-11"/>
+        <Parameter name="Value" type="double" value="1e-11"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="29946"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="3993"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="29946.0"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="3993.0"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Wall}"/>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-11"/>
+        <Parameter name="Value" type="double" value="1e-11"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="29946"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="3993"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="29946.0"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="3993.0"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Grout}"/>
     </ParameterList>
-
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.35"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-6"/>
+        <Parameter name="Value" type="double" value="0.000001"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="8597"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="17194"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="8597.0"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="17194.0"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Soil}"/>
     </ParameterList>
-
     <ParameterList name="Fast-Flow Path">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{FF}"/>
     </ParameterList>
-
     <ParameterList name="Sand">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Sand}"/>
     </ParameterList>
-
     <ParameterList name="WasteTank">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Floor}"/>
     </ParameterList>
-
     <ParameterList name="WasteAnnulus">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Left, Waste Right}"/>
     </ParameterList>
-
     <ParameterList name="Liner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-14"/>
+        <Parameter name="Value" type="double" value="1e-14"/>
       </ParameterList>
       <ParameterList name="Tortuosity Aqueous: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
-	<ParameterList name="Tracer">
-	  <Parameter name="Kd" type="double" value="1.e-6"/>
-	</ParameterList>
-	<ParameterList name="Sr90">
-	  <Parameter name="Kd" type="double" value="0."/>
-	</ParameterList>
-	<ParameterList name="Cs137">
-	  <Parameter name="Kd" type="double" value="0."/>
-	</ParameterList>
+        <ParameterList name="Tracer">
+          <Parameter name="Kd" type="double" value="0.000001"/>
+        </ParameterList>
+        <ParameterList name="Sr90">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
+        <ParameterList name="Cs137">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Liners}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -522,22 +479,21 @@
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{Tracer, Sr90, Cs137}"/>
           <ParameterList name="Tracer">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
           <ParameterList name="Sr90">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
           <ParameterList name="Cs137">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition NonSources">
       <Parameter name="Assigned Regions" type="Array(string)" value="{NonSources}"/>
@@ -566,7 +522,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Waste Floor">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Floor}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -594,7 +549,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Annulus Waste">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Left, Waste Right}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -622,7 +576,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Primary Sand Pad">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Primary Sand Pad}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -650,7 +603,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Secondary Sand Pad">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Secondary Sand Pad}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -679,9 +631,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
@@ -709,11 +659,10 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
-        <Parameter name="Values" type="Array(double)" value="{30}"/>
+        <Parameter name="Values" type="Array(double)" value="{30.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -734,40 +683,32 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data_v1/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="run_data_v1/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_10_steps}"/>
     </ParameterList>
-<!--
+    <!--
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="Tracer.out"/>
       <ParameterList name="Tracer concentration">
@@ -791,12 +732,10 @@
     </ParameterList>
 -->
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="Tank_isotherms.in"/>
-    <Parameter name="Verbosity" type="string" value="verbose" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase3/tank/Tank.xml
+++ b/demos/phase3/tank/Tank.xml
@@ -1,254 +1,232 @@
 <ParameterList name="Main">
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Dump ParmParse Table" type="string" value="run_data/ppfile"/>
   <Parameter name="Petsc Options File" type="string" value="DOTpetsc_hypre"/>
-
   <ParameterList name="General Description">
     <Parameter name="Simulation name" type="string" value="Phase 3 Tank Test"/>
     <Parameter name="Simulation units" type="string" value="[L]=m, [t]=s, [M]=g"/>
     <Parameter name="Simulation type" type="string" value="Saturated lateral flow and transport"/>
     <Parameter name="Simulation dimension" type="string" value="2D"/>
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-24.8,-10}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{24.8,20.4}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{62,38}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-24.8, -10.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{24.8, 20.4}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{62, 38}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Amanzi"/>
-
     <!-- <ParameterList name="Restart"> -->
     <!--   <Parameter name="File Name" type="string" value="chkfile"/> -->
     <!-- </ParameterList> -->
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="Switch" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.5778463e8"/>
-        <Parameter name="Transient Initial Time Step" type="double" value="1.e3"/>
-        <Parameter name="Steady Initial Time Step" type="double" value="1.e1"/>
-        <Parameter name="Steady Maximum Time Step Size" type="double" value="1.e9"/>
-        <Parameter name="Transient Maximum Time Step Size" type="double" value="1.e9"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="Switch" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1.5778463e+8"/>
+        <Parameter name="Transient Initial Time Step" type="double" value="1e+3"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+1"/>
+        <Parameter name="Steady Maximum Time Step Size" type="double" value="1e+9"/>
+        <Parameter name="Transient Maximum Time Step Size" type="double" value="1e+9"/>
         <Parameter name="Maximum Cycle Number" type="int" value="20"/>
         <Parameter name="Initial Time Step Multiplier" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-
     <!-- <Parameter name="Verbosity" type="string" value="Extreme"/> -->
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
           <Parameter name="richard_init_to_steady_verbose" type="int" value="2"/>
           <Parameter name="steady_do_grid_sequence" type="bool" value="false"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="1.e30"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="1e+30"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="false"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e18"/>
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+18"/>
           <Parameter name="max_n_subcycle_transport" type="int" value="4"/>
         </ParameterList>
-	<ParameterList name="Iterative Linear Solver Control">
-	  <ParameterList name="Multigrid Algorithm">
-	    <ParameterList name="Expert Settings">
-	      <Parameter name="v" type="int" value="0"/>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Conjugate Gradient Algorithm">
-	    <ParameterList name="Expert Settings">
-	      <Parameter name="v" type="int" value="0"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="4"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 2, 2}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{2, 16, 16, 16, 16, 16}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Tank ref, Wall ref, FF ref, Liners ref, InletOutlet ref, Sorbed ref, Tracer ref}"/>
-
-	  <ParameterList name="Tank ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Tank}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="1"/>
-	  </ParameterList>
-
-	  <ParameterList name="Wall ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Wall}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-
-	  <ParameterList name="FF ref">
-	    <Parameter name="Regions" type="Array(string)" value="{FF, Sand, Waste}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-
-	  <ParameterList name="Liners ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Liners}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="3"/>
-	  </ParameterList>
-
-	  <ParameterList name="InletOutlet ref">
-	    <Parameter name="Regions" type="Array(string)" value="{InletOutlet}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Sorbed ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Cs137 Sorbed Concentration"/>
-	    <Parameter name="Value Greater" type="double" value="1.e-4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Tracer ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Tracer Aqueous Concentration"/>
-	    <Parameter name="Value Greater" type="double" value="1.e-2"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Iterative Linear Solver Control">
+          <ParameterList name="Multigrid Algorithm">
+            <ParameterList name="Expert Settings">
+              <Parameter name="v" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Conjugate Gradient Algorithm">
+            <ParameterList name="Expert Settings">
+              <Parameter name="v" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="4"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4, 4, 2, 2}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{2}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{2, 16, 16, 16, 16, 16}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{32, 32, 32, 32, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{1, 1, 1, 1, 1, 1}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Tank ref, Wall ref, FF ref, Liners ref, InletOutlet ref, Sorbed ref, Tracer ref}"/>
+          <ParameterList name="Tank ref">
+            <Parameter name="Regions" type="Array(string)" value="{Tank}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="1"/>
+          </ParameterList>
+          <ParameterList name="Wall ref">
+            <Parameter name="Regions" type="Array(string)" value="{Wall}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="FF ref">
+            <Parameter name="Regions" type="Array(string)" value="{FF, Sand, Waste}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="Liners ref">
+            <Parameter name="Regions" type="Array(string)" value="{Liners}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="3"/>
+          </ParameterList>
+          <ParameterList name="InletOutlet ref">
+            <Parameter name="Regions" type="Array(string)" value="{InletOutlet}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Sorbed ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Cs137 Sorbed Concentration"/>
+            <Parameter name="Value Greater" type="double" value="0.0001"/>
+          </ParameterList>
+          <ParameterList name="Tracer ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Tracer Aqueous Concentration"/>
+            <Parameter name="Value Greater" type="double" value="0.01"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
-
     <ParameterList name="Wall Top">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 9.0,9.0,9.9,9.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{9.0, 9.0, 9.9, 9.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Bottom">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0,0,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.75,13.05,13.05,13.075,13.075,13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 9.0,9.0,2.475,2.475,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.75, 13.05, 13.05, 13.075, 13.075, 13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{9.0, 9.0, 2.475, 2.475, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Wall Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,-13.075,-13.075,-13.05,-13.05,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.475,2.475,9.0,9.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, -13.075, -13.075, -13.05, -13.05, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.475, 2.475, 9.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,-13.05,-13.05,-13.025,-13.025,-13.0,-13.0,-13.075,-13.075,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.9,0.9,2.45,2.45,0.975,0.975,2.475,2.475,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, -13.05, -13.05, -13.025, -13.025, -13.0, -13.0, -13.075, -13.075, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.9, 0.9, 2.45, 2.45, 0.975, 0.975, 2.475, 2.475, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.75,13.075,13.075,13.0,13.0,13.025,13.025,13.05,13.05,13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.475,2.475,0.975,0.975,2.45,2.45,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.75, 13.075, 13.075, 13.0, 13.0, 13.025, 13.025, 13.05, 13.05, 13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.475, 2.475, 0.975, 0.975, 2.45, 2.45, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Sand Pad">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.95,0.95,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.95, 0.95, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Secondary Sand Pad">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.05,13.05,13.05,-13.05 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.9,0.9,0.925,0.925 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.05, 13.05, 13.05, -13.05}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.9, 0.9, 0.925, 0.925}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Liner Floor">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,1.0,1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Primary Liner">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.275,-12.25,-12.25,12.25,12.25,12.275,12.275,-12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.025,1.025,8.975,8.975,1.025,1.025,9.0,9.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.275, -12.25, -12.25, 12.25, 12.25, 12.275, 12.275, -12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.025, 1.025, 8.975, 8.975, 1.025, 1.025, 9.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Secondary Liner">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.05,13.05,13.05,13.025,13.025,-13.025,-13.025,-13.05 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,2.45,2.45,0.95,0.95,2.45,2.45 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.05, 13.05, 13.05, 13.025, 13.025, -13.025, -13.025, -13.05}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 2.45, 2.45, 0.95, 0.95, 2.45, 2.45}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Floor">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.25,12.25,12.25,-12.25 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.0,1.0,1.025,1.025 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.25, 12.25, 12.25, -12.25}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.0, 1.0, 1.025, 1.025}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Left">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.025,-12.25,-12.25,-13.025 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.95,0.95,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.025, -12.25, -12.25, -13.025}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.95, 0.95, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Waste Right">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.025,12.25,12.25,13.025 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,0.95,0.95 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.025, 12.25, 12.25, 13.025}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 0.95, 0.95}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Left 1">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -12.275,-12.25,-12.25,-12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.975,0.975,1.025,1.025 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-12.275, -12.25, -12.25, -12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.975, 0.975, 1.025, 1.025}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FF Right 1">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 12.275,12.25,12.25,12.275 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 1.025,1.025,0.975,0.975 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{12.275, 12.25, 12.25, 12.275}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{1.025, 1.025, 0.975, 0.975}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Tank Block">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.75,13.75,13.75,-13.75 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0,0,9.9,9.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.75, 13.75, 13.75, -13.75}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 9.9, 9.9}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Inlet">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ -13.775,-13.75,-13.75,-13.775 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{-13.775, -13.75, -13.75, -13.775}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Outlet">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 13.775,13.75,13.75,13.775 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.925,0.925,0.9,0.9 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{13.775, 13.75, 13.75, 13.775}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.925, 0.925, 0.9, 0.9}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="InletOutlet">
@@ -257,71 +235,60 @@
         <Parameter name="Regions" type="Array(string)" value="{Inlet, Outlet}"/>
       </ParameterList>
     </ParameterList>
-
-
     <ParameterList name="Wall">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Wall Right, Wall Left, Wall Top, Wall Bottom}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="FF">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{FF Right,FF Left,FF Right 1,FF Left 1}"/>
+        <Parameter name="Regions" type="Array(string)" value="{FF Right, FF Left, FF Right 1, FF Left 1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Sand">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{Primary Sand Pad,Secondary Sand Pad}"/>
+        <Parameter name="Regions" type="Array(string)" value="{Primary Sand Pad, Secondary Sand Pad}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Liners">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Primary Liner, Primary Liner Floor, Secondary Liner}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Waste">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Subtraction"/>
         <Parameter name="Regions" type="Array(string)" value="{Tank Block, Wall, FF, Sand, Liners, Waste}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Tank">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
         <Parameter name="Regions" type="Array(string)" value="{Wall, FF, Sand, Liners, Waste, Grout}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Soil">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Complement"/>
         <Parameter name="Region" type="string" value="Tank"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Sources">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Union"/>
-        <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right, Primary Sand Pad,Secondary Sand Pad}"/>
+        <Parameter name="Regions" type="Array(string)" value="{Waste Floor, Waste Left, Waste Right, Primary Sand Pad, Secondary Sand Pad}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="NonSources">
       <ParameterList name="Region: Logical">
         <Parameter name="Operation" type="string" value="Complement"/>
@@ -329,234 +296,224 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Concrete">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-11"/>
+        <Parameter name="Value" type="double" value="1e-11"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="29946"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="3993"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="29946.0"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="3993.0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Wall}"/>
     </ParameterList>
-
     <ParameterList name="Grout">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-11"/>
+        <Parameter name="Value" type="double" value="1e-11"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="29946"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="3993"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="29946.0"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="3993.0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Grout}"/>
     </ParameterList>
-
     <ParameterList name="Soil">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.35"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-6"/>
+        <Parameter name="Value" type="double" value="0.000001"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="8597"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="17194"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="8597.0"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="17194.0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Soil}"/>
     </ParameterList>
-
     <ParameterList name="Fast-Flow Path">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{FF}"/>
     </ParameterList>
-
     <ParameterList name="Sand">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Sand}"/>
     </ParameterList>
-
     <ParameterList name="WasteTank">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Floor}"/>
     </ParameterList>
-
     <ParameterList name="WasteAnnulus">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.3"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value=".15e-2"/>
+        <Parameter name="Value" type="double" value="0.0015"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Left, Waste Right}"/>
     </ParameterList>
-
     <ParameterList name="Liner">
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.2"/>
       </ParameterList>
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="1.e-14"/>
+        <Parameter name="Value" type="double" value="1e-14"/>
       </ParameterList>
       <ParameterList name="Tortuosity: Uniform">
-        <Parameter name="Value" type="double" value="1."/>
+        <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-	    <ParameterList name="Tracer">
-	      <Parameter name="Kd" type="double" value="1.e-6"/>
-	    </ParameterList>
-	    <ParameterList name="Sr90">
-	      <Parameter name="Kd" type="double" value="0."/>
-	    </ParameterList>
-	    <ParameterList name="Cs137">
-	      <Parameter name="Kd" type="double" value="0."/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="Tracer">
+              <Parameter name="Kd" type="double" value="0.000001"/>
+            </ParameterList>
+            <ParameterList name="Sr90">
+              <Parameter name="Kd" type="double" value="0.0"/>
+            </ParameterList>
+            <ParameterList name="Cs137">
+              <Parameter name="Kd" type="double" value="0.0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <Parameter name="Assigned Regions" type="Array(string)" value="{Liners}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
@@ -571,22 +528,21 @@
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{Tracer, Sr90, Cs137}"/>
           <ParameterList name="Tracer">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
           <ParameterList name="Sr90">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
           <ParameterList name="Cs137">
-            <Parameter name="Molecular Diffusivity" type="double" value="5.e-12"/>
-            <Parameter name="First Order Decay Constant" type="double" value="0"/>
+            <Parameter name="Molecular Diffusivity" type="double" value="5e-12"/>
+            <Parameter name="First Order Decay Constant" type="double" value="0.0"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition NonSources">
       <Parameter name="Assigned Regions" type="Array(string)" value="{NonSources}"/>
@@ -598,24 +554,23 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Waste Floor">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Floor}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -626,24 +581,23 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1"/>
+                <Parameter name="Value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="10"/>
+                <Parameter name="Value" type="double" value="10.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="100"/>
+                <Parameter name="Value" type="double" value="100.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Annulus Waste">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Waste Left, Waste Right}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -654,24 +608,23 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2"/>
+                <Parameter name="Value" type="double" value="2.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="20"/>
+                <Parameter name="Value" type="double" value="20.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="200"/>
+                <Parameter name="Value" type="double" value="200.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Primary Sand Pad">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Primary Sand Pad}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -682,24 +635,23 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="3"/>
+                <Parameter name="Value" type="double" value="3.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="30"/>
+                <Parameter name="Value" type="double" value="30.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="300"/>
+                <Parameter name="Value" type="double" value="300.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition Secondary Sand Pad">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Secondary Sand Pad}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -710,17 +662,17 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="4"/>
+                <Parameter name="Value" type="double" value="4.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="40"/>
+                <Parameter name="Value" type="double" value="40.0"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="400"/>
+                <Parameter name="Value" type="double" value="400.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -728,9 +680,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
@@ -741,28 +691,27 @@
           <ParameterList name="Water">
             <ParameterList name="Tracer">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Sr90">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20}"/>
               </ParameterList>
             </ParameterList>
             <ParameterList name="Cs137">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
-        <Parameter name="Values" type="Array(double)" value="{30}"/>
+        <Parameter name="Values" type="Array(double)" value="{30.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -783,40 +732,32 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <Parameter name="File Name Digits" type="int" value="5"/>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_1_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_10_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_100_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
-
       <ParameterList name="Every_1000_steps">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1000,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1000, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_10_steps}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="run_data/chk"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1_steps}"/>
     </ParameterList>
-<!--
+    <!--
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="Tracer.out"/>
       <ParameterList name="Tracer concentration">
@@ -840,17 +781,15 @@
     </ParameterList>
 -->
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="Tank.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="Tank.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
   </ParameterList>
-
 </ParameterList>

--- a/demos/phase3/wma-c/dvz_3_layer_k_c/dvz_3_layer_2d-isv2_1_native_v6.xml
+++ b/demos/phase3/wma-c/dvz_3_layer_k_c/dvz_3_layer_2d-isv2_1_native_v6.xml
@@ -14,62 +14,62 @@
   <ParameterList name="Regions">
     <ParameterList name="All">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Between_Planes_0_and_1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 3.98999999999999986e+01}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 39.8999999999999986}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Between_Planes_1_and_2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 3.98999999999999986e+01}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 8.02199999999999989e+01}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 39.8999999999999986}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 80.2199999999999989}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Between_Planes_2_and_3">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 8.02199999999999989e+01}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 80.2199999999999989}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib_216-B-17">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{7.45000000000000000e+01, 0.00000000000000000e+00, 1.07519999999999996e+02}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{7.85000000000000000e+01, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{74.5000000000000000, 0e-17, 107.519999999999996}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{78.5000000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib_216-B-18">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{1.43500000000000000e+02, 0.00000000000000000e+00, 1.07519999999999996e+02}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.47500000000000000e+02, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{143.500000000000000, 0e-17, 107.519999999999996}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{147.500000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_WestofCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 1.07519999999999996e+02}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{7.45000000000000000e+01, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 107.519999999999996}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{74.5000000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_btwnCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{7.85000000000000000e+01, 0.00000000000000000e+00, 1.07519999999999996e+02}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.43500000000000000e+02, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{78.5000000000000000, 0e-17, 107.519999999999996}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{143.500000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_EastofCribs">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{1.47500000000000000e+02, 0.00000000000000000e+00, 1.07519999999999996e+02}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 1.07519999999999996e+02}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{147.500000000000000, 0e-17, 107.519999999999996}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 107.519999999999996}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Water Table">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{2.16000000000000000e+02, 1.00000000000000000e+00, 0.00000000000000000e+00}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{216.000000000000000, 1.00000000000000000, 0e-17}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -95,10 +95,10 @@
             <Parameter name="PK type" type="string" value="richards"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="end period time" type="double" value="6.17266656000000000e+0"/>
+        <Parameter name="start period time" type="double" value="0e-17"/>
+        <Parameter name="end period time" type="double" value="6.17266656000000000"/>
         <Parameter name="maximum cycle number" type="int" value="1"/>
-        <Parameter name="initial timestep" type="double" value="1.00000000000000000e+02"/>
+        <Parameter name="initial timestep" type="double" value="100.000000000000000"/>
       </ParameterList>
       <ParameterList name="TP 1">
         <ParameterList name="PK Tree">
@@ -112,17 +112,17 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="6.17266656000000000e+10"/>
-        <Parameter name="end period time" type="double" value="9.46728000000000000e+10"/>
+        <Parameter name="start period time" type="double" value="61726665600.0000000"/>
+        <Parameter name="end period time" type="double" value="94672800000.0000000"/>
         <Parameter name="maximum cycle number" type="int" value="1"/>
-        <Parameter name="initial timestep" type="double" value="1.00000000000000000e+01"/>
+        <Parameter name="initial timestep" type="double" value="10.0000000000000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{Tc-99}"/>
     <ParameterList name="Time Period Control">
-      <Parameter name="Start Times" type="Array(double)" value="{6.17292596347200012e+10, 6.17318536694399948e+10, 6.17370417388799973e+10, 6.34938912000000000e+10}"/>
-      <Parameter name="Initial Time Step" type="Array(double)" value="{1.00000000000000000e+01, 1.00000000000000000e+01, 1.00000000000000000e+01, 1.00000000000000000e+00}"/>
-      <Parameter name="Maximum Time Step" type="Array(double)" value="{4.32340000000000000e+17, 4.32340000000000000e+17, 4.32340000000000000e+17, 4.32340000000000000e+17}"/>
+      <Parameter name="Start Times" type="Array(double)" value="{61729259634.7200012, 61731853669.4399948, 61737041738.8799973, 63493891200.0000000}"/>
+      <Parameter name="Initial Time Step" type="Array(double)" value="{10.0000000000000000, 10.0000000000000000, 10.0000000000000000, 1.00000000000000000}"/>
+      <Parameter name="Maximum Time Step" type="Array(double)" value="{432340000000000000.0, 432340000000000000.0, 432340000000000000.0, 432340000000000000.0}"/>
     </ParameterList>
     <ParameterList name="VerboseObject">
       <Parameter name="Verbosity Level" type="string" value="medium"/>
@@ -130,6 +130,7 @@
   </ParameterList>
   <ParameterList name="State">
     <ParameterList name="field evaluators">
+
       <ParameterList name="porosity">
         <ParameterList name="function">
           <ParameterList name="Between_Planes_1_and_2">
@@ -137,7 +138,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.08200000000000007e-01"/>
+                <Parameter name="value" type="double" value="0.408200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -146,7 +147,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.20599999999999991e-01"/>
+                <Parameter name="value" type="double" value="0.220599999999999991"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -155,24 +156,29 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.34000000000000014e-01"/>
+                <Parameter name="value" type="double" value="0.234000000000000014"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
         <Parameter name="field evaluator type" type="string" value="independent variable"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0e-17, 0e-17, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
+
       <ParameterList name="water_density">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -180,18 +186,20 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="exodus file initialization">
           <Parameter name="file" type="string" value="mesh_att.exo"/>
           <Parameter name="attribute" type="string" value="perm"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="particle_density">
         <ParameterList name="function">
           <ParameterList name="Between_Planes_1_and_2">
@@ -199,7 +207,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.72000000000000000e+03"/>
+                <Parameter name="value" type="double" value="2720.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -208,7 +216,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.72000000000000000e+03"/>
+                <Parameter name="value" type="double" value="2720.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -217,12 +225,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.72000000000000000e+03"/>
+                <Parameter name="value" type="double" value="2720.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -230,14 +239,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325000000000000e+05"/>
-                <Parameter name="x0" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00, 5.00000000000000000e-01}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00, -9.79351920000000064e+03}"/>
+                <Parameter name="y0" type="double" value="101325.000000000000"/>
+                <Parameter name="x0" type="Array(double)" value="{0e-17, 0e-17, 0e-17, 0.500000000000000000}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0e-17, 0e-17, 0e-17, -9793.51920000000064}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="exodus file initialization">
           <Parameter name="file" type="string" value="mesh_att.exo"/>
@@ -259,6 +269,7 @@
           </ParameterList>
         </ParameterList-->
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -276,12 +287,12 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
-        <Parameter name="aggregation: threshold" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
+        <Parameter name="aggregation: threshold" type="double" value="0e-17"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
         <Parameter name="smoother: sweeps" type="int" value="3"/>
-        <Parameter name="smoother: damping factor" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.00000000000000000"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: type" type="string" value="Jacobi"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -292,10 +303,10 @@
       <Parameter name="preconditioning type" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="1.00000000000000006e-01"/>
+        <Parameter name="tolerance" type="double" value="0.100000000000000006"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="10"/>
-        <Parameter name="strong threshold" type="double" value="4.00000000000000022e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.400000000000000022"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -306,9 +317,9 @@
       <Parameter name="preconditioning type" type="string" value="block ilu"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.00000000000000000e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.00000000000000000"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0e-17"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.00000000000000000"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>
@@ -341,7 +352,7 @@
     <ParameterList name="GMRES for Newton">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
-        <Parameter name="error tolerance" type="double" value="9.99999999999999955e-08"/>
+        <Parameter name="error tolerance" type="double" value="9.99999999999999955e-8"/>
         <Parameter name="maximum number of iterations" type="int" value="50"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, relative residual}"/>
         <ParameterList name="VerboseObject">
@@ -351,6 +362,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="Flow Steady">
       <ParameterList name="Richards problem">
         <Parameter name="relative permeability" type="string" value="upwind: amanzi"/>
@@ -358,36 +370,36 @@
         <ParameterList name="VerboseObject">
           <Parameter name="Verbosity Level" type="string" value="medium"/>
         </ParameterList>
-        <Parameter name="atmospheric pressure" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="atmospheric pressure" type="double" value="101325.000000000000"/>
         <ParameterList name="water retention models">
           <ParameterList name="WRM for Between_Planes_1_and_2">
             <Parameter name="water retention model" type="string" value="van Genuchten"/>
             <Parameter name="region" type="string" value="Between_Planes_1_and_2"/>
-            <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-            <Parameter name="van Genuchten l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="van Genuchten alpha" type="double" value="1.94670000000000005e-04"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+            <Parameter name="van Genuchten l" type="double" value="0.500000000000000000"/>
+            <Parameter name="van Genuchten alpha" type="double" value="0.000194670000000000005"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
           <ParameterList name="WRM for Between_Planes_0_and_1">
             <Parameter name="water retention model" type="string" value="van Genuchten"/>
             <Parameter name="region" type="string" value="Between_Planes_0_and_1"/>
-            <Parameter name="van Genuchten m" type="double" value="2.13600000000000012e-01"/>
-            <Parameter name="van Genuchten l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="van Genuchten alpha" type="double" value="2.02600000000000002e-03"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="van Genuchten m" type="double" value="0.213600000000000012"/>
+            <Parameter name="van Genuchten l" type="double" value="0.500000000000000000"/>
+            <Parameter name="van Genuchten alpha" type="double" value="0.00202600000000000002"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
           <ParameterList name="WRM for Between_Planes_2_and_3">
             <Parameter name="water retention model" type="string" value="Brooks Corey"/>
             <Parameter name="region" type="string" value="Between_Planes_2_and_3"/>
-            <Parameter name="Brooks Corey lambda" type="double" value="3.00599999999999978e-01"/>
-            <Parameter name="Brooks Corey alpha" type="double" value="2.06740000000000005e-03"/>
-            <Parameter name="Brooks Corey l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="Brooks Corey lambda" type="double" value="0.300599999999999978"/>
+            <Parameter name="Brooks Corey alpha" type="double" value="0.00206740000000000005"/>
+            <Parameter name="Brooks Corey l" type="double" value="0.500000000000000000"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
         </ParameterList>
@@ -423,8 +435,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -434,8 +446,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17292596347200012e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -2.54022000000000015e-03, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61729259634.7200012, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00254022000000000015, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -445,8 +457,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17318536694399948e+10, 6.17370417388799973e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -1.48666000000000005e-06, -3.30423000000000001e-03, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61731853669.4399948, 61737041738.8799973, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00000148666000000000005, -0.00330423000000000001, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -457,8 +469,8 @@
               <Parameter name="regions" type="Array(string)" value="{Water Table}"/>
               <ParameterList name="boundary pressure">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{1.01325000000000000e+05, 1.01325000000000000e+05}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{101325.000000000000, 101325.000000000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -481,16 +493,16 @@
             <ParameterList name="timestep controller standard parameters">
               <Parameter name="max iterations" type="int" value="15"/>
               <Parameter name="min iterations" type="int" value="10"/>
-              <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-              <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-              <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
+              <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+              <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+              <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
               <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
             </ParameterList>
             <Parameter name="solver type" type="string" value="nka"/>
             <ParameterList name="nka parameters">
-              <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-              <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-              <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
+              <Parameter name="nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+              <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+              <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
               <Parameter name="max divergent iterations" type="int" value="3"/>
               <Parameter name="max nka vectors" type="int" value="10"/>
               <Parameter name="limit iterations" type="int" value="20"/>
@@ -498,10 +510,10 @@
             </ParameterList>
             <Parameter name="max preconditioner lag iterations" type="int" value="30"/>
             <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-            <Parameter name="nonlinear iteration damping factor" type="double" value="1.00000000000000000e+00"/>
+            <Parameter name="nonlinear iteration damping factor" type="double" value="1.00000000000000000"/>
             <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-            <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+            <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+            <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           </ParameterList>
           <ParameterList name="initialization">
             <Parameter name="method" type="string" value="saturated solver"/>
@@ -509,20 +521,25 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="Flow and Transport">
       <Parameter name="PKs order" type="Array(string)" value="{Flow, Transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="Transport">
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="1.00000000000000000e+00"/>
+      <Parameter name="cfl" type="double" value="1.00000000000000000"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <ParameterList name="VerboseObject">
         <Parameter name="Verbosity Level" type="string" value="medium"/>
       </ParameterList>
+
       <Parameter name="enable internal tests" type="string" value="no"/>
       <Parameter name="transport subcycling" type="bool" value="true"/>
       <ParameterList name="reconstruction">
@@ -530,10 +547,12 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1.00000000000000006e-09}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.00000000000000006e-9}"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Tc-99">
@@ -541,8 +560,8 @@
               <Parameter name="regions" type="Array(string)" value="{Recharge_Boundary_WestofCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastofCribs}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
-                  <Parameter name="y values" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0e-17, 0e-17, 0e-17, 0e-17}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 63493891200.0000000, 94672800000.0000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -551,8 +570,8 @@
               <Parameter name="regions" type="Array(string)" value="{Crib_216-B-17}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
-                  <Parameter name="y values" type="Array(double)" value="{0.00000000000000000e+00, 1.88138900000000001e-06, 0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17292596347200012e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0e-17, 0.00000188138900000000001, 0e-17, 0e-17, 0e-17}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61729259634.7200012, 63493891200.0000000, 94672800000.0000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -561,8 +580,8 @@
               <Parameter name="regions" type="Array(string)" value="{Crib_216-B-18}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
-                  <Parameter name="y values" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 2.26688500000000007e-06, 0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17318536694399948e+10, 6.17370417388799973e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0e-17, 0e-17, 0.00000226688500000000007, 0e-17, 0e-17, 0e-17}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61731853669.4399948, 61737041738.8799973, 63493891200.0000000, 94672800000.0000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -571,8 +590,8 @@
               <Parameter name="regions" type="Array(string)" value="{Water Table}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
-                  <Parameter name="y values" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 9.46728000000000000e+10}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0e-17, 0e-17}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 94672800000.0000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -580,9 +599,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="Flow">
       <ParameterList name="Richards problem">
         <Parameter name="relative permeability" type="string" value="upwind: amanzi"/>
@@ -590,36 +612,36 @@
         <ParameterList name="VerboseObject">
           <Parameter name="Verbosity Level" type="string" value="medium"/>
         </ParameterList>
-        <Parameter name="atmospheric pressure" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="atmospheric pressure" type="double" value="101325.000000000000"/>
         <ParameterList name="water retention models">
           <ParameterList name="WRM for Between_Planes_1_and_2">
             <Parameter name="water retention model" type="string" value="van Genuchten"/>
             <Parameter name="region" type="string" value="Between_Planes_1_and_2"/>
-            <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-            <Parameter name="van Genuchten l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="van Genuchten alpha" type="double" value="1.94670000000000005e-04"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+            <Parameter name="van Genuchten l" type="double" value="0.500000000000000000"/>
+            <Parameter name="van Genuchten alpha" type="double" value="0.000194670000000000005"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
           <ParameterList name="WRM for Between_Planes_0_and_1">
             <Parameter name="water retention model" type="string" value="van Genuchten"/>
             <Parameter name="region" type="string" value="Between_Planes_0_and_1"/>
-            <Parameter name="van Genuchten m" type="double" value="2.13600000000000012e-01"/>
-            <Parameter name="van Genuchten l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="van Genuchten alpha" type="double" value="2.02600000000000002e-03"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="van Genuchten m" type="double" value="0.213600000000000012"/>
+            <Parameter name="van Genuchten l" type="double" value="0.500000000000000000"/>
+            <Parameter name="van Genuchten alpha" type="double" value="0.00202600000000000002"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
           <ParameterList name="WRM for Between_Planes_2_and_3">
             <Parameter name="water retention model" type="string" value="Brooks Corey"/>
             <Parameter name="region" type="string" value="Between_Planes_2_and_3"/>
-            <Parameter name="Brooks Corey lambda" type="double" value="3.00599999999999978e-01"/>
-            <Parameter name="Brooks Corey alpha" type="double" value="2.06740000000000005e-03"/>
-            <Parameter name="Brooks Corey l" type="double" value="5.00000000000000000e-01"/>
-            <Parameter name="residual saturation" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="regularization interval" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="Brooks Corey lambda" type="double" value="0.300599999999999978"/>
+            <Parameter name="Brooks Corey alpha" type="double" value="0.00206740000000000005"/>
+            <Parameter name="Brooks Corey l" type="double" value="0.500000000000000000"/>
+            <Parameter name="residual saturation" type="double" value="0e-17"/>
+            <Parameter name="regularization interval" type="double" value="0e-17"/>
             <Parameter name="relative permeability model" type="string" value="Mualem"/>
           </ParameterList>
         </ParameterList>
@@ -655,8 +677,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -666,8 +688,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17292596347200012e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -2.54022000000000015e-03, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61729259634.7200012, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00254022000000000015, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -677,8 +699,8 @@
               <Parameter name="rainfall" type="bool" value="false"/>
               <ParameterList name="outward mass flux">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 6.17266656000000000e+10, 6.17318536694399948e+10, 6.17370417388799973e+10, 6.34938912000000000e+10, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-07, -1.48666000000000005e-06, -3.30423000000000001e-03, -1.48666000000000005e-06, -1.48666000000000005e-06, -1.48666000000000005e-06}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 61726665600.0000000, 61731853669.4399948, 61737041738.8799973, 63493891200.0000000, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{-1.10710000000000003e-7, -0.00000148666000000000005, -0.00330423000000000001, -0.00000148666000000000005, -0.00000148666000000000005, -0.00000148666000000000005}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -689,8 +711,8 @@
               <Parameter name="regions" type="Array(string)" value="{Water Table}"/>
               <ParameterList name="boundary pressure">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.00000000000000000e+00, 9.46728000000000000e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{1.01325000000000000e+05, 1.01325000000000000e+05}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0e-17, 94672800000.0000000}"/>
+                  <Parameter name="y values" type="Array(double)" value="{101325.000000000000, 101325.000000000000}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -713,16 +735,16 @@
             <ParameterList name="timestep controller standard parameters">
               <Parameter name="max iterations" type="int" value="15"/>
               <Parameter name="min iterations" type="int" value="10"/>
-              <Parameter name="timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-              <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-              <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
+              <Parameter name="timestep increase factor" type="double" value="1.25000000000000000"/>
+              <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+              <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
               <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
             </ParameterList>
             <Parameter name="solver type" type="string" value="nka"/>
             <ParameterList name="nka parameters">
-              <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-              <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-              <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
+              <Parameter name="nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+              <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+              <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
               <Parameter name="max divergent iterations" type="int" value="3"/>
               <Parameter name="max nka vectors" type="int" value="10"/>
               <Parameter name="limit iterations" type="int" value="20"/>
@@ -730,18 +752,21 @@
             </ParameterList>
             <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
             <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-            <Parameter name="nonlinear iteration damping factor" type="double" value="1.00000000000000000e+00"/>
+            <Parameter name="nonlinear iteration damping factor" type="double" value="1.00000000000000000"/>
             <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-            <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+            <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+            <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           </ParameterList>
           <ParameterList name="VerboseObject">
             <Parameter name="Verbosity Level" type="string" value="medium"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="Analysis">
     <Parameter name="used boundary condition regions" type="Array(string)" value="{Recharge_Boundary_WestofCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastofCribs, Crib_216-B-17, Crib_216-B-18, Water Table, Recharge_Boundary_WestofCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastofCribs, Crib_216-B-17, Crib_216-B-18, Water Table, Recharge_Boundary_WestofCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastofCribs, Crib_216-B-17, Crib_216-B-18, Water Table}"/>
     <Parameter name="used source regions" type="Array(string)" value="{}"/>

--- a/src/common/chemistry/test/chemistry_beaker_carbonate.xml
+++ b/src/common/chemistry/test/chemistry_beaker_carbonate.xml
@@ -1,7 +1,7 @@
 <ParameterList name="thermodynamic database">
   <ParameterList name="primary species">
     <ParameterList name="H+">
-      <Parameter name="ion size parameter" type="double" value="9.00000000000000000e+00"/>
+      <Parameter name="ion size parameter" type="double" value="9.00000000000000000"/>
       <Parameter name="charge" type="int" value="1"/>
       <Parameter name="gram molecular weight" type="double" value="1.0079"/>
     </ParameterList>
@@ -11,14 +11,13 @@
       <Parameter name="gram molecular weight" type="double" value="61.0171"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="aqueous equilibrium complexes">
     <ParameterList name="OH-">
-      <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
+      <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
       <Parameter name="charge" type="int" value="-1"/>
-      <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
       <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-      <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
+      <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
     </ParameterList>
     <ParameterList name="CO3--">
       <Parameter name="ion size parameter" type="double" value="4.5"/>
@@ -31,9 +30,8 @@
       <Parameter name="ion size parameter" type="double" value="3.0"/>
       <Parameter name="charge" type="int" value="0"/>
       <Parameter name="gram molecular weight" type="double" value="44.0098"/>
-      <Parameter name="reaction" type="string" value=" -1.0 H2O  1.0 H+  1.0 HCO3-"/>
+      <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
       <Parameter name="equilibrium constant" type="double" value="-6.3447"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/common/chemistry/test/chemistry_pitzer.xml
+++ b/src/common/chemistry/test/chemistry_pitzer.xml
@@ -1,259 +1,255 @@
 <ParameterList>
-<ParameterList name="b0">
-  <Parameter name="l01" type="string" value="Na+   Cl-  0.0765  -777.03  -4.4706  0.008946  -3.3158E-6"/>
-  <Parameter name="l02" type="string" value="K+    Cl-  0.04835  0.0  0.0   5.794E-4"/>
-  <Parameter name="l03" type="string" value="Mg+2  Cl-  0.35235  0.0  0.0  -1.943E-4"/>
-  <Parameter name="l04" type="string" value="Ca+2  Cl-  0.3159   0.0  0.0  -1.725E-4"/>
-  <Parameter name="l05" type="string" value="MgOH+ Cl- -0.1"/>
-  <Parameter name="l06" type="string" value="H+    Cl-  0.1775   0.0  0.0  -3.081E-4"/>
-  <Parameter name="l07" type="string" value="Li+   Cl-  0.1494   0.0  0.0  -1.685E-4"/>
-  <Parameter name="l08" type="string" value="Sr+2  Cl-  0.2858   0.0  0.0   0.717E-3"/>
-  <Parameter name="l09" type="string" value="Fe+2  Cl-  0.335925"/>
-  <Parameter name="l10" type="string" value="Mn+2  Cl-  0.327225"/>
-  <Parameter name="l11" type="string" value="Ba+2  Cl-  0.2628   0.0  0.0   0.6405E-3"/>
-  <Parameter name="l12" type="string" value="CaB(OH)4+  Cl-  0.12"/>
-  <Parameter name="l13" type="string" value="MgB(OH)4+  Cl-  0.16"/>
-  <Parameter name="l14" type="string" value="Na+   Br-  0.0973   0.0  0.0   7.692E-4"/>
-  <Parameter name="l15" type="string" value="K+    Br-  0.0569   0.0  0.0   7.39E-4"/>
-  <Parameter name="l16" type="string" value="H+    Br-  0.1960   0.0  0.0  -2.049E-4"/>
-  <Parameter name="l17" type="string" value="Mg+2  Br-  0.4327   0.0  0.0  -5.625E-5"/>
-  <Parameter name="l18" type="string" value="Ca+2  Br-  0.3816   0.0  0.0  -5.2275E-4"/>
-  <Parameter name="l19" type="string" value="Li+   Br-  0.1748   0.0  0.0  -1.819E-4"/>
-  <Parameter name="l20" type="string" value="Sr+2  Br-  0.331125 0.0  0.0  -0.32775E-3"/>
-  <Parameter name="l21" type="string" value="Ba+2  Br-  0.31455  0.0  0.0  -0.33825E-3"/>
-  <Parameter name="l22" type="string" value="Na+   SO4-2  0.01958  0.0  0.0  2.367E-3"/>
-  <Parameter name="l23" type="string" value="K+    SO4-2  0.04995  0.0  0.0  1.44E-3"/>
-  <Parameter name="l24" type="string" value="Mg+2  SO4-2  0.221    0.0  0.0 -0.69E-3"/>
-  <Parameter name="l25" type="string" value="Ca+2  SO4-2  0.2"/>
-  <Parameter name="l26" type="string" value="H+    SO4-2  0.0298"/>
-  <Parameter name="l27" type="string" value="Li+   SO4-2  0.136275 0.0  0.0  0.5055E-3"/>
-  <Parameter name="l28" type="string" value="Sr+2  SO4-2  0.200.0  0.0  0.0  -2.9E-3"/>
-  <Parameter name="l29" type="string" value="Fe+2  SO4-2  0.2568"/>
-  <Parameter name="l30" type="string" value="Mn+2  SO4-2  0.2065"/>
-  <Parameter name="l31" type="string" value="Na+   HSO4-  0.0454"/>
-  <Parameter name="l32" type="string" value="K+    HSO4- -0.03"/>
-  <Parameter name="l33" type="string" value="Mg+2  HSO4-  0.4746"/>
-  <Parameter name="l34" type="string" value="Ca+2  HSO4-  0.2145"/>
-  <Parameter name="l35" type="string" value="H+    HSO4-  0.2065"/>
-  <Parameter name="l36" type="string" value="Fe+2  HSO4-  0.4273"/>
-  <Parameter name="l37" type="string" value="Na+   OH-  0.0864  0.0  0.0  7.00E-4"/>
-  <Parameter name="l38" type="string" value="K+    OH-  0.1298"/>
-  <Parameter name="l39" type="string" value="Ca+2  OH- -0.1747"/>
-  <Parameter name="l40" type="string" value="Li+   OH-  0.015"/>
-  <Parameter name="l41" type="string" value="Ba+2  OH-  0.17175"/>
-  <Parameter name="l42" type="string" value="Na+   HCO3-  0.0277  0.0  0.0  1.00E-3"/>
-  <Parameter name="l43" type="string" value="K+    HCO3-  0.0296  0.0  0.0  0.996E-3"/>
-  <Parameter name="l44" type="string" value="Mg+2  HCO3-  0.329"/>
-  <Parameter name="l45" type="string" value="Ca+2  HCO3-  0.4"/>
-  <Parameter name="l46" type="string" value="Sr+2  HCO3-  0.12"/>
-  <Parameter name="l47" type="string" value="Na+   CO3-2  0.0399  0.0  0.0  1.79E-3"/>
-  <Parameter name="l48" type="string" value="K+    CO3-2  0.1488  0.0  0.0  1.788E-3"/>
-  <Parameter name="l49" type="string" value="Na+   B(OH)4-     -0.0427"/>
-  <Parameter name="l50" type="string" value="Na+   B3O3(OH)4-  -0.056"/>
-  <Parameter name="l51" type="string" value="Na+   B4O5(OH)4-2 -0.11"/>
-  <Parameter name="l52" type="string" value="K+    B(OH)4-      0.035"/>
-  <Parameter name="l53" type="string" value="K+    B3O3(OH)4-  -0.13"/>
-</ParameterList>
-<ParameterList name="b1">
-  <Parameter name="l01" type="string" value="Na+   Cl-    0.2664   0.0  0.0  6.1608E-5  1.0715E-6"/>
-  <Parameter name="l02" type="string" value="K+    Cl-    0.2122   0.0  0.0  10.71E-4"/>
-  <Parameter name="l03" type="string" value="Mg+2  Cl-    1.6815   0.0  0.0  3.6525E-3"/>
-  <Parameter name="l04" type="string" value="Ca+2  Cl-    1.614    0.0  0.0  3.9E-3"/>
-  <Parameter name="l05" type="string" value="MgOH+ Cl-    1.658"/>        
-  <Parameter name="l06" type="string" value="H+    Cl-    0.2945   0.0  0.0  1.419E-4"/>
-  <Parameter name="l07" type="string" value="Li+   Cl-    0.3074   0.0  0.0  5.366E-4"/>
-  <Parameter name="l08" type="string" value="Sr+2  Cl-    1.667    0.0  0.0  2.8425E-3"/>
-  <Parameter name="l09" type="string" value="Fe+2  Cl-    1.53225"/>
-  <Parameter name="l10" type="string" value="Mn+2  Cl-    1.55025"/>    
-  <Parameter name="l11" type="string" value="Ba+2  Cl-    1.49625  0.0  0.0  3.2325E-3"/>
-  <Parameter name="l12" type="string" value="Na+   Br-    0.2791   0.0  0.0  10.79E-4"/>
-  <Parameter name="l13" type="string" value="K+    Br-    0.2212   0.0  0.0  17.40E-4"/>
-  <Parameter name="l14" type="string" value="H+    Br-    0.3564   0.0  0.0  4.467E-4"/>
-  <Parameter name="l15" type="string" value="Mg+2  Br-    1.753    0.0  0.0  3.8625E-3"/>
-  <Parameter name="l16" type="string" value="Ca+2  Br-    1.613    0.0  0.0  6.0375E-3"/>
-  <Parameter name="l17" type="string" value="Li+   Br-    0.2547   0.0  0.0  6.636E-4"/>
-  <Parameter name="l18" type="string" value="Sr+2  Br-    1.7115   0.0  0.0  6.5325E-3"/>
-  <Parameter name="l19" type="string" value="Ba+2  Br-    1.56975  0.0  0.0  6.78E-3"/>
-  <Parameter name="l20" type="string" value="Na+   SO4-2  1.113    0.0  0.0  5.6325E-3"/>
-  <Parameter name="l21" type="string" value="K+    SO4-2  0.7793   0.0  0.0  6.6975E-3"/>
-  <Parameter name="l22" type="string" value="Mg+2  SO4-2  3.343    0.0  0.0  1.53E-2"/>
-  <Parameter name="l23" type="string" value="Ca+2  SO4-2  3.1973   0.0  0.0  5.46E-2"/>
-  <Parameter name="l24" type="string" value="Li+   SO4-2  1.2705   0.0  0.0  1.41E-3"/>
-  <Parameter name="l25" type="string" value="Sr+2  SO4-2  3.1973   0.0  0.0  27.0E-3"/>
-  <Parameter name="l26" type="string" value="Fe+2  SO4-2  3.063"/> 
-  <Parameter name="l27" type="string" value="Mn+2  SO4-2  2.9511"/> 
-  <Parameter name="l28" type="string" value="Na+   HSO4-  0.398"/>    
-  <Parameter name="l29" type="string" value="K+    HSO4-  0.1735"/>      
-  <Parameter name="l30" type="string" value="Mg+2  HSO4-  1.729"/>     
-  <Parameter name="l31" type="string" value="Ca+2  HSO4-  2.53"/>          
-  <Parameter name="l32" type="string" value="H+    HSO4-  0.5556"/>       
-  <Parameter name="l33" type="string" value="Fe+2  HSO4-  3.48"/>          
-  <Parameter name="l34" type="string" value="Na+   OH-    0.253    0.0  0.0  1.34E-4"/>
-  <Parameter name="l35" type="string" value="K+    OH-    0.32"/>
-  <Parameter name="l36" type="string" value="Ca+2  OH-   -0.2303"/>       
-  <Parameter name="l37" type="string" value="Li+   OH-    0.14"/>     
-  <Parameter name="l38" type="string" value="Ba+2  OH-    1.2"/>       
-  <Parameter name="l39" type="string" value="Na+   HCO3-  0.0411   0.0  0.0  1.10E-3"/>
-  <Parameter name="l40" type="string" value="K+    HCO3- -0.013    0.0  0.0  1.104E-3"/>
-  <Parameter name="l41" type="string" value="Mg+2  HCO3-  0.6072"/>
-  <Parameter name="l42" type="string" value="Ca+2  HCO3-  2.977"/>     
-  <Parameter name="l43" type="string" value="Na+   CO3-2  1.389    0.0  0.0  2.05E-3"/>
-  <Parameter name="l44" type="string" value="K+    CO3-2  1.43     0.0  0.0  2.051E-3"/>
-  <Parameter name="l45" type="string" value="Na+   B(OH)4-      0.089"/>
-  <Parameter name="l46" type="string" value="Na+   B3O3(OH)4-  -0.910"/>    
-  <Parameter name="l47" type="string" value="Na+   B4O5(OH)4-2 -0.40"/>   
-  <Parameter name="l48" type="string" value="K+    B(OH)4-      0.14"/>       
-</ParameterList>
-<ParameterList name="b2">
-  <Parameter name="l01" type="string" value="Mg+2  SO4-2  -37.23  0.0  0.0  -0.253"/>
-  <Parameter name="l02" type="string" value="Ca+2  SO4-2  -54.24  0.0  0.0  -0.516"/>
-  <Parameter name="l03" type="string" value="Sr+2  SO4-2  -54.24  0.0  0.0  -0.42"/>
-  <Parameter name="l04" type="string" value="Fe+2  SO4-2  -42.0"/>
-  <Parameter name="l05" type="string" value="Mn+2  SO4-2  -40.0"/>
-  <Parameter name="l06" type="string" value="Ca+2  OH-    -5.72"/>
-</ParameterList>
-
-<ParameterList name="cfi">
-  <Parameter name="l01" type="string" value="Na+   Cl-     0.00127   33.317  0.09421  -4.655E-5"/>
-  <Parameter name="l02" type="string" value="K+    Cl-    -0.00084   0.0     0.0      -5.095E-5"/>
-  <Parameter name="l03" type="string" value="Mg+2  Cl-     0.00519   0.0     0.0      -1.64933E-4"/>
-  <Parameter name="l04" type="string" value="Ca+2  Cl-    -0.00034"/>
-  <Parameter name="l05" type="string" value="H+    Cl-     0.0008    0.0     0.0       6.213E-5"/>
-  <Parameter name="l06" type="string" value="Li+   Cl-     0.00359   0.0     0.0      -4.520E-5"/>
-  <Parameter name="l07" type="string" value="Sr+2  Cl-    -0.00130"/>
-  <Parameter name="l08" type="string" value="Fe+2  Cl-    -0.00860725"/>
-  <Parameter name="l09" type="string" value="Mn+2  Cl-    -0.0204972"/> 
-  <Parameter name="l10" type="string" value="Ba+2  Cl-    -0.0193782 0.0     0.0      -1.53796E-4"/>
-  <Parameter name="l11" type="string" value="Na+   Br-     0.00116   0.0     0.0      -9.30E-5"/>
-  <Parameter name="l12" type="string" value="K+    Br-    -0.00180   0.0     0.0      -7.004E-5"/>
-  <Parameter name="l13" type="string" value="H+    Br-     0.00827   0.0     0.0      -5.685E-5"/>
-  <Parameter name="l14" type="string" value="Mg+2  Br-     0.00312"/>
-  <Parameter name="l15" type="string" value="Ca+2  Br-    -0.00257"/>
-  <Parameter name="l16" type="string" value="Li+   Br-     0.0053    0.0     0.0      -2.813E-5"/>
-  <Parameter name="l17" type="string" value="Sr+2  Br-     0.00122506"/>
-  <Parameter name="l18" type="string" value="Ba+2  Br-    -0.0159576"/>
-  <Parameter name="l19" type="string" value="Na+   SO4-2   0.00497   0.0     0.0      -4.87904E-4"/>
-  <Parameter name="l20" type="string" value="Mg+2  SO4-2   0.025     0.0     0.0       0.523E-3"/>
-  <Parameter name="l21" type="string" value="H+    SO4-2   0.0438"/>
-  <Parameter name="l22" type="string" value="Li+   SO4-2  -0.00399338  0.0   0.0      -2.33345E-4"/>
-  <Parameter name="l23" type="string" value="Fe+2  SO4-2   0.0209"/>
-  <Parameter name="l24" type="string" value="Mn+2  SO4-2   0.01636"/>
-  <Parameter name="l25" type="string" value="Na+   OH-     0.0044     0.0    0.0      -18.94E-5"/>
-  <Parameter name="l26" type="string" value="K+    OH-     0.0041"/>
-  <Parameter name="l27" type="string" value="K+    HCO3-  -0.008"/>
-  <Parameter name="l28" type="string" value="Na+   CO3-2   0.0044"/>
-  <Parameter name="l29" type="string" value="K+    CO3-2  -0.0015"/>
-  <Parameter name="l30" type="string" value="Na+   B(OH)4- 0.0114"/>
-</ParameterList>
-<ParameterList name="theta">
-  <Parameter name="l01" type="string" value="K+      Na+  -0.012"/>
-  <Parameter name="l02" type="string" value="Mg+2    Na+   0.07"/>
-  <Parameter name="l03" type="string" value="Ca+2    Na+   0.07"/>
-  <Parameter name="l04" type="string" value="Sr+2    Na+   0.051"/>
-  <Parameter name="l05" type="string" value="H+      Na+   0.036"/>
-  <Parameter name="l06" type="string" value="Ca+2    K+    0.032"/>
-  <Parameter name="l07" type="string" value="H+      K+    0.005"/>
-  <Parameter name="l08" type="string" value="Ca+2    Mg+2  0.007"/>
-  <Parameter name="l09" type="string" value="H+      Mg+2  0.1"/>
-  <Parameter name="l10" type="string" value="H+      Ca+2  0.092"/>
-  <Parameter name="l11" type="string" value="SO4-2   Cl-   0.02"/>
-  <Parameter name="l12" type="string" value="HSO4-   Cl-  -0.006"/>
-  <Parameter name="l13" type="string" value="OH-     Cl-  -0.05"/>
-  <Parameter name="l14" type="string" value="HCO3-   Cl-   0.03"/>
-  <Parameter name="l15" type="string" value="CO3-2   Cl-  -0.02"/>
-  <Parameter name="l16" type="string" value="B(OH)4- Cl-  -0.065"/>
-  <Parameter name="l17" type="string" value="B3O3(OH)4-  Cl-  0.12"/>
-  <Parameter name="l18" type="string" value="B4O5(OH)4-2 Cl-  0.074"/>
-  <Parameter name="l19" type="string" value="OH-       Br-   -0.065"/>
-  <Parameter name="l20" type="string" value="OH-       SO4-2 -0.013"/>
-  <Parameter name="l21" type="string" value="HCO3-     SO4-2  0.01"/>
-  <Parameter name="l22" type="string" value="CO3-2     SO4-2  0.02"/>
-  <Parameter name="l23" type="string" value="B(OH)4-   SO4-2 -0.012"/>
-  <Parameter name="l24" type="string" value="B3O3(OH)4-   SO4-2  0.10"/>
-  <Parameter name="l25" type="string" value="B4O5(OH)4-2  SO4-2  0.12"/>
-  <Parameter name="l26" type="string" value="CO3-2        OH-    0.1"/>
-  <Parameter name="l27" type="string" value="CO3-2        HCO3- -0.04"/>
-  <Parameter name="l28" type="string" value="B3O3(OH)4-   HCO3- -0.10"/>
-  <Parameter name="l29" type="string" value="B4O5(OH)4-2  HCO3- -0.087"/>
-</ParameterList>
-
-<ParameterList name="lamda">
-  <Parameter name="l01" type="string" value="Na+    CO2      0.1"/>
-  <Parameter name="l02" type="string" value="K+     CO2      0.051"/>
-  <Parameter name="l03" type="string" value="Mg+2   CO2      0.183"/>
-  <Parameter name="l04" type="string" value="Ca+2   CO2      0.183"/>
-  <Parameter name="l05" type="string" value="Cl-    CO2     -0.005"/>
-  <Parameter name="l06" type="string" value="SO4-2  CO2      0.097"/>
-  <Parameter name="l07" type="string" value="HSO4-  CO2     -0.003"/>
-  <Parameter name="l08" type="string" value="Na+    B(OH)3  -0.097"/>
-  <Parameter name="l09" type="string" value="K+     B(OH)3  -0.14"/>
-  <Parameter name="l10" type="string" value="Cl-    B(OH)3   0.091"/>
-  <Parameter name="l11" type="string" value="SO4-2  B(OH)3   0.018"/>
-  <Parameter name="l12" type="string" value="B3O3(OH)4-  B(OH)3  -0.20"/>
-</ParameterList>
-
-<ParameterList name="zeta">
-  <Parameter name="l01" type="string" value="H+   Cl-    B(OH)3  -0.0102"/>
-  <Parameter name="l02" type="string" value="Na+  SO4-2  B(OH)3   0.046"/>
-</ParameterList>
-
-<ParameterList name="psi">
- <Parameter name="l01" type="string" value="Na+   K+    Cl-    -0.0018"/>
- <Parameter name="l02" type="string" value="Na+   K+    Br-    -0.0022"/>
- <Parameter name="l03" type="string" value="Na+   K+    SO4-2  -0.010"/>
- <Parameter name="l04" type="string" value="Na+   K+    HCO3-  -0.003"/>
- <Parameter name="l05" type="string" value="Na+   K+    CO3-2   0.003"/>
- <Parameter name="l06" type="string" value="Na+   Ca+2  Cl-    -0.007"/>
- <Parameter name="l07" type="string" value="Na+   Sr+2  Cl-    -0.0021"/>
- <Parameter name="l09" type="string" value="Na+   Ca+2  SO4-2  -0.055"/>
- <Parameter name="l10" type="string" value="Na+   Mg+2  Cl-    -0.012"/>
- <Parameter name="l11" type="string" value="Na+   Mg+2  SO4-2  -0.015"/>
- <Parameter name="l12" type="string" value="Na+   H+    Cl-    -0.004"/>
- <Parameter name="l13" type="string" value="Na+   H+    Br-    -0.012"/>
- <Parameter name="l14" type="string" value="Na+   H+    HSO4-  -0.0129"/>
- <Parameter name="l15" type="string" value="K+    Ca+2  Cl-    -0.025"/>
- <Parameter name="l16" type="string" value="K+    Mg+2  Cl-    -0.022"/>
- <Parameter name="l17" type="string" value="K+    Mg+2  SO4-2  -0.048"/>
- <Parameter name="l18" type="string" value="K+    H+    Cl-    -0.011"/>
- <Parameter name="l19" type="string" value="K+    H+    Br-    -0.021"/>
- <Parameter name="l20" type="string" value="K+    H+    SO4-2   0.197"/>
- <Parameter name="l21" type="string" value="K+    H+    HSO4-  -0.0265"/>
- <Parameter name="l22" type="string" value="Ca+2  Mg+2  Cl-    -0.012"/>
- <Parameter name="l23" type="string" value="Ca+2  Mg+2  SO4-2   0.024"/>
- <Parameter name="l24" type="string" value="Ca+2  H+    Cl-    -0.015"/>
- <Parameter name="l25" type="string" value="Mg+2  MgOH+ Cl-     0.028"/>
- <Parameter name="l26" type="string" value="Mg+2  H+    Cl-    -0.011"/>
- <Parameter name="l27" type="string" value="Mg+2  H+    HSO4-  -0.0178"/>
- <Parameter name="l28" type="string" value="Cl-   Br-   K+      0.0000"/>
- <Parameter name="l29" type="string" value="Cl-   SO4-2 Na+     0.0014"/>
- <Parameter name="l30" type="string" value="Cl-   SO4-2 Ca+2   -0.018"/>
- <Parameter name="l31" type="string" value="Cl-   SO4-2 Mg+2   -0.004"/>
- <Parameter name="l32" type="string" value="Cl-   HSO4- Na+    -0.006"/>
- <Parameter name="l33" type="string" value="Cl-   HSO4- H+      0.013"/>
- <Parameter name="l34" type="string" value="Cl-   OH-   Na+    -0.006"/>
- <Parameter name="l35" type="string" value="Cl-   OH-   K+     -0.006"/>
- <Parameter name="l36" type="string" value="Cl-   OH-   Ca+2   -0.025"/>
- <Parameter name="l37" type="string" value="Cl-   HCO3-   Na+   -0.015"/>
- <Parameter name="l38" type="string" value="Cl-   HCO3-   Mg+2  -0.096"/>
- <Parameter name="l39" type="string" value="Cl-   CO3-2   Na+    0.0085"/>
- <Parameter name="l40" type="string" value="Cl-   CO3-2   K+     0.004"/>
- <Parameter name="l41" type="string" value="Cl-   B(OH)4-     Na+  -0.0073"/>
- <Parameter name="l42" type="string" value="Cl-   B3O3(OH)4-  Na+  -0.024"/>
- <Parameter name="l43" type="string" value="Cl-   B4O5(OH)4-2 Na+   0.026"/>
- <Parameter name="l44" type="string" value="SO4-2  HSO4-  Na+   -0.0094"/>
- <Parameter name="l45" type="string" value="SO4-2  HSO4-  K+    -0.0677"/>
- <Parameter name="l46" type="string" value="SO4-2  HSO4-  Mg+2  -0.0425"/>
- <Parameter name="l47" type="string" value="SO4-2  OH-    Na+   -0.009"/>
- <Parameter name="l48" type="string" value="SO4-2  OH-    K+    -0.050"/>
- <Parameter name="l49" type="string" value="SO4-2  HCO3-  Na+   -0.005"/>
- <Parameter name="l50" type="string" value="SO4-2  HCO3-  Mg+2  -0.161"/>
- <Parameter name="l51" type="string" value="SO4-2  CO3-2  Na+   -0.005"/>
- <Parameter name="l52" type="string" value="SO4-2  CO3-2  K+    -0.009"/>
- <Parameter name="l53" type="string" value="OH-    CO3-2  Na+   -0.017"/>
- <Parameter name="l54" type="string" value="OH-    CO3-2  K+    -0.01"/>
- <Parameter name="l55" type="string" value="OH-    Br-    Na+   -0.018"/>
- <Parameter name="l56" type="string" value="OH-    Br-    K+    -0.014"/>
- <Parameter name="l57" type="string" value="HCO3-  CO3-2  Na+    0.002"/>
- <Parameter name="l58" type="string" value="HCO3-  CO3-2  K+     0.012"/>
-</ParameterList>
+  <ParameterList name="b0">
+    <Parameter name="l01" type="string" value="Na+   Cl-  0.0765  -777.03  -4.4706  0.008946  -3.3158E-6"/>
+    <Parameter name="l02" type="string" value="K+    Cl-  0.04835  0.0  0.0   5.794E-4"/>
+    <Parameter name="l03" type="string" value="Mg+2  Cl-  0.35235  0.0  0.0  -1.943E-4"/>
+    <Parameter name="l04" type="string" value="Ca+2  Cl-  0.3159   0.0  0.0  -1.725E-4"/>
+    <Parameter name="l05" type="string" value="MgOH+ Cl- -0.1"/>
+    <Parameter name="l06" type="string" value="H+    Cl-  0.1775   0.0  0.0  -3.081E-4"/>
+    <Parameter name="l07" type="string" value="Li+   Cl-  0.1494   0.0  0.0  -1.685E-4"/>
+    <Parameter name="l08" type="string" value="Sr+2  Cl-  0.2858   0.0  0.0   0.717E-3"/>
+    <Parameter name="l09" type="string" value="Fe+2  Cl-  0.335925"/>
+    <Parameter name="l10" type="string" value="Mn+2  Cl-  0.327225"/>
+    <Parameter name="l11" type="string" value="Ba+2  Cl-  0.2628   0.0  0.0   0.6405E-3"/>
+    <Parameter name="l12" type="string" value="CaB(OH)4+  Cl-  0.12"/>
+    <Parameter name="l13" type="string" value="MgB(OH)4+  Cl-  0.16"/>
+    <Parameter name="l14" type="string" value="Na+   Br-  0.0973   0.0  0.0   7.692E-4"/>
+    <Parameter name="l15" type="string" value="K+    Br-  0.0569   0.0  0.0   7.39E-4"/>
+    <Parameter name="l16" type="string" value="H+    Br-  0.1960   0.0  0.0  -2.049E-4"/>
+    <Parameter name="l17" type="string" value="Mg+2  Br-  0.4327   0.0  0.0  -5.625E-5"/>
+    <Parameter name="l18" type="string" value="Ca+2  Br-  0.3816   0.0  0.0  -5.2275E-4"/>
+    <Parameter name="l19" type="string" value="Li+   Br-  0.1748   0.0  0.0  -1.819E-4"/>
+    <Parameter name="l20" type="string" value="Sr+2  Br-  0.331125 0.0  0.0  -0.32775E-3"/>
+    <Parameter name="l21" type="string" value="Ba+2  Br-  0.31455  0.0  0.0  -0.33825E-3"/>
+    <Parameter name="l22" type="string" value="Na+   SO4-2  0.01958  0.0  0.0  2.367E-3"/>
+    <Parameter name="l23" type="string" value="K+    SO4-2  0.04995  0.0  0.0  1.44E-3"/>
+    <Parameter name="l24" type="string" value="Mg+2  SO4-2  0.221    0.0  0.0 -0.69E-3"/>
+    <Parameter name="l25" type="string" value="Ca+2  SO4-2  0.2"/>
+    <Parameter name="l26" type="string" value="H+    SO4-2  0.0298"/>
+    <Parameter name="l27" type="string" value="Li+   SO4-2  0.136275 0.0  0.0  0.5055E-3"/>
+    <Parameter name="l28" type="string" value="Sr+2  SO4-2  0.200.0  0.0  0.0  -2.9E-3"/>
+    <Parameter name="l29" type="string" value="Fe+2  SO4-2  0.2568"/>
+    <Parameter name="l30" type="string" value="Mn+2  SO4-2  0.2065"/>
+    <Parameter name="l31" type="string" value="Na+   HSO4-  0.0454"/>
+    <Parameter name="l32" type="string" value="K+    HSO4- -0.03"/>
+    <Parameter name="l33" type="string" value="Mg+2  HSO4-  0.4746"/>
+    <Parameter name="l34" type="string" value="Ca+2  HSO4-  0.2145"/>
+    <Parameter name="l35" type="string" value="H+    HSO4-  0.2065"/>
+    <Parameter name="l36" type="string" value="Fe+2  HSO4-  0.4273"/>
+    <Parameter name="l37" type="string" value="Na+   OH-  0.0864  0.0  0.0  7.00E-4"/>
+    <Parameter name="l38" type="string" value="K+    OH-  0.1298"/>
+    <Parameter name="l39" type="string" value="Ca+2  OH- -0.1747"/>
+    <Parameter name="l40" type="string" value="Li+   OH-  0.015"/>
+    <Parameter name="l41" type="string" value="Ba+2  OH-  0.17175"/>
+    <Parameter name="l42" type="string" value="Na+   HCO3-  0.0277  0.0  0.0  1.00E-3"/>
+    <Parameter name="l43" type="string" value="K+    HCO3-  0.0296  0.0  0.0  0.996E-3"/>
+    <Parameter name="l44" type="string" value="Mg+2  HCO3-  0.329"/>
+    <Parameter name="l45" type="string" value="Ca+2  HCO3-  0.4"/>
+    <Parameter name="l46" type="string" value="Sr+2  HCO3-  0.12"/>
+    <Parameter name="l47" type="string" value="Na+   CO3-2  0.0399  0.0  0.0  1.79E-3"/>
+    <Parameter name="l48" type="string" value="K+    CO3-2  0.1488  0.0  0.0  1.788E-3"/>
+    <Parameter name="l49" type="string" value="Na+   B(OH)4-     -0.0427"/>
+    <Parameter name="l50" type="string" value="Na+   B3O3(OH)4-  -0.056"/>
+    <Parameter name="l51" type="string" value="Na+   B4O5(OH)4-2 -0.11"/>
+    <Parameter name="l52" type="string" value="K+    B(OH)4-      0.035"/>
+    <Parameter name="l53" type="string" value="K+    B3O3(OH)4-  -0.13"/>
+  </ParameterList>
+  <ParameterList name="b1">
+    <Parameter name="l01" type="string" value="Na+   Cl-    0.2664   0.0  0.0  6.1608E-5  1.0715E-6"/>
+    <Parameter name="l02" type="string" value="K+    Cl-    0.2122   0.0  0.0  10.71E-4"/>
+    <Parameter name="l03" type="string" value="Mg+2  Cl-    1.6815   0.0  0.0  3.6525E-3"/>
+    <Parameter name="l04" type="string" value="Ca+2  Cl-    1.614    0.0  0.0  3.9E-3"/>
+    <Parameter name="l05" type="string" value="MgOH+ Cl-    1.658"/>
+    <Parameter name="l06" type="string" value="H+    Cl-    0.2945   0.0  0.0  1.419E-4"/>
+    <Parameter name="l07" type="string" value="Li+   Cl-    0.3074   0.0  0.0  5.366E-4"/>
+    <Parameter name="l08" type="string" value="Sr+2  Cl-    1.667    0.0  0.0  2.8425E-3"/>
+    <Parameter name="l09" type="string" value="Fe+2  Cl-    1.53225"/>
+    <Parameter name="l10" type="string" value="Mn+2  Cl-    1.55025"/>
+    <Parameter name="l11" type="string" value="Ba+2  Cl-    1.49625  0.0  0.0  3.2325E-3"/>
+    <Parameter name="l12" type="string" value="Na+   Br-    0.2791   0.0  0.0  10.79E-4"/>
+    <Parameter name="l13" type="string" value="K+    Br-    0.2212   0.0  0.0  17.40E-4"/>
+    <Parameter name="l14" type="string" value="H+    Br-    0.3564   0.0  0.0  4.467E-4"/>
+    <Parameter name="l15" type="string" value="Mg+2  Br-    1.753    0.0  0.0  3.8625E-3"/>
+    <Parameter name="l16" type="string" value="Ca+2  Br-    1.613    0.0  0.0  6.0375E-3"/>
+    <Parameter name="l17" type="string" value="Li+   Br-    0.2547   0.0  0.0  6.636E-4"/>
+    <Parameter name="l18" type="string" value="Sr+2  Br-    1.7115   0.0  0.0  6.5325E-3"/>
+    <Parameter name="l19" type="string" value="Ba+2  Br-    1.56975  0.0  0.0  6.78E-3"/>
+    <Parameter name="l20" type="string" value="Na+   SO4-2  1.113    0.0  0.0  5.6325E-3"/>
+    <Parameter name="l21" type="string" value="K+    SO4-2  0.7793   0.0  0.0  6.6975E-3"/>
+    <Parameter name="l22" type="string" value="Mg+2  SO4-2  3.343    0.0  0.0  1.53E-2"/>
+    <Parameter name="l23" type="string" value="Ca+2  SO4-2  3.1973   0.0  0.0  5.46E-2"/>
+    <Parameter name="l24" type="string" value="Li+   SO4-2  1.2705   0.0  0.0  1.41E-3"/>
+    <Parameter name="l25" type="string" value="Sr+2  SO4-2  3.1973   0.0  0.0  27.0E-3"/>
+    <Parameter name="l26" type="string" value="Fe+2  SO4-2  3.063"/>
+    <Parameter name="l27" type="string" value="Mn+2  SO4-2  2.9511"/>
+    <Parameter name="l28" type="string" value="Na+   HSO4-  0.398"/>
+    <Parameter name="l29" type="string" value="K+    HSO4-  0.1735"/>
+    <Parameter name="l30" type="string" value="Mg+2  HSO4-  1.729"/>
+    <Parameter name="l31" type="string" value="Ca+2  HSO4-  2.53"/>
+    <Parameter name="l32" type="string" value="H+    HSO4-  0.5556"/>
+    <Parameter name="l33" type="string" value="Fe+2  HSO4-  3.48"/>
+    <Parameter name="l34" type="string" value="Na+   OH-    0.253    0.0  0.0  1.34E-4"/>
+    <Parameter name="l35" type="string" value="K+    OH-    0.32"/>
+    <Parameter name="l36" type="string" value="Ca+2  OH-   -0.2303"/>
+    <Parameter name="l37" type="string" value="Li+   OH-    0.14"/>
+    <Parameter name="l38" type="string" value="Ba+2  OH-    1.2"/>
+    <Parameter name="l39" type="string" value="Na+   HCO3-  0.0411   0.0  0.0  1.10E-3"/>
+    <Parameter name="l40" type="string" value="K+    HCO3- -0.013    0.0  0.0  1.104E-3"/>
+    <Parameter name="l41" type="string" value="Mg+2  HCO3-  0.6072"/>
+    <Parameter name="l42" type="string" value="Ca+2  HCO3-  2.977"/>
+    <Parameter name="l43" type="string" value="Na+   CO3-2  1.389    0.0  0.0  2.05E-3"/>
+    <Parameter name="l44" type="string" value="K+    CO3-2  1.43     0.0  0.0  2.051E-3"/>
+    <Parameter name="l45" type="string" value="Na+   B(OH)4-      0.089"/>
+    <Parameter name="l46" type="string" value="Na+   B3O3(OH)4-  -0.910"/>
+    <Parameter name="l47" type="string" value="Na+   B4O5(OH)4-2 -0.40"/>
+    <Parameter name="l48" type="string" value="K+    B(OH)4-      0.14"/>
+  </ParameterList>
+  <ParameterList name="b2">
+    <Parameter name="l01" type="string" value="Mg+2  SO4-2  -37.23  0.0  0.0  -0.253"/>
+    <Parameter name="l02" type="string" value="Ca+2  SO4-2  -54.24  0.0  0.0  -0.516"/>
+    <Parameter name="l03" type="string" value="Sr+2  SO4-2  -54.24  0.0  0.0  -0.42"/>
+    <Parameter name="l04" type="string" value="Fe+2  SO4-2  -42.0"/>
+    <Parameter name="l05" type="string" value="Mn+2  SO4-2  -40.0"/>
+    <Parameter name="l06" type="string" value="Ca+2  OH-    -5.72"/>
+  </ParameterList>
+  <ParameterList name="cfi">
+    <Parameter name="l01" type="string" value="Na+   Cl-     0.00127   33.317  0.09421  -4.655E-5"/>
+    <Parameter name="l02" type="string" value="K+    Cl-    -0.00084   0.0     0.0      -5.095E-5"/>
+    <Parameter name="l03" type="string" value="Mg+2  Cl-     0.00519   0.0     0.0      -1.64933E-4"/>
+    <Parameter name="l04" type="string" value="Ca+2  Cl-    -0.00034"/>
+    <Parameter name="l05" type="string" value="H+    Cl-     0.0008    0.0     0.0       6.213E-5"/>
+    <Parameter name="l06" type="string" value="Li+   Cl-     0.00359   0.0     0.0      -4.520E-5"/>
+    <Parameter name="l07" type="string" value="Sr+2  Cl-    -0.00130"/>
+    <Parameter name="l08" type="string" value="Fe+2  Cl-    -0.00860725"/>
+    <Parameter name="l09" type="string" value="Mn+2  Cl-    -0.0204972"/>
+    <Parameter name="l10" type="string" value="Ba+2  Cl-    -0.0193782 0.0     0.0      -1.53796E-4"/>
+    <Parameter name="l11" type="string" value="Na+   Br-     0.00116   0.0     0.0      -9.30E-5"/>
+    <Parameter name="l12" type="string" value="K+    Br-    -0.00180   0.0     0.0      -7.004E-5"/>
+    <Parameter name="l13" type="string" value="H+    Br-     0.00827   0.0     0.0      -5.685E-5"/>
+    <Parameter name="l14" type="string" value="Mg+2  Br-     0.00312"/>
+    <Parameter name="l15" type="string" value="Ca+2  Br-    -0.00257"/>
+    <Parameter name="l16" type="string" value="Li+   Br-     0.0053    0.0     0.0      -2.813E-5"/>
+    <Parameter name="l17" type="string" value="Sr+2  Br-     0.00122506"/>
+    <Parameter name="l18" type="string" value="Ba+2  Br-    -0.0159576"/>
+    <Parameter name="l19" type="string" value="Na+   SO4-2   0.00497   0.0     0.0      -4.87904E-4"/>
+    <Parameter name="l20" type="string" value="Mg+2  SO4-2   0.025     0.0     0.0       0.523E-3"/>
+    <Parameter name="l21" type="string" value="H+    SO4-2   0.0438"/>
+    <Parameter name="l22" type="string" value="Li+   SO4-2  -0.00399338  0.0   0.0      -2.33345E-4"/>
+    <Parameter name="l23" type="string" value="Fe+2  SO4-2   0.0209"/>
+    <Parameter name="l24" type="string" value="Mn+2  SO4-2   0.01636"/>
+    <Parameter name="l25" type="string" value="Na+   OH-     0.0044     0.0    0.0      -18.94E-5"/>
+    <Parameter name="l26" type="string" value="K+    OH-     0.0041"/>
+    <Parameter name="l27" type="string" value="K+    HCO3-  -0.008"/>
+    <Parameter name="l28" type="string" value="Na+   CO3-2   0.0044"/>
+    <Parameter name="l29" type="string" value="K+    CO3-2  -0.0015"/>
+    <Parameter name="l30" type="string" value="Na+   B(OH)4- 0.0114"/>
+  </ParameterList>
+  <ParameterList name="theta">
+    <Parameter name="l01" type="string" value="K+      Na+  -0.012"/>
+    <Parameter name="l02" type="string" value="Mg+2    Na+   0.07"/>
+    <Parameter name="l03" type="string" value="Ca+2    Na+   0.07"/>
+    <Parameter name="l04" type="string" value="Sr+2    Na+   0.051"/>
+    <Parameter name="l05" type="string" value="H+      Na+   0.036"/>
+    <Parameter name="l06" type="string" value="Ca+2    K+    0.032"/>
+    <Parameter name="l07" type="string" value="H+      K+    0.005"/>
+    <Parameter name="l08" type="string" value="Ca+2    Mg+2  0.007"/>
+    <Parameter name="l09" type="string" value="H+      Mg+2  0.1"/>
+    <Parameter name="l10" type="string" value="H+      Ca+2  0.092"/>
+    <Parameter name="l11" type="string" value="SO4-2   Cl-   0.02"/>
+    <Parameter name="l12" type="string" value="HSO4-   Cl-  -0.006"/>
+    <Parameter name="l13" type="string" value="OH-     Cl-  -0.05"/>
+    <Parameter name="l14" type="string" value="HCO3-   Cl-   0.03"/>
+    <Parameter name="l15" type="string" value="CO3-2   Cl-  -0.02"/>
+    <Parameter name="l16" type="string" value="B(OH)4- Cl-  -0.065"/>
+    <Parameter name="l17" type="string" value="B3O3(OH)4-  Cl-  0.12"/>
+    <Parameter name="l18" type="string" value="B4O5(OH)4-2 Cl-  0.074"/>
+    <Parameter name="l19" type="string" value="OH-       Br-   -0.065"/>
+    <Parameter name="l20" type="string" value="OH-       SO4-2 -0.013"/>
+    <Parameter name="l21" type="string" value="HCO3-     SO4-2  0.01"/>
+    <Parameter name="l22" type="string" value="CO3-2     SO4-2  0.02"/>
+    <Parameter name="l23" type="string" value="B(OH)4-   SO4-2 -0.012"/>
+    <Parameter name="l24" type="string" value="B3O3(OH)4-   SO4-2  0.10"/>
+    <Parameter name="l25" type="string" value="B4O5(OH)4-2  SO4-2  0.12"/>
+    <Parameter name="l26" type="string" value="CO3-2        OH-    0.1"/>
+    <Parameter name="l27" type="string" value="CO3-2        HCO3- -0.04"/>
+    <Parameter name="l28" type="string" value="B3O3(OH)4-   HCO3- -0.10"/>
+    <Parameter name="l29" type="string" value="B4O5(OH)4-2  HCO3- -0.087"/>
+  </ParameterList>
+  <ParameterList name="lamda">
+    <Parameter name="l01" type="string" value="Na+    CO2      0.1"/>
+    <Parameter name="l02" type="string" value="K+     CO2      0.051"/>
+    <Parameter name="l03" type="string" value="Mg+2   CO2      0.183"/>
+    <Parameter name="l04" type="string" value="Ca+2   CO2      0.183"/>
+    <Parameter name="l05" type="string" value="Cl-    CO2     -0.005"/>
+    <Parameter name="l06" type="string" value="SO4-2  CO2      0.097"/>
+    <Parameter name="l07" type="string" value="HSO4-  CO2     -0.003"/>
+    <Parameter name="l08" type="string" value="Na+    B(OH)3  -0.097"/>
+    <Parameter name="l09" type="string" value="K+     B(OH)3  -0.14"/>
+    <Parameter name="l10" type="string" value="Cl-    B(OH)3   0.091"/>
+    <Parameter name="l11" type="string" value="SO4-2  B(OH)3   0.018"/>
+    <Parameter name="l12" type="string" value="B3O3(OH)4-  B(OH)3  -0.20"/>
+  </ParameterList>
+  <ParameterList name="zeta">
+    <Parameter name="l01" type="string" value="H+   Cl-    B(OH)3  -0.0102"/>
+    <Parameter name="l02" type="string" value="Na+  SO4-2  B(OH)3   0.046"/>
+  </ParameterList>
+  <ParameterList name="psi">
+    <Parameter name="l01" type="string" value="Na+   K+    Cl-    -0.0018"/>
+    <Parameter name="l02" type="string" value="Na+   K+    Br-    -0.0022"/>
+    <Parameter name="l03" type="string" value="Na+   K+    SO4-2  -0.010"/>
+    <Parameter name="l04" type="string" value="Na+   K+    HCO3-  -0.003"/>
+    <Parameter name="l05" type="string" value="Na+   K+    CO3-2   0.003"/>
+    <Parameter name="l06" type="string" value="Na+   Ca+2  Cl-    -0.007"/>
+    <Parameter name="l07" type="string" value="Na+   Sr+2  Cl-    -0.0021"/>
+    <Parameter name="l09" type="string" value="Na+   Ca+2  SO4-2  -0.055"/>
+    <Parameter name="l10" type="string" value="Na+   Mg+2  Cl-    -0.012"/>
+    <Parameter name="l11" type="string" value="Na+   Mg+2  SO4-2  -0.015"/>
+    <Parameter name="l12" type="string" value="Na+   H+    Cl-    -0.004"/>
+    <Parameter name="l13" type="string" value="Na+   H+    Br-    -0.012"/>
+    <Parameter name="l14" type="string" value="Na+   H+    HSO4-  -0.0129"/>
+    <Parameter name="l15" type="string" value="K+    Ca+2  Cl-    -0.025"/>
+    <Parameter name="l16" type="string" value="K+    Mg+2  Cl-    -0.022"/>
+    <Parameter name="l17" type="string" value="K+    Mg+2  SO4-2  -0.048"/>
+    <Parameter name="l18" type="string" value="K+    H+    Cl-    -0.011"/>
+    <Parameter name="l19" type="string" value="K+    H+    Br-    -0.021"/>
+    <Parameter name="l20" type="string" value="K+    H+    SO4-2   0.197"/>
+    <Parameter name="l21" type="string" value="K+    H+    HSO4-  -0.0265"/>
+    <Parameter name="l22" type="string" value="Ca+2  Mg+2  Cl-    -0.012"/>
+    <Parameter name="l23" type="string" value="Ca+2  Mg+2  SO4-2   0.024"/>
+    <Parameter name="l24" type="string" value="Ca+2  H+    Cl-    -0.015"/>
+    <Parameter name="l25" type="string" value="Mg+2  MgOH+ Cl-     0.028"/>
+    <Parameter name="l26" type="string" value="Mg+2  H+    Cl-    -0.011"/>
+    <Parameter name="l27" type="string" value="Mg+2  H+    HSO4-  -0.0178"/>
+    <Parameter name="l28" type="string" value="Cl-   Br-   K+      0.0000"/>
+    <Parameter name="l29" type="string" value="Cl-   SO4-2 Na+     0.0014"/>
+    <Parameter name="l30" type="string" value="Cl-   SO4-2 Ca+2   -0.018"/>
+    <Parameter name="l31" type="string" value="Cl-   SO4-2 Mg+2   -0.004"/>
+    <Parameter name="l32" type="string" value="Cl-   HSO4- Na+    -0.006"/>
+    <Parameter name="l33" type="string" value="Cl-   HSO4- H+      0.013"/>
+    <Parameter name="l34" type="string" value="Cl-   OH-   Na+    -0.006"/>
+    <Parameter name="l35" type="string" value="Cl-   OH-   K+     -0.006"/>
+    <Parameter name="l36" type="string" value="Cl-   OH-   Ca+2   -0.025"/>
+    <Parameter name="l37" type="string" value="Cl-   HCO3-   Na+   -0.015"/>
+    <Parameter name="l38" type="string" value="Cl-   HCO3-   Mg+2  -0.096"/>
+    <Parameter name="l39" type="string" value="Cl-   CO3-2   Na+    0.0085"/>
+    <Parameter name="l40" type="string" value="Cl-   CO3-2   K+     0.004"/>
+    <Parameter name="l41" type="string" value="Cl-   B(OH)4-     Na+  -0.0073"/>
+    <Parameter name="l42" type="string" value="Cl-   B3O3(OH)4-  Na+  -0.024"/>
+    <Parameter name="l43" type="string" value="Cl-   B4O5(OH)4-2 Na+   0.026"/>
+    <Parameter name="l44" type="string" value="SO4-2  HSO4-  Na+   -0.0094"/>
+    <Parameter name="l45" type="string" value="SO4-2  HSO4-  K+    -0.0677"/>
+    <Parameter name="l46" type="string" value="SO4-2  HSO4-  Mg+2  -0.0425"/>
+    <Parameter name="l47" type="string" value="SO4-2  OH-    Na+   -0.009"/>
+    <Parameter name="l48" type="string" value="SO4-2  OH-    K+    -0.050"/>
+    <Parameter name="l49" type="string" value="SO4-2  HCO3-  Na+   -0.005"/>
+    <Parameter name="l50" type="string" value="SO4-2  HCO3-  Mg+2  -0.161"/>
+    <Parameter name="l51" type="string" value="SO4-2  CO3-2  Na+   -0.005"/>
+    <Parameter name="l52" type="string" value="SO4-2  CO3-2  K+    -0.009"/>
+    <Parameter name="l53" type="string" value="OH-    CO3-2  Na+   -0.017"/>
+    <Parameter name="l54" type="string" value="OH-    CO3-2  K+    -0.01"/>
+    <Parameter name="l55" type="string" value="OH-    Br-    Na+   -0.018"/>
+    <Parameter name="l56" type="string" value="OH-    Br-    K+    -0.014"/>
+    <Parameter name="l57" type="string" value="HCO3-  CO3-2  Na+    0.002"/>
+    <Parameter name="l58" type="string" value="HCO3-  CO3-2  K+     0.012"/>
+  </ParameterList>
 </ParameterList>

--- a/src/common/chemistry/test/native/ca-carbonate.xml
+++ b/src/common/chemistry/test/native/ca-carbonate.xml
@@ -1,71 +1,68 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="HCO3-">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="61.1017"/>
+  <ParameterList name="primary species">
+    <ParameterList name="HCO3-">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="61.1017"/>
+    </ParameterList>
+    <ParameterList name="Ca++">
+      <Parameter name="ion size parameter" type="double" value="6.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="40.078"/>
+    </ParameterList>
+    <ParameterList name="H+">
+      <Parameter name="ion size parameter" type="double" value="9.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0079"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Ca++">
-    <Parameter name="ion size parameter" type="double" value="6.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="40.078"/>
+  <ParameterList name="aqueous equilibrium complexes">
+    <ParameterList name="OH-">
+      <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
+    </ParameterList>
+    <ParameterList name="CO3--">
+      <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-2"/>
+      <Parameter name="gram molecular weight" type="double" value="60.0091999999999999"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="10.3287999999999993"/>
+    </ParameterList>
+    <ParameterList name="CO2(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="44.0097999999999985"/>
+      <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956"/>
+    </ParameterList>
+    <ParameterList name="CaOH+">
+      <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="57.0852999999999966"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="12.8499999999999996"/>
+    </ParameterList>
+    <ParameterList name="CaHCO3+">
+      <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="101.095100000000002"/>
+      <Parameter name="reaction" type="string" value="1.0 HCO3-  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996"/>
+    </ParameterList>
+    <ParameterList name="CaCO3(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="100.087199999999996"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="7.00169999999999959"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="H+">
-    <Parameter name="ion size parameter" type="double" value="9.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0079"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="aqueous equilibrium complexes">
-  <ParameterList name="OH-">
-    <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
-  </ParameterList>
-  <ParameterList name="CO3--">
-    <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-2"/>
-    <Parameter name="gram molecular weight" type="double" value="6.00091999999999999e+01"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.03287999999999993e+01"/>
-  </ParameterList>
-  <ParameterList name="CO2(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="4.40097999999999985e+01"/>
-    <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956e+00"/>
-  </ParameterList>
-  <ParameterList name="CaOH+">
-    <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="5.70852999999999966e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="1.28499999999999996e+01"/>
-  </ParameterList>
-  <ParameterList name="CaHCO3+">
-    <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.01095100000000002e+02"/>
-    <Parameter name="reaction" type="string" value="1.0 HCO3-  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996e+00"/>
-  </ParameterList>
-  <ParameterList name="CaCO3(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.00087199999999996e+02"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="7.00169999999999959e+00"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/calcite.xml
+++ b/src/common/chemistry/test/native/calcite.xml
@@ -1,90 +1,85 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="H+">
-    <Parameter name="ion size parameter" type="double" value="9.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.01"/>
-  </ParameterList>
-  <ParameterList name="HCO3-">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="61.02"/>
-  </ParameterList>
-  <ParameterList name="Ca++">
-    <Parameter name="ion size parameter" type="double" value="6.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="40.08"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="aqueous equilibrium complexes">
-  <ParameterList name="OH-">
-    <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-    <!--Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/-->
-    <Parameter name="temperature" type="double" value="298.15"/>
-    <ParameterList name="equilibrium constant">
-      <Parameter name="T" type="Array(double)" value="{273.15,  298.15,  333.15,  373.15,  423.15,  473.15,  523.15,  573.15}"/>
-      <Parameter name="Keq" type="Array(double)" value="{14.9398, 13.9951, 13.0272, 12.2551, 11.6308, 11.2836, 11.1675, 11.3002}"/>
+  <ParameterList name="primary species">
+    <ParameterList name="H+">
+      <Parameter name="ion size parameter" type="double" value="9.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="1.01"/>
+    </ParameterList>
+    <ParameterList name="HCO3-">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="61.02"/>
+    </ParameterList>
+    <ParameterList name="Ca++">
+      <Parameter name="ion size parameter" type="double" value="6.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="40.08"/>
     </ParameterList>
   </ParameterList>
-  <ParameterList name="CO3--">
-    <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-2"/>
-    <Parameter name="gram molecular weight" type="double" value="60.0092"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.03287999999999993e+01"/>
+  <ParameterList name="aqueous equilibrium complexes">
+    <ParameterList name="OH-">
+      <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
+      <!--Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/-->
+      <Parameter name="temperature" type="double" value="298.15"/>
+      <ParameterList name="equilibrium constant">
+        <Parameter name="T" type="Array(double)" value="{273.15, 298.15, 333.15, 373.15, 423.15, 473.15, 523.15, 573.15}"/>
+        <Parameter name="Keq" type="Array(double)" value="{14.9398, 13.9951, 13.0272, 12.2551, 11.6308, 11.2836, 11.1675, 11.3002}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="CO3--">
+      <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-2"/>
+      <Parameter name="gram molecular weight" type="double" value="60.0092"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="10.3287999999999993"/>
+    </ParameterList>
+    <ParameterList name="CO2(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="44.0097999999999985"/>
+      <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956"/>
+    </ParameterList>
+    <ParameterList name="CaOH+">
+      <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="57.0852999999999966"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="12.8499999999999996"/>
+    </ParameterList>
+    <ParameterList name="CaHCO3+">
+      <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="101.095100000000002"/>
+      <Parameter name="reaction" type="string" value="1.0 HCO3-  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996"/>
+    </ParameterList>
+    <ParameterList name="CaCO3(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="100.087199999999996"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="7.00169999999999959"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="CO2(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="4.40097999999999985e+01"/>
-    <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956e+00"/>
+  <ParameterList name="mineral kinetics">
+    <ParameterList name="Calcite">
+      <Parameter name="rate model" type="string" value="TST"/>
+      <Parameter name="rate constant" type="double" value="-9.0"/>
+      <Parameter name="modifiers" type="string" value=""/>
+      <Parameter name="gram molecular weight" type="double" value="100.087"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
+      <Parameter name="equilibrium constant" type="double" value="1.84870"/>
+      <Parameter name="molar volume" type="double" value="0.0000369339999999999975"/>
+      <Parameter name="specific surface area" type="double" value="100.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="CaOH+">
-    <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="5.70852999999999966e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="1.28499999999999996e+01"/>
-  </ParameterList>
-  <ParameterList name="CaHCO3+">
-    <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.01095100000000002e+02"/>
-    <Parameter name="reaction" type="string" value="1.0 HCO3-  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996e+00"/>
-  </ParameterList>
-  <ParameterList name="CaCO3(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.00087199999999996e+02"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="7.00169999999999959e+00"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="mineral kinetics">
-  <ParameterList name="Calcite">
-    <Parameter name="rate model" type="string" value="TST"/>
-    <Parameter name="rate constant" type="double" value="-9.0"/>
-    <Parameter name="modifiers" type="string" value=""/>
-    <Parameter name="gram molecular weight" type="double" value="1.00087e+02"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
-    <Parameter name="equilibrium constant" type="double" value="1.84870"/>
-    <Parameter name="molar volume" type="double" value="3.69339999999999975e-5"/>
-    <Parameter name="specific surface area" type="double" value="100.0"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-
-

--- a/src/common/chemistry/test/native/carbonate.xml
+++ b/src/common/chemistry/test/native/carbonate.xml
@@ -1,45 +1,42 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="H+">
-    <Parameter name="ion size parameter" type="double" value="9.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0079"/>
+  <ParameterList name="primary species">
+    <ParameterList name="H+">
+      <Parameter name="ion size parameter" type="double" value="9.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0079"/>
+    </ParameterList>
+    <ParameterList name="HCO3-">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="61.1017"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="HCO3-">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="61.1017"/>
+  <ParameterList name="aqueous equilibrium complexes">
+    <ParameterList name="OH-">
+      <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
+    </ParameterList>
+    <ParameterList name="CO3--">
+      <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
+      <Parameter name="charge" type="int" value="-2"/>
+      <Parameter name="gram molecular weight" type="double" value="60.0091999999999999"/>
+      <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="10.3287999999999993"/>
+    </ParameterList>
+    <ParameterList name="CO2(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="44.0097999999999985"/>
+      <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
+      <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="aqueous equilibrium complexes">
-  <ParameterList name="OH-">
-    <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
-  </ParameterList>
-  <ParameterList name="CO3--">
-    <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="-2"/>
-    <Parameter name="gram molecular weight" type="double" value="6.00091999999999999e+01"/>
-    <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.03287999999999993e+01"/>
-  </ParameterList>
-  <ParameterList name="CO2(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="4.40097999999999985e+01"/>
-    <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
-    <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956e+00"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/colloid-isotherms.xml
+++ b/src/common/chemistry/test/native/colloid-isotherms.xml
@@ -1,47 +1,43 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="A">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="A">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="colloids">
+    <ParameterList name="colloid">
+      <Parameter name="gram molecular weight" type="double" value="5000.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="isotherms">
+    <ParameterList name="A">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{250.0}"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="model" type="string" value="freundlich"/>
+      <Parameter name="parameters" type="Array(double)" value="{1.25, 0.8}"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="model" type="string" value="langmuir"/>
+      <Parameter name="parameters" type="Array(double)" value="{0.1, 30.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="colloids">
-  <ParameterList name="colloid">
-    <Parameter name="gram molecular weight" type="double" value="5000.0"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="isotherms">
-  <ParameterList name="A">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 250.0 }"/>
-  </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="model" type="string" value="freundlich"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 1.25, 0.8 }"/>
-  </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="model" type="string" value="langmuir"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 0.1, 30.0 }"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/general-reaction-quadratic.xml
+++ b/src/common/chemistry/test/native/general-reaction-quadratic.xml
@@ -1,37 +1,33 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="HO2(g)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="HO2(g)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="H2O2(g)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="O2(g)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="H2O2(g)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="general kinetics">
+    <ParameterList name="general_0">
+      <Parameter name="reactants" type="string" value="1.0 HO2(g)"/>
+      <Parameter name="products" type="string" value="0.5 H2O2(g)  0.5 O2(g)"/>
+      <Parameter name="forward rate" type="double" value="0.000014"/>
+      <Parameter name="backward rate" type="double" value="0.0"/>
+      <Parameter name="reaction orders (reactants/products)" type="Array(double)" value="{2.0, 0.0, 0.0}"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="O2(g)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="general kinetics">
-  <ParameterList name="general_0">
-    <Parameter name="reactants" type="string" value="1.0 HO2(g)"/>
-    <Parameter name="products" type="string" value="0.5 H2O2(g)  0.5 O2(g)"/>
-    <Parameter name="forward rate" type="double" value="1.4e-5"/>
-    <Parameter name="backward rate" type="double" value="0.0"/>
-    <Parameter name="reaction orders (reactants/products)" type="Array(double)" value="{2.0, 0.0, 0.0}"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-
-

--- a/src/common/chemistry/test/native/general-reaction.xml
+++ b/src/common/chemistry/test/native/general-reaction.xml
@@ -1,32 +1,28 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="A(aq)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="A(aq)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="B(aq)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="B(aq)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="general kinetics">
+    <ParameterList name="general_0">
+      <Parameter name="reactants" type="string" value="1.0 A(aq)"/>
+      <Parameter name="products" type="string" value="1.0 B(aq)"/>
+      <Parameter name="forward rate" type="double" value="0.00000115741"/>
+      <Parameter name="backward rate" type="double" value="0.0"/>
+      <Parameter name="reaction orders (reactants/products)" type="Array(double)" value="{1.0, 0.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="general kinetics">
-  <ParameterList name="general_0">
-    <Parameter name="reactants" type="string" value="1.0 A(aq)"/>
-    <Parameter name="products" type="string" value="1.0 B(aq)"/>
-    <Parameter name="forward rate" type="double" value="1.15741e-6"/>
-    <Parameter name="backward rate" type="double" value="0.0"/>
-    <Parameter name="reaction orders (reactants/products)" type="Array(double)" value="{1.0, 0.0}"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-
-

--- a/src/common/chemistry/test/native/ion-exchange-valocchi.xml
+++ b/src/common/chemistry/test/native/ion-exchange-valocchi.xml
@@ -1,66 +1,61 @@
 <ParameterList name="thermodynamic database">
-<ParameterList name="primary species">
-  <ParameterList name="Na+">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="22.99"/>
+  <ParameterList name="primary species">
+    <ParameterList name="Na+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="22.99"/>
+    </ParameterList>
+    <ParameterList name="Ca++">
+      <Parameter name="ion size parameter" type="double" value="6.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="40.0799999999999983"/>
+    </ParameterList>
+    <ParameterList name="Mg++">
+      <Parameter name="ion size parameter" type="double" value="8.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="24.3000000000000007"/>
+    </ParameterList>
+    <ParameterList name="Cl-">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="35.4500000000000028"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Ca++">
-    <Parameter name="ion size parameter" type="double" value="6.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="4.00799999999999983e+01"/>
+  <ParameterList name="mineral kinetics">
+    <ParameterList name="Halite">
+      <Parameter name="rate model" type="string" value="TST"/>
+      <Parameter name="rate constant" type="double" value="-36.0"/>
+      <Parameter name="modifiers" type="string" value=""/>
+      <Parameter name="gram molecular weight" type="double" value="58.4425"/>
+      <Parameter name="reaction" type="string" value="1.00 Na+  1.00 Cl-"/>
+      <Parameter name="equilibrium constant" type="double" value="1.58550"/>
+      <Parameter name="molar volume" type="double" value="0.0000270150"/>
+      <Parameter name="specific surface area" type="double" value="100.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Mg++">
-    <Parameter name="ion size parameter" type="double" value="8.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="2.43000000000000007e+01"/>
+  <ParameterList name="ion exchange sites">
+    <ParameterList name="X-">
+      <Parameter name="location" type="string" value="Halite"/>
+      <Parameter name="charge" type="int" value="-1"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Cl-">
-    <Parameter name="ion size parameter" type="double" value="3.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="3.54500000000000028e+01"/>
+  <ParameterList name="ion exchange complexes">
+    <ParameterList name="Na+X">
+      <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="Ca++X">
+      <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="0.295300"/>
+    </ParameterList>
+    <ParameterList name="Mg++X">
+      <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="0.166600"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="mineral kinetics">
-  <ParameterList name="Halite">
-    <Parameter name="rate model" type="string" value="TST"/>
-    <Parameter name="rate constant" type="double" value="-36.0"/>
-    <Parameter name="modifiers" type="string" value=""/>
-    <Parameter name="gram molecular weight" type="double" value=" 5.84425E+01"/>
-    <Parameter name="reaction" type="string" value="1.00 Na+  1.00 Cl-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.58550E+00"/>
-    <Parameter name="molar volume" type="double" value="2.70150e-05"/>
-    <Parameter name="specific surface area" type="double" value="100.0"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="ion exchange sites">
-  <ParameterList name="X-">
-    <Parameter name="location" type="string" value="Halite"/>
-    <Parameter name="charge" type="int" value="-1"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="ion exchange complexes">
-  <ParameterList name="Na+X">
-    <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.0"/>
-  </ParameterList>
-  <ParameterList name="Ca++X">
-    <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
-    <Parameter name="equilibrium constant" type="double" value="2.95300E-01"/>
-  </ParameterList>
-  <ParameterList name="Mg++X">
-    <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
-    <Parameter name="equilibrium constant" type="double" value="1.66600E-01"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/radioactive-decay-aqueous.xml
+++ b/src/common/chemistry/test/native/radioactive-decay-aqueous.xml
@@ -1,54 +1,51 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="A">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="A">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="D">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="radioactive decay">
+    <ParameterList name="complex_0">
+      <Parameter name="reactant" type="string" value="A"/>
+      <Parameter name="product" type="string" value="1.0 B"/>
+      <Parameter name="half life" type="double" value="43200.0"/>
+    </ParameterList>
+    <ParameterList name="complex_1">
+      <Parameter name="reactant" type="string" value="B"/>
+      <Parameter name="product" type="string" value="1.0 C"/>
+      <Parameter name="half life" type="double" value="172800.0"/>
+    </ParameterList>
+    <ParameterList name="complex_2">
+      <Parameter name="reactant" type="string" value="C"/>
+      <Parameter name="product" type="string" value=""/>
+      <Parameter name="half life" type="double" value="1.57788e+7"/>
+    </ParameterList>
+    <ParameterList name="complex_3">
+      <Parameter name="reactant" type="string" value="D"/>
+      <Parameter name="product" type="string" value=""/>
+      <Parameter name="half life" type="double" value="43200.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
-  </ParameterList>
-  <ParameterList name="D">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="radioactive decay">
-  <ParameterList name="complex_0">
-    <Parameter name="reactant" type="string" value="A"/>
-    <Parameter name="product" type="string" value="1.0 B"/>
-    <Parameter name="half life" type="double" value="43200.0"/>
-  </ParameterList>
-  <ParameterList name="complex_1">
-    <Parameter name="reactant" type="string" value="B"/>
-    <Parameter name="product" type="string" value="1.0 C"/>
-    <Parameter name="half life" type="double" value="172800.0"/>
-  </ParameterList>
-  <ParameterList name="complex_2">
-    <Parameter name="reactant" type="string" value="C"/>
-    <Parameter name="product" type="string" value=""/>
-    <Parameter name="half life" type="double" value="1.57788e+07"/>
-  </ParameterList>
-  <ParameterList name="complex_3">
-    <Parameter name="reactant" type="string" value="D"/>
-    <Parameter name="product" type="string" value=""/>
-    <Parameter name="half life" type="double" value="43200.0"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/radioactive-decay-branches.xml
+++ b/src/common/chemistry/test/native/radioactive-decay-branches.xml
@@ -1,89 +1,86 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="In">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="114.818"/>
+  <ParameterList name="primary species">
+    <ParameterList name="In">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="114.818"/>
+    </ParameterList>
+    <ParameterList name="Sn">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="118.710"/>
+    </ParameterList>
+    <ParameterList name="Sb">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="121.760"/>
+    </ParameterList>
+    <ParameterList name="mTe">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="127.60"/>
+    </ParameterList>
+    <ParameterList name="Te">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="127.60"/>
+    </ParameterList>
+    <ParameterList name="I">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="126.90"/>
+    </ParameterList>
+    <ParameterList name="mXe">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="131.293"/>
+    </ParameterList>
+    <ParameterList name="Xe">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="131.293"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Sn">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="118.710"/>
+  <ParameterList name="radioactive decay">
+    <ParameterList name="complex_0">
+      <Parameter name="reactant" type="string" value="In"/>
+      <Parameter name="product" type="string" value="0.982 Sn"/>
+      <Parameter name="half life" type="double" value="0.282"/>
+    </ParameterList>
+    <ParameterList name="complex_1">
+      <Parameter name="reactant" type="string" value="Sn"/>
+      <Parameter name="product" type="string" value="1.0 Sb"/>
+      <Parameter name="half life" type="double" value="56.0"/>
+    </ParameterList>
+    <ParameterList name="complex_2">
+      <Parameter name="reactant" type="string" value="Sb"/>
+      <Parameter name="product" type="string" value="0.07 mTe 0.93 Te"/>
+      <Parameter name="half life" type="double" value="1381.8"/>
+    </ParameterList>
+    <ParameterList name="complex_3">
+      <Parameter name="reactant" type="string" value="mTe"/>
+      <Parameter name="product" type="string" value="0.18 Te 0.82 I"/>
+      <Parameter name="half life" type="double" value="116640.0"/>
+    </ParameterList>
+    <ParameterList name="complex_4">
+      <Parameter name="reactant" type="string" value="Te"/>
+      <Parameter name="product" type="string" value="1.0 I"/>
+      <Parameter name="half life" type="double" value="1500.0"/>
+    </ParameterList>
+    <ParameterList name="complex_5">
+      <Parameter name="reactant" type="string" value="I"/>
+      <Parameter name="product" type="string" value="0.014 mXe 0.986 Xe"/>
+      <Parameter name="half life" type="double" value="692988.48"/>
+    </ParameterList>
+    <ParameterList name="complex_6">
+      <Parameter name="reactant" type="string" value="mXe"/>
+      <Parameter name="product" type="string" value="1.0 Xe"/>
+      <Parameter name="half life" type="double" value="1022976.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Sb">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="121.760"/>
-  </ParameterList>
-  <ParameterList name="mTe">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="127.60"/>
-  </ParameterList>
-  <ParameterList name="Te">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="127.60"/>
-  </ParameterList>
-  <ParameterList name="I">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="126.90"/>
-  </ParameterList>
-  <ParameterList name="mXe">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="131.293"/>
-  </ParameterList>
-  <ParameterList name="Xe">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="131.293"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="radioactive decay">
-  <ParameterList name="complex_0">
-    <Parameter name="reactant" type="string" value="In"/>
-    <Parameter name="product" type="string" value="0.982 Sn"/>
-    <Parameter name="half life" type="double" value="0.282"/>
-  </ParameterList>
-  <ParameterList name="complex_1">
-    <Parameter name="reactant" type="string" value="Sn"/>
-    <Parameter name="product" type="string" value="1.0 Sb"/>
-    <Parameter name="half life" type="double" value="56.0"/>
-  </ParameterList>
-  <ParameterList name="complex_2">
-    <Parameter name="reactant" type="string" value="Sb"/>
-    <Parameter name="product" type="string" value="0.07 mTe 0.93 Te"/>
-    <Parameter name="half life" type="double" value="1381.8"/>
-  </ParameterList>
-  <ParameterList name="complex_3">
-    <Parameter name="reactant" type="string" value="mTe"/>
-    <Parameter name="product" type="string" value="0.18 Te 0.82 I"/>
-    <Parameter name="half life" type="double" value="116640.0"/>
-  </ParameterList>
-  <ParameterList name="complex_4">
-    <Parameter name="reactant" type="string" value="Te"/>
-    <Parameter name="product" type="string" value="1.0 I"/>
-    <Parameter name="half life" type="double" value="1500.0"/>
-  </ParameterList>
-  <ParameterList name="complex_5">
-    <Parameter name="reactant" type="string" value="I"/>
-    <Parameter name="product" type="string" value="0.014 mXe 0.986 Xe"/>
-    <Parameter name="half life" type="double" value="692988.48"/>
-  </ParameterList>
-  <ParameterList name="complex_6">
-    <Parameter name="reactant" type="string" value="mXe"/>
-    <Parameter name="product" type="string" value="1.0 Xe"/>
-    <Parameter name="half life" type="double" value="1022976.0"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/radioactive-decay-sorbed-tiny.xml
+++ b/src/common/chemistry/test/native/radioactive-decay-sorbed-tiny.xml
@@ -1,32 +1,27 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="C(aq)">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="0.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="C(aq)">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="0.0"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="radioactive decay">
+    <ParameterList name="complex_0">
+      <Parameter name="reactant" type="string" value="C(aq)"/>
+      <Parameter name="product" type="string" value=""/>
+      <Parameter name="half life" type="double" value="1.5779e+8"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="isotherms">
+    <ParameterList name="C(aq)">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{62.5}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="radioactive decay">
-  <ParameterList name="complex_0">
-    <Parameter name="reactant" type="string" value="C(aq)"/>
-    <Parameter name="product" type="string" value=""/>
-    <Parameter name="half life" type="double" value="1.5779e+08"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="isotherms">
-  <ParameterList name="C(aq)">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 62.5 }"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-  </ParameterList>
-</ParameterList>
-
-

--- a/src/common/chemistry/test/native/radioactive-decay-sorbed.xml
+++ b/src/common/chemistry/test/native/radioactive-decay-sorbed.xml
@@ -1,60 +1,55 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="A">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="A">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="ion size parameter" type="double" value="0.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="radioactive decay">
+    <ParameterList name="complex_0">
+      <Parameter name="reactant" type="string" value="A"/>
+      <Parameter name="product" type="string" value="1.0 B"/>
+      <Parameter name="half life" type="double" value="3.9447e+8"/>
+    </ParameterList>
+    <ParameterList name="complex_1">
+      <Parameter name="reactant" type="string" value="B"/>
+      <Parameter name="product" type="string" value="1.0 C"/>
+      <Parameter name="half life" type="double" value="7.8894e+8"/>
+    </ParameterList>
+    <ParameterList name="complex_2">
+      <Parameter name="reactant" type="string" value="C"/>
+      <Parameter name="product" type="string" value=""/>
+      <Parameter name="half life" type="double" value="1.5779e+8"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="ion size parameter" type="double" value="0.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="isotherms">
+    <ParameterList name="A">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{250.0}"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{0.0}"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{62.5}"/>
+    </ParameterList>
   </ParameterList>
-</ParameterList>
-
-<ParameterList name="radioactive decay">
-  <ParameterList name="complex_0">
-    <Parameter name="reactant" type="string" value="A"/>
-    <Parameter name="product" type="string" value="1.0 B"/>
-    <Parameter name="half life" type="double" value="3.9447e+08"/>
-  </ParameterList>
-  <ParameterList name="complex_1">
-    <Parameter name="reactant" type="string" value="B"/>
-    <Parameter name="product" type="string" value="1.0 C"/>
-    <Parameter name="half life" type="double" value="7.8894e+08"/>
-  </ParameterList>
-  <ParameterList name="complex_2">
-    <Parameter name="reactant" type="string" value="C"/>
-    <Parameter name="product" type="string" value=""/>
-    <Parameter name="half life" type="double" value="1.5779e+08"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="isotherms">
-  <ParameterList name="A">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 250.0 }"/>
-  </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 0.0 }"/>
-  </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 62.5 }"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-

--- a/src/common/chemistry/test/native/sorption-isotherms.xml
+++ b/src/common/chemistry/test/native/sorption-isotherms.xml
@@ -1,41 +1,38 @@
 <ParameterList>
-<ParameterList name="primary species">
-  <ParameterList name="A">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="primary species">
+    <ParameterList name="A">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="ion size parameter" type="double" value="1.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="1.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="isotherms">
+    <ParameterList name="A">
+      <Parameter name="model" type="string" value="linear"/>
+      <Parameter name="parameters" type="Array(double)" value="{250.0}"/>
+    </ParameterList>
+    <ParameterList name="B">
+      <Parameter name="model" type="string" value="freundlich"/>
+      <Parameter name="parameters" type="Array(double)" value="{1.25, 0.8}"/>
+    </ParameterList>
+    <ParameterList name="C">
+      <Parameter name="model" type="string" value="langmuir"/>
+      <Parameter name="parameters" type="Array(double)" value="{0.1, 30.0}"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="ion size parameter" type="double" value="1.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value="1.0"/>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="isotherms">
-  <ParameterList name="A">
-    <Parameter name="model" type="string" value="linear"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 250.0 }"/>
-  </ParameterList>
-  <ParameterList name="B">
-    <Parameter name="model" type="string" value="freundlich"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 1.25, 0.8 }"/>
-  </ParameterList>
-  <ParameterList name="C">
-    <Parameter name="model" type="string" value="langmuir"/>
-    <Parameter name="parameters" type="Array(double)" value="{ 0.1, 30.0 }"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-

--- a/src/common/chemistry/test/native/surface-complexation-1.xml
+++ b/src/common/chemistry/test/native/surface-complexation-1.xml
@@ -1,93 +1,88 @@
 <ParameterList name="thermodynamic database">
-<ParameterList name="primary species">
-  <ParameterList name="H+">
-    <Parameter name="ion size parameter" type="double" value="9.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.01"/>
+  <ParameterList name="primary species">
+    <ParameterList name="H+">
+      <Parameter name="ion size parameter" type="double" value="9.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="1.01"/>
+    </ParameterList>
+    <ParameterList name="Na+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="22.99"/>
+    </ParameterList>
+    <ParameterList name="NO3-">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="62.0"/>
+    </ParameterList>
+    <ParameterList name="Zn++">
+      <Parameter name="ion size parameter" type="double" value="6.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="65.39"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Na+">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="22.99"/>
+  <ParameterList name="aqueous equilibrium complexes">
+    <ParameterList name="OH-">
+      <Parameter name="ion size parameter" type="double" value="3.5"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)2(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="99.40470"/>
+      <Parameter name="reaction" type="string" value="2.00 H2O  -2.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="17.32820"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)3-">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="116.41200"/>
+      <Parameter name="reaction" type="string" value="3.00 H2O  -3.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="28.83690"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)4--">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-2"/>
+      <Parameter name="gram molecular weight" type="double" value="133.41940"/>
+      <Parameter name="reaction" type="string" value="4.00 H2O  -4.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="41.60520"/>
+    </ParameterList>
+    <ParameterList name="ZnOH+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="82.39730"/>
+      <Parameter name="reaction" type="string" value="1.00 H2O  -1.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="8.96000"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="NO3-">
-    <Parameter name="ion size parameter" type="double" value="3.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="62.0"/>
+  <ParameterList name="surface complex sites">
+    <ParameterList name="&gt;FeOH_w">
+      <Parameter name="density" type="double" value="76355.0"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Zn++">
-    <Parameter name="ion size parameter" type="double" value="6.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="65.39"/>
+  <ParameterList name="surface complexes">
+    <ParameterList name="&gt;FeOH2+_w">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w  1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="-7.18000"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeO-_w">
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="8.82000"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeOHZn+_w">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w -1.0 H+  1.0 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="2.32000"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="aqueous equilibrium complexes">
-  <ParameterList name="OH-">
-    <Parameter name="ion size parameter" type="double" value="3.5"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)2(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value=" 99.40470"/>
-    <Parameter name="reaction" type="string" value="2.00 H2O  -2.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="17.32820"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)3-">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="116.41200"/>
-    <Parameter name="reaction" type="string" value="3.00 H2O  -3.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="28.83690"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)4--">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-2"/>
-    <Parameter name="gram molecular weight" type="double" value="133.41940"/>
-    <Parameter name="reaction" type="string" value="4.00 H2O  -4.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="41.60520"/>
-  </ParameterList>
-  <ParameterList name="ZnOH+">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="82.39730"/>
-    <Parameter name="reaction" type="string" value="1.00 H2O  -1.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value=" 8.96000"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="surface complex sites">
-  <ParameterList name=">FeOH_w">
-    <Parameter name="density" type="double" value="7.63550E+04"/>
-  </ParameterList>
-</ParameterList>
-<ParameterList name="surface complexes">
-  <ParameterList name=">FeOH2+_w">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w  1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="-7.18000E+00"/>
-  </ParameterList>
-  <ParameterList name=">FeO-_w">
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="8.82000"/>
-  </ParameterList>
-  <ParameterList name=">FeOHZn+_w">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w -1.0 H+  1.0 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="2.32000"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-
-

--- a/src/common/chemistry/test/native/surface-complexation-2.xml
+++ b/src/common/chemistry/test/native/surface-complexation-2.xml
@@ -1,112 +1,106 @@
 <ParameterList name="thermodynamic database">
-<ParameterList name="primary species">
-  <ParameterList name="H+">
-    <Parameter name="ion size parameter" type="double" value="9.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.01"/>
+  <ParameterList name="primary species">
+    <ParameterList name="H+">
+      <Parameter name="ion size parameter" type="double" value="9.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="1.01"/>
+    </ParameterList>
+    <ParameterList name="Na+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="22.99"/>
+    </ParameterList>
+    <ParameterList name="NO3-">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="62.0"/>
+    </ParameterList>
+    <ParameterList name="Zn++">
+      <Parameter name="ion size parameter" type="double" value="6.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="65.39"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Na+">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="22.99"/>
+  <ParameterList name="aqueous equilibrium complexes">
+    <ParameterList name="OH-">
+      <Parameter name="ion size parameter" type="double" value="3.5"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
+      <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)2(aq)">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="0"/>
+      <Parameter name="gram molecular weight" type="double" value="99.40470"/>
+      <Parameter name="reaction" type="string" value="2.00 H2O  -2.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="17.32820"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)3-">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="116.41200"/>
+      <Parameter name="reaction" type="string" value="3.00 H2O  -3.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="28.83690"/>
+    </ParameterList>
+    <ParameterList name="Zn(OH)4--">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="-2"/>
+      <Parameter name="gram molecular weight" type="double" value="133.41940"/>
+      <Parameter name="reaction" type="string" value="4.00 H2O  -4.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="41.60520"/>
+    </ParameterList>
+    <ParameterList name="ZnOH+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="82.39730"/>
+      <Parameter name="reaction" type="string" value="1.00 H2O  -1.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="8.96000"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="NO3-">
-    <Parameter name="ion size parameter" type="double" value="3.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="62.0"/>
+  <ParameterList name="surface complex sites">
+    <ParameterList name="&gt;FeOH_w">
+      <Parameter name="density" type="double" value="76355.0"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeOH_s">
+      <Parameter name="density" type="double" value="1908.00"/>
+    </ParameterList>
   </ParameterList>
-  <ParameterList name="Zn++">
-    <Parameter name="ion size parameter" type="double" value="6.0"/>
-    <Parameter name="charge" type="int" value="2"/>
-    <Parameter name="gram molecular weight" type="double" value="65.39"/>
+  <ParameterList name="surface complexes">
+    <ParameterList name="&gt;FeOH2+_w">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w  1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="-7.18000"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeO-_w">
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w  -1.0 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="8.82000"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeOHZn+_w">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.0 &gt;FeOH_w -1.0 H+  1.0 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="2.32000"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeOH2+_s">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.00 &gt;FeOH_s  1.00 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="-7.1800"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeO-_s">
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="reaction" type="string" value="1.00 &gt;FeOH_s -1.00 H+"/>
+      <Parameter name="equilibrium constant" type="double" value="8.8200"/>
+    </ParameterList>
+    <ParameterList name="&gt;FeOHZn+_s">
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="reaction" type="string" value="1.00 &gt;FeOH_s -1.00 H+  1.00 Zn++"/>
+      <Parameter name="equilibrium constant" type="double" value="-0.660000"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="verbose object">
+    <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="hide line prefix" type="bool" value="true"/>
+    <Parameter name="output filename" type="string" value="batch_native.test"/>
   </ParameterList>
 </ParameterList>
-
-<ParameterList name="aqueous equilibrium complexes">
-  <ParameterList name="OH-">
-    <Parameter name="ion size parameter" type="double" value="3.5"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
-    <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)2(aq)">
-    <Parameter name="ion size parameter" type="double" value="3.0"/>
-    <Parameter name="charge" type="int" value="0"/>
-    <Parameter name="gram molecular weight" type="double" value=" 99.40470"/>
-    <Parameter name="reaction" type="string" value="2.00 H2O  -2.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="17.32820"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)3-">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="gram molecular weight" type="double" value="116.41200"/>
-    <Parameter name="reaction" type="string" value="3.00 H2O  -3.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="28.83690"/>
-  </ParameterList>
-  <ParameterList name="Zn(OH)4--">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="-2"/>
-    <Parameter name="gram molecular weight" type="double" value="133.41940"/>
-    <Parameter name="reaction" type="string" value="4.00 H2O  -4.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="41.60520"/>
-  </ParameterList>
-  <ParameterList name="ZnOH+">
-    <Parameter name="ion size parameter" type="double" value="4.0"/>
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="gram molecular weight" type="double" value="82.39730"/>
-    <Parameter name="reaction" type="string" value="1.00 H2O  -1.00 H+  1.00 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value=" 8.96000"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="surface complex sites">
-  <ParameterList name=">FeOH_w">
-    <Parameter name="density" type="double" value="7.63550E+04"/>
-  </ParameterList>
-  <ParameterList name=">FeOH_s">
-    <Parameter name="density" type="double" value="1.90800E+03"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="surface complexes">
-  <ParameterList name=">FeOH2+_w">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w  1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="-7.18000E+00"/>
-  </ParameterList>
-  <ParameterList name=">FeO-_w">
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w  -1.0 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="8.82000"/>
-  </ParameterList>
-  <ParameterList name=">FeOHZn+_w">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.0 >FeOH_w -1.0 H+  1.0 Zn++"/>
-    <Parameter name="equilibrium constant" type="double" value="2.32000"/>
-  </ParameterList>
-  <ParameterList name=">FeOH2+_s">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.00 >FeOH_s  1.00 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="-7.1800"/>
-  </ParameterList>
-  <ParameterList name=">FeO-_s">
-    <Parameter name="charge" type="int" value="-1"/>
-    <Parameter name="reaction" type="string" value="1.00 >FeOH_s -1.00 H+"/>
-    <Parameter name="equilibrium constant" type="double" value="8.8200"/>
-  </ParameterList>
-  <ParameterList name=">FeOHZn+_s">
-    <Parameter name="charge" type="int" value="1"/>
-    <Parameter name="reaction" type="string" value="1.00 >FeOH_s -1.00 H+  1.00 Zn++ "/>
-    <Parameter name="equilibrium constant" type="double" value="-6.60000E-01"/>
-  </ParameterList>
-</ParameterList>
-
-<ParameterList name="verbose object">
-  <Parameter name="verbosity level" type="string" value="high"/>
-  <Parameter name="hide line prefix" type="bool" value="true"/>
-  <Parameter name="output filename" type="string" value="batch_native.test"/>
-</ParameterList>
-</ParameterList>
-
-

--- a/src/common/interface_platform/test/converter_u_base.cc
+++ b/src/common/interface_platform/test/converter_u_base.cc
@@ -131,7 +131,7 @@ TEST(CONVERTER_BASE)
       Teuchos::XMLObject XMLobj = XMLWriter.toXML(new_xml);
 
       std::stringstream ss;
-      ss << "test" << id.str() << "_native.xml";
+      ss << "converter_u_test" << id.str() << "_native.xml";
       std::ofstream xmlfile;
       xmlfile.open(ss.str().c_str());
       xmlfile << XMLobj;
@@ -139,18 +139,16 @@ TEST(CONVERTER_BASE)
       std::cout << "Successful translation. Validating the result...\n\n";
 
       // development
-      Teuchos::RCP<Teuchos::ParameterList> old_xml;
+      Teuchos::RCP<Teuchos::ParameterList> gold_xml;
       xmlFileName.str("");
       xmlFileName << "test/converter_u_validate" << id.str() << ".xml";
-      old_xml = Teuchos::getParametersFromXmlFile(xmlFileName.str());
-      new_xml.validateParameters(*old_xml);
-      old_xml->validateParameters(new_xml);
-      // new_xml.validateParametersAndSetDefaults(*old_xml);
-      // old_xml->validateParametersAndSetDefaults(new_xml);
+      gold_xml = Teuchos::getParametersFromXmlFile(xmlFileName.str());
+      new_xml.validateParameters(*gold_xml);
+      gold_xml->validateParameters(new_xml);
 
       // data validation
       std::string name;
-      bool flag = ComparePLists(new_xml, *old_xml, name);
+      bool flag = ComparePLists(new_xml, *gold_xml, name);
       if (!flag) {
         std::cout << "Test:" << i << ", error at \"" << name << "\".\n";
         CHECK(false);

--- a/src/common/interface_platform/test/converter_u_validate02.xml
+++ b/src/common/interface_platform/test/converter_u_validate02.xml
@@ -8,21 +8,21 @@
     <Parameter name="concentration" type="string" value="molar"/>
     <Parameter name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{54, 60}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{2.160e+02, 1.200e+02}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{216.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
@@ -35,62 +35,62 @@
     </ParameterList>
     <ParameterList name="Bottom Surface">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.160e+02, 0.0e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.160e+02, 4.000e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 40.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionMiddle">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 4.000e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.160e+02, 8.000e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 40.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 80.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 8.000e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.160e+02, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 80.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_WestOfCribs">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 1.200e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{7.200e+01, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{72.00, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib_17">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{7.200e+01, 1.200e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{8.000e+01, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.00, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{80.00, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_btwnCribs">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{8.000e+01, 1.200e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.360e+02, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{80.00, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{136.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib_18">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.360e+02, 1.200e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.480e+02, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{136.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{148.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Recharge_Boundary_EastOfCribs">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.480e+02, 1.200e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.160e+02, 1.200e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{148.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.080e+02, 4.000e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.120e+02, 6.000e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{108.0, 40.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{112.0, 60.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="ColorRegion">
@@ -100,6 +100,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
@@ -109,7 +110,6 @@
     <Parameter name="file name digits" type="int" value="5"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -122,7 +122,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.6e+03"/>
+                <Parameter name="value" type="double" value="2.6e+3"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -137,7 +137,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.082e-01"/>
+                <Parameter name="value" type="double" value="0.4082"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -146,7 +146,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.206e-01"/>
+                <Parameter name="value" type="double" value="0.2206"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -155,7 +155,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.340e-01"/>
+                <Parameter name="value" type="double" value="0.2340"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -168,7 +168,7 @@
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="liquid water 0-30C"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -179,7 +179,7 @@
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="liquid water 0-30C"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
@@ -199,14 +199,16 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0e+00, -9.80665e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -254,7 +256,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0706e-09"/>
+                  <Parameter name="value" type="double" value="2.0706e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -266,6 +268,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -273,14 +276,15 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
-                <Parameter name="x0" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0e+00, 0.0e+00, -9.7935192e+03}"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
+                <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -291,13 +295,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.0e+00"/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -305,15 +310,17 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.980e+02"/>
+                <Parameter name="value" type="double" value="298.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -329,10 +336,10 @@
             <Parameter name="PK type" type="string" value="richards"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.0e+00"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="6.17266656e+10"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.000e+03"/>
+        <Parameter name="initial timestep" type="double" value="1000.0"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -350,7 +357,7 @@
         <Parameter name="start period time" type="double" value="6.17266656e+10"/>
         <Parameter name="end period time" type="double" value="9.46728e+10"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+00"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
     </ParameterList>
@@ -369,11 +376,13 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="steady:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -384,14 +393,15 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="van Genuchten"/>
           <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973e+00"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973"/>
           <Parameter name="van Genuchten l" type="double" value="0.5"/>
-          <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
           <Parameter name="relative permeability model" type="string" value="Mualem"/>
@@ -403,270 +413,13 @@
         <ParameterList name="WRM_1">
           <Parameter name="water retention model" type="string" value="van Genuchten"/>
           <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.27161749745676511e+00"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten n" type="double" value="1.27161749745676511"/>
           <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.026e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0e+00"/>
-	  <Parameter name="regularization interval" type="double" value="0.0e+00"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	  <ParameterList name="output">
-	    <Parameter name="file" type="string" value="WRM_1.txt"/>
-	    <Parameter name="number of points" type="int" value="1000"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="WRM_2">
-          <Parameter name="water retention model" type="string" value="tabular"/>
-          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-          <Parameter name="cap pressure" type="Array(double)" value="{0.0, 10.0, 100.0, 1000.0}"/>
-          <Parameter name="permeability" type="Array(double)" value="{1.0, 0.7, 0.2, 0.05}"/>
-          <Parameter name="saturation" type="Array(double)" value="{1.0, 0.7, 0.2, 0.05}"/>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="clipping parameters">
-        <Parameter name="maximum correction change" type="double" value="-1.0"/>
-      </ParameterList>
-      <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="time integrator">
-        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-	    <Parameter name="min timestep" type="double" value="1.0e-6"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.000e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
-        <ParameterList name="initialization">
-          <Parameter name="method" type="string" value="saturated solver"/>
-          <Parameter name="linear solver" type="string" value="AztecOO"/>
-          <Parameter name="active wells" type="bool" value="false"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="no flow above water table" type="bool" value="false"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.80665"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="0.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="relative to top" type="bool" value="false"/>
-	    <Parameter name="relative to bottom" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Crib_17}"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, -1.483984012e-06, -1.483984012e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Crib_18}"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -1.483984012e-06, -3.298282386e-03, -1.483984012e-06, -1.483984012e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 3">
-	    <Parameter name="regions" type="Array(string)" value="{Recharge_Boundary_WestOfCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastOfCribs}"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.105107220e-07, -1.483984012e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="verbose object">
-        <Parameter name="verbosity level" type="string" value="high"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="transient:flow and energy">
-      <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:energy}"/>
-      <Parameter name="master PK index" type="int" value="0"/>
-      <Parameter name="domain name" type="string" value="domain"/>
-      <Parameter name="PK type" type="string" value="thermal flow"/>
-      <ParameterList name="physical models and assumptions">
-        <Parameter name="vapor diffusion" type="bool" value="false"/>
-      </ParameterList>
-      <ParameterList name="time integrator">
-        <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
-        <Parameter name="linear solver" type="string" value="AztecOO"/>
-        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-        <ParameterList name="dae constraint">
-          <Parameter name="method" type="string" value="projection"/>
-          <Parameter name="inflow krel correction" type="bool" value="true"/>
-          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-        </ParameterList>
-        <Parameter name="time integration method" type="string" value="BDF1"/>
-        <ParameterList name="BDF1">
-          <Parameter name="timestep controller type" type="string" value="standard"/>
-          <ParameterList name="timestep controller standard parameters">
-            <Parameter name="max iterations" type="int" value="15"/>
-            <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.2"/>
-            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
-          </ParameterList>
-          <Parameter name="solver type" type="string" value="nka"/>
-          <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
-            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.000e+03"/>
-            <Parameter name="max divergent iterations" type="int" value="3"/>
-            <Parameter name="max nka vectors" type="int" value="10"/>
-            <Parameter name="limit iterations" type="int" value="20"/>
-            <Parameter name="modify correction" type="bool" value="false"/>
-          </ParameterList>
-          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          <ParameterList name="verbose object">
-            <Parameter name="verbosity level" type="string" value="high"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="verbose object">
-        <Parameter name="verbosity level" type="string" value="high"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="transient:flow">
-      <Parameter name="domain name" type="string" value="domain"/>
-      <ParameterList name="relative permeability">
-        <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-        <Parameter name="upwind frequency" type="string" value="every timestep"/>
-        <ParameterList name="upwind parameters">
-          <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-          <Parameter name="method" type="string" value="cell-based"/>
-          <Parameter name="polynomial order" type="int" value="1"/>
-          <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="water retention models">
-        <ParameterList name="WRM_0">
-          <Parameter name="water retention model" type="string" value="van Genuchten"/>
-          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973e+00"/>
-          <Parameter name="van Genuchten l" type="double" value="0.5"/>
-          <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.002026"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-          <Parameter name="relative permeability model" type="string" value="Mualem"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
-          <ParameterList name="output">
-            <Parameter name="file" type="string" value="WRM_0.txt"/>
-            <Parameter name="number of points" type="int" value="1000"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="WRM_1">
-          <Parameter name="water retention model" type="string" value="van Genuchten"/>
-          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.27161749745676511e+00"/>
-          <Parameter name="van Genuchten l" type="double" value="0.5"/>
-          <Parameter name="van Genuchten alpha" type="double" value="2.026e-03"/>
-          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="relative permeability model" type="string" value="Mualem"/>
-          <Parameter name="regularization interval" type="double" value="0.0"/>
           <ParameterList name="output">
             <Parameter name="file" type="string" value="WRM_1.txt"/>
             <Parameter name="number of points" type="int" value="1000"/>
@@ -680,12 +433,11 @@
           <Parameter name="saturation" type="Array(double)" value="{1.0, 0.7, 0.2, 0.05}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
-      <ParameterList name="absolute permeability">
-        <Parameter name="coordinate system" type="string" value="cartesian"/>
-      </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -718,6 +470,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -736,14 +489,143 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+          <Parameter name="active wells" type="bool" value="false"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="no flow above water table" type="bool" value="false"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.80665"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="0.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="relative to top" type="bool" value="false"/>
+            <Parameter name="relative to bottom" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Crib_17}"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, -0.000001483984012, -0.000001483984012}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Crib_18}"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.000001483984012, -0.003298282386, -0.000001483984012, -0.000001483984012}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Recharge_Boundary_WestOfCribs, Recharge_Boundary_btwnCribs, Recharge_Boundary_EastOfCribs}"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.105107220e-7, -0.000001483984012}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="transient:flow and energy">
+      <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:energy}"/>
+      <Parameter name="master PK index" type="int" value="0"/>
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="PK type" type="string" value="thermal flow"/>
+      <ParameterList name="physical models and assumptions">
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -759,6 +641,149 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="transient:flow">
+      <Parameter name="domain name" type="string" value="domain"/>
+      <ParameterList name="relative permeability">
+        <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
+          <Parameter name="method" type="string" value="cell-based"/>
+          <Parameter name="polynomial order" type="int" value="1"/>
+          <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM_0">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <ParameterList name="output">
+            <Parameter name="file" type="string" value="WRM_0.txt"/>
+            <Parameter name="number of points" type="int" value="1000"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="WRM_1">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten n" type="double" value="1.27161749745676511"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.002026"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <ParameterList name="output">
+            <Parameter name="file" type="string" value="WRM_1.txt"/>
+            <Parameter name="number of points" type="int" value="1000"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="WRM_2">
+          <Parameter name="water retention model" type="string" value="tabular"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="cap pressure" type="Array(double)" value="{0.0, 10.0, 100.0, 1000.0}"/>
+          <Parameter name="permeability" type="Array(double)" value="{1.0, 0.7, 0.2, 0.05}"/>
+          <Parameter name="saturation" type="Array(double)" value="{1.0, 0.7, 0.2, 0.05}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="clipping parameters">
+        <Parameter name="maximum correction change" type="double" value="-1.0"/>
+      </ParameterList>
+
+      <ParameterList name="absolute permeability">
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="static head">
           <ParameterList name="BC 0">
@@ -771,7 +796,7 @@
               <ParameterList name="function-static-head">
                 <Parameter name="space dimension" type="int" value="2"/>
                 <Parameter name="density" type="double" value="998.2"/>
-                <Parameter name="gravity" type="double" value="9.80664999999999942e+00"/>
+                <Parameter name="gravity" type="double" value="9.80664999999999942"/>
                 <Parameter name="p0" type="double" value="101325.0"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-constant">
@@ -789,7 +814,7 @@
             <ParameterList name="outward mass flux">
               <ParameterList name="function-tabular">
                 <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, -1.48398401199999992e-06, -1.48398401199999992e-06}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, -0.00000148398401199999992, -0.00000148398401199999992}"/>
                 <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
               </ParameterList>
             </ParameterList>
@@ -802,7 +827,7 @@
             <ParameterList name="outward mass flux">
               <ParameterList name="function-tabular">
                 <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.173178481e+10, 6.173705521e+10, 9.4672798e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -1.48398401199999992e-06, -3.298282386e-03, -1.48398401199999992e-06, -1.48398401199999992e-06}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.00000148398401199999992, -0.003298282386, -0.00000148398401199999992, -0.00000148398401199999992}"/>
                 <Parameter name="forms" type="Array(string)" value="{constant, constant, constant, constant}"/>
               </ParameterList>
             </ParameterList>
@@ -815,7 +840,7 @@
             <ParameterList name="outward mass flux">
               <ParameterList name="function-tabular">
                 <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -1.48398401199999992e-06}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.00000148398401199999992}"/>
                 <Parameter name="forms" type="Array(string)" value="{constant}"/>
               </ParameterList>
             </ParameterList>
@@ -825,140 +850,150 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:energy">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="advection operator">
           <Parameter name="single domain" type="bool" value="true"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="TCM_0">
           <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
           <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-          <Parameter name="thermal conductivity of gas" type="double" value="2.0e-02"/>
+          <Parameter name="thermal conductivity of gas" type="double" value="0.020"/>
           <Parameter name="unsaturated alpha" type="double" value="1.0"/>
           <Parameter name="epsilon" type="double" value="1.0e-10"/>
           <Parameter name="thermal conductivity of liquid" type="double" value="0.0"/>
           <Parameter name="thermal conductivity of rock" type="double" value="0.0"/>
-          <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+          <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
         </ParameterList>
         <ParameterList name="TCM_1">
           <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
           <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-          <Parameter name="thermal conductivity of gas" type="double" value="2.0e-02"/>
+          <Parameter name="thermal conductivity of gas" type="double" value="0.020"/>
           <Parameter name="unsaturated alpha" type="double" value="1.0"/>
           <Parameter name="epsilon" type="double" value="1.0e-10"/>
           <Parameter name="thermal conductivity of liquid" type="double" value="0.0"/>
           <Parameter name="thermal conductivity of rock" type="double" value="0.0"/>
-          <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+          <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
         </ParameterList>
         <ParameterList name="TCM_2">
           <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
           <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-          <Parameter name="thermal conductivity of gas" type="double" value="2.0e-02"/>
+          <Parameter name="thermal conductivity of gas" type="double" value="0.020"/>
           <Parameter name="unsaturated alpha" type="double" value="1.0"/>
           <Parameter name="epsilon" type="double" value="1.0e-10"/>
           <Parameter name="thermal conductivity of liquid" type="double" value="0.0"/>
           <Parameter name="thermal conductivity of rock" type="double" value="0.0"/>
-          <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+          <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{energy}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-	    <Parameter name="min timestep" type="double" value="1.0e-6"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.000e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{energy}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
               <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="3"/>
                 <Parameter name="formula" type="string" value="298.0 + 1e-8 * t"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -1013,12 +1048,12 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33333e+00"/>
-        <Parameter name="aggregation: threshold" type="double" value="0.0e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33333"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
         <Parameter name="smoother: sweeps" type="int" value="3"/>
-        <Parameter name="smoother: damping factor" type="double" value="1.0e+00"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: type" type="string" value="Jacobi"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -1028,10 +1063,10 @@
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -1040,9 +1075,9 @@
     <ParameterList name="Block ILU">
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.0e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.0e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>

--- a/src/common/interface_platform/test/converter_u_validate03.xml
+++ b/src/common/interface_platform/test/converter_u_validate03.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -27,7 +26,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
@@ -79,14 +77,14 @@
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{3.29183999999999983e+01, 40.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{3.41375999999999920e+01, 60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{32.9183999999999983, 40.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{34.1375999999999920, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well2">
       <ParameterList name="region: line segment">
-        <Parameter name="end coordinate" type="Array(double)" value="{3.29183999999999983e+01, 3.04799999999999960e-01}"/>
-        <Parameter name="opposite end coordinate" type="Array(double)" value="{3.29183999999999983e+01, 3.38632799999999934e+00}"/>
+        <Parameter name="end coordinate" type="Array(double)" value="{32.9183999999999983, 0.304799999999999960}"/>
+        <Parameter name="opposite end coordinate" type="Array(double)" value="{32.9183999999999983, 3.38632799999999934}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Total_Recharge">
@@ -101,7 +99,6 @@
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -114,9 +111,9 @@
           <ParameterList name="RegionMiddle">
             <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
             <Parameter name="model" type="string" value="standard"/>
-            <Parameter name="fluid compressibility" type="double" value="1.0e-09"/>
-            <Parameter name="matrix compressibility" type="double" value="9.99999999999999955e-08"/>
-            <Parameter name="gravity" type="double" value="9.80664999999999942e+00"/>
+            <Parameter name="fluid compressibility" type="double" value="1.0e-9"/>
+            <Parameter name="matrix compressibility" type="double" value="9.99999999999999955e-8"/>
+            <Parameter name="gravity" type="double" value="9.80664999999999942"/>
             <Parameter name="fluid density" type="double" value="998.2"/>
           </ParameterList>
         </ParameterList>
@@ -145,7 +142,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -178,7 +175,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.34e-01"/>
+                <Parameter name="value" type="double" value="0.234"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -193,7 +190,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -208,7 +205,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.54093810713294515e+04"/>
+                <Parameter name="value" type="double" value="55409.3810713294515"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -223,7 +220,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -232,20 +229,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -259,6 +260,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity_msp">
         <ParameterList name="function">
           <ParameterList name="RegionMiddle">
@@ -290,6 +292,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="exodus file initialization">
@@ -297,9 +300,11 @@
           <Parameter name="attributes" type="Array(string)" value="{permx, permy}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="particle_density">
         <Parameter name="restart file" type="string" value="particle_density.h5"/>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -307,14 +312,15 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -332,18 +338,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
-      </ParameterList>
-    </ParameterList>
 
+      <ParameterList name="atmospheric_pressure">
+        <Parameter name="value" type="double" value="101325.0"/>
+      </ParameterList>
+
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{RegionMiddle, RegionBottom, RegionTop}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -354,7 +360,7 @@
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="6.172666560e+10"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+00"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
       </ParameterList>
@@ -379,315 +385,157 @@
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{Tc-99}"/>
     <Parameter name="number of liquid components" type="int" value="1"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{9.89062549999999985e-02}"/>
+    <Parameter name="component molar masses" type="Array(double)" value="{0.0989062549999999985}"/>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{6.1729344e+10, 9.4672798e+10}"/>
-      <Parameter name="initial timestep" type="Array(double)" value="{1.0e+00, 1.0e+00}"/>
+      <Parameter name="initial timestep" type="Array(double)" value="{1.0, 1.0}"/>
       <Parameter name="maximum timestep" type="Array(double)" value="{4.3234e+17, 4.32340e+17}"/>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-	    <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	  <Parameter name="active wells" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+          <Parameter name="active wells" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-linear">
-		<Parameter name="y0" type="double" value="1.013250e+05"/>
-		<Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-		<Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Crib}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10, 6.17293440e+10, 9.46727980e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, 0.0, -1.483984012e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant, USER_FNC2}"/>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-linear">
+                <Parameter name="y0" type="double" value="101325.0"/>
+                <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Crib}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10, 6.17293440e+10, 9.46727980e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, 0.0, -0.000001483984012}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant, USER_FNC2}"/>
                 <ParameterList name="USER_FNC2">
                   <ParameterList name="function-exprtk">
                     <Parameter name="number of arguments" type="int" value="3"/>
                     <Parameter name="formula" type="string" value="t + x + y"/>
                   </ParameterList>
-                </ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Total_Recharge}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -1.48398401199999992e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="source terms">
-        <ParameterList name="wells">
-          <ParameterList name="Pumping Well">
-            <Parameter name="regions" type="Array(string)" value="{Well}"/>
-            <Parameter name="spatial distribution method" type="string" value="simple well"/>
-            <Parameter name="use volume fractions" type="bool" value="false"/>
-            <ParameterList name="well">
-              <Parameter name="submodel" type="string" value="bhp"/>
-              <Parameter name="well radius" type="double" value="0.1"/>
-              <Parameter name="depth" type="double" value="25.0"/>
-              <ParameterList name="bhp">
-                <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="1.1e+05"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
           </ParameterList>
-	</ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Total_Recharge}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.00000148398401199999992}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-      <ParameterList name="physical models and assumptions">
-	<Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
-      </ParameterList>
-      <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
-      </ParameterList>
-    </ParameterList>
 
-    <ParameterList name="transient:flow and transport">
-      <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:transport}"/>
-      <Parameter name="master PK index" type="int" value="0"/>
-      <Parameter name="PK type" type="string" value="flow reactive transport"/>
-    </ParameterList>
-    <ParameterList name="transient:flow">
-      <Parameter name="domain name" type="string" value="domain"/>
-      <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
-      </ParameterList>
-      <ParameterList name="clipping parameters">
-        <Parameter name="maximum correction change" type="double" value="-1.0"/>
-      </ParameterList>
-      <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="adaptive"/>
-	  <ParameterList name="timestep controller adaptive parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.323400e+17"/>
-	    <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
-	    <Parameter name="relative tolerance" type="double" value="1e-04"/>
-	    <Parameter name="absolute tolerance" type="double" value="10.0"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-linear">
-		<Parameter name="y0" type="double" value="1.013250e+05"/>
-		<Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-		<Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Crib}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10, 6.17293440e+10, 9.46727980e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, 0.0, -1.483984012e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant, USER_FNC2}"/>
-                <ParameterList name="USER_FNC2">
-                  <ParameterList name="function-exprtk">
-                    <Parameter name="number of arguments" type="int" value="3"/>
-                    <Parameter name="formula" type="string" value="t + x + y"/>
-                  </ParameterList>
-                </ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Total_Recharge}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -1.48398401199999992e-06}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
       <ParameterList name="source terms">
         <ParameterList name="wells">
           <ParameterList name="Pumping Well">
@@ -700,27 +548,202 @@
               <Parameter name="depth" type="double" value="25.0"/>
               <ParameterList name="bhp">
                 <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="1.1e+05"/>
+                  <Parameter name="value" type="double" value="1.1e+5"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
-	<Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
+        <Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="transient:flow and transport">
+      <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:transport}"/>
+      <Parameter name="master PK index" type="int" value="0"/>
+      <Parameter name="PK type" type="string" value="flow reactive transport"/>
+
+    </ParameterList>
+
+    <ParameterList name="transient:flow">
+      <Parameter name="domain name" type="string" value="domain"/>
+      <ParameterList name="absolute permeability">
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
+      </ParameterList>
+
+      <ParameterList name="clipping parameters">
+        <Parameter name="maximum correction change" type="double" value="-1.0"/>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="adaptive"/>
+          <ParameterList name="timestep controller adaptive parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.323400e+17"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
+            <Parameter name="relative tolerance" type="double" value="0.0001"/>
+            <Parameter name="absolute tolerance" type="double" value="10.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-linear">
+                <Parameter name="y0" type="double" value="101325.0"/>
+                <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Crib}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10, 6.17293440e+10, 9.46727980e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, 0.0, -0.000001483984012}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant, USER_FNC2}"/>
+                <ParameterList name="USER_FNC2">
+                  <ParameterList name="function-exprtk">
+                    <Parameter name="number of arguments" type="int" value="3"/>
+                    <Parameter name="formula" type="string" value="t + x + y"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Total_Recharge}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.00000148398401199999992}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="source terms">
+        <ParameterList name="wells">
+          <ParameterList name="Pumping Well">
+            <Parameter name="regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="spatial distribution method" type="string" value="simple well"/>
+            <Parameter name="use volume fractions" type="bool" value="false"/>
+            <ParameterList name="well">
+              <Parameter name="submodel" type="string" value="bhp"/>
+              <Parameter name="well radius" type="double" value="0.1"/>
+              <Parameter name="depth" type="double" value="25.0"/>
+              <ParameterList name="bhp">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.1e+5"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="physical models and assumptions">
+        <Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:transport">
       <Parameter name="domain name" type="string" value="domain"/>
-
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="1.0e+00"/>
+      <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="method" type="string" value="fct"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
@@ -734,11 +757,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-09}"/>
-        <Parameter name="molar masses" type="Array(double)" value="{9.89062549999999985e-02}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0989062549999999985}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -757,6 +782,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="multiscale models">
         <ParameterList name="MSM 0">
           <Parameter name="multiscale model" type="string" value="dual porosity"/>
@@ -765,7 +791,7 @@
             <Parameter name="Warren Root parameter" type="double" value="4.0"/>
             <Parameter name="matrix depth" type="double" value="0.8"/>
             <Parameter name="matrix tortuosity" type="double" value="0.9"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.999e-01"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.9999"/>
           </ParameterList>
         </ParameterList>
         <ParameterList name="MSM 1">
@@ -775,7 +801,7 @@
             <Parameter name="number of matrix nodes" type="int" value="2"/>
             <Parameter name="matrix depth" type="double" value="1.0"/>
             <Parameter name="matrix tortuosity" type="double" value="1.0"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.999e-01"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.9999"/>
           </ParameterList>
         </ParameterList>
         <ParameterList name="MSM 2">
@@ -785,10 +811,11 @@
             <Parameter name="number of matrix nodes" type="int" value="3"/>
             <Parameter name="matrix depth" type="double" value="2.0"/>
             <Parameter name="matrix tortuosity" type="double" value="0.8"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.999e-01"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.9999"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Tc-99">
@@ -809,7 +836,7 @@
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
                   <Parameter name="x values" type="Array(double)" value="{0.0, 6.172666560e+10, 6.17293440e+10}"/>
-                  <Parameter name="y values" type="Array(double)" value="{0.0, 1.881389e-06, 0.0}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0.0, 0.000001881389, 0.0}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant, constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -831,6 +858,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -839,10 +867,13 @@
         <Parameter name="use dispersion solver" type="bool" value="true"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -894,7 +925,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
@@ -904,12 +934,12 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
         <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
         <Parameter name="smoother: sweeps" type="int" value="3"/>
-        <Parameter name="smoother: damping factor" type="double" value="1.0e+00"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: type" type="string" value="Jacobi"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -931,16 +961,15 @@
     <ParameterList name="Block ILU">
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.0"/>
         <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{Bottom Surface, Crib, Total_Recharge, Bottom Surface, Crib, Total_Recharge, Bottom Surface, Crib, Total_Recharge}"/>

--- a/src/common/interface_platform/test/converter_u_validate04.xml
+++ b/src/common/interface_platform/test/converter_u_validate04.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -27,7 +26,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="+Z_Boundary">
       <ParameterList name="region: box">
@@ -71,7 +69,6 @@
         <Parameter name="high coordinate" type="Array(double)" value="{9.99999999999999967e+98, 9.99999999999999967e+98, 9.99999999999999967e+98}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="LS1">
       <ParameterList name="region: line segment">
         <Parameter name="end coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
@@ -84,14 +81,10 @@
         <Parameter name="opposite end coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Side">
       <ParameterList name="region: polygon">
         <Parameter name="number of points" type="int" value="4"/>
-        <Parameter name="points" type="Array(double)" value="{100.0, 0.0, 0.0, 
-                                                              100.0, 0.0, 1.0, 
-                                                              100.0, 1.0, 1.0, 
-                                                              100.0, 1.0, 0.0}"/>
+        <Parameter name="points" type="Array(double)" value="{100.0, 0.0, 0.0, 100.0, 0.0, 1.0, 100.0, 1.0, 1.0, 100.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -107,7 +100,7 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-03"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -118,7 +111,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -133,7 +126,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.54093810713294515e+04"/>
+                <Parameter name="value" type="double" value="55409.3810713294515"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -148,7 +141,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -163,7 +156,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.5e-01"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -192,7 +185,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -202,18 +195,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -227,6 +225,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -255,6 +254,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -262,20 +262,23 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="geochemical conditions">
         <ParameterList name="background">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="first_order_decay_constant">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -286,13 +289,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.78577e-09"/>
+                  <Parameter name="value" type="double" value="1.78577e-9"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -303,17 +307,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.8e-01"/>
+                  <Parameter name="value" type="double" value="0.88"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.6e-02"/>
+                  <Parameter name="value" type="double" value="0.016"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.1e-01"/>
+                  <Parameter name="value" type="double" value="0.11"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
@@ -345,6 +349,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -355,17 +360,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="3.2623e+03"/>
+                  <Parameter name="value" type="double" value="3262.3"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.10763e+04"/>
+                  <Parameter name="value" type="double" value="11076.3"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.90939e+04"/>
+                  <Parameter name="value" type="double" value="59093.9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
@@ -397,6 +402,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -407,7 +413,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.3345e+01"/>
+                  <Parameter name="value" type="double" value="-13.345"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -417,7 +423,7 @@
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.2967e+01"/>
+                  <Parameter name="value" type="double" value="-12.967"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
@@ -427,7 +433,7 @@
               </ParameterList>
               <ParameterList name="dof 5 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.15e+01"/>
+                  <Parameter name="value" type="double" value="-11.5"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 6 function">
@@ -442,13 +448,14 @@
               </ParameterList>
               <ParameterList name="dof 8 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.2135e+01"/>
+                  <Parameter name="value" type="double" value="-12.135"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_sites">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -462,6 +469,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="sorption_sites">
         <ParameterList name="function">
           <ParameterList name="MESH BLOCK 1">
@@ -472,29 +480,26 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.56199e-01"/>
+                  <Parameter name="value" type="double" value="0.156199"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="blacklist" type="Array(string)" value="{alquimia_aux.*, free_ion.*, primary.*, secondary.*, ion_exchange_ref.*, mineral_reaction.*, mineral_specific.*}"/>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1556926e+07, 1.57788e+09}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 31556926.0, 1.57788e+9}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -506,7 +511,7 @@
         <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="0.0"/>
         <Parameter name="initial timestep" type="double" value="1.0"/>
-        <Parameter name="maximum timestep" type="double" value="3.15576e+09"/>
+        <Parameter name="maximum timestep" type="double" value="3.15576e+9"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -528,13 +533,12 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.57788e+09"/>
+        <Parameter name="end period time" type="double" value="1.57788e+9"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.5768e+05"/>
-        <Parameter name="maximum timestep" type="double" value="3.15576e+07"/>
+        <Parameter name="initial timestep" type="double" value="1.5768e+5"/>
+        <Parameter name="maximum timestep" type="double" value="3.15576e+7"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
     <Parameter name="number of liquid components" type="int" value="14"/>
     <Parameter name="component molar masses" type="Array(double)" value="{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}"/>
@@ -547,131 +551,139 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.250"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-	    <Parameter name="min timestep" type="double" value="1.0e-06"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-12"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.250"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.3234e+17"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-12"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{-X_Boundary}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="-7.91317859e-06"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{+X_Boundary}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="2.01325e+05"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{-X_Boundary}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-0.00000791317859"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{+X_Boundary}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="201325.0"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow and reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:reactive transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="PK type" type="string" value="flow reactive transport"/>
+
     </ParameterList>
+
     <ParameterList name="transient:reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{transient:chemistry, transient:transport}"/>
       <Parameter name="PK type" type="string" value="reactive transport"/>
+
     </ParameterList>
 
     <ParameterList name="transient:transport">
       <Parameter name="domain name" type="string" value="domain"/>
-
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="1.0"/>
@@ -688,6 +700,7 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="material properties">
         <ParameterList name="Soil">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
@@ -698,11 +711,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-09}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9, 1e-9}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -721,6 +736,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="geochemical">
           <ParameterList name="West BC">
@@ -739,6 +755,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="14"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -746,9 +763,11 @@
         <Parameter name="use dispersion solver" type="bool" value="true"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:chemistry">
@@ -763,13 +782,13 @@
       <Parameter name="tolerance" type="double" value="1.0e-10"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+07"/>
+      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
       <Parameter name="timestep cut factor" type="double" value="2.0"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
       <Parameter name="timestep increase factor" type="double" value="1.2"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
-      <Parameter name="sorption sites" type="Array(string)" value="{>davis_OH}"/>
+      <Parameter name="sorption sites" type="Array(string)" value="{&gt;davis_OH}"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="14"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -777,120 +796,129 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="physics module" type="string" value="Amanzi"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.250"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-	    <Parameter name="min timestep" type="double" value="1e-06"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-12"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.250"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.32340e+17"/>
+            <Parameter name="min timestep" type="double" value="0.000001"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-12"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{-X_Boundary}"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="-7.91317859e-06"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{+X_Boundary}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="2.01325e+05"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{-X_Boundary}"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-0.00000791317859"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{+X_Boundary}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="201325.0"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -950,7 +978,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
@@ -996,7 +1023,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{-X_Boundary, +X_Boundary, -X_Boundary, +X_Boundary, -X_Boundary, +X_Boundary}"/>

--- a/src/common/interface_platform/test/converter_u_validate05.xml
+++ b/src/common/interface_platform/test/converter_u_validate05.xml
@@ -1,28 +1,23 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 2, -1}"/>
   </ParameterList>
-
   <ParameterList name="visualization data fracture">
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 2, -1}"/>
   </ParameterList>
-
   <ParameterList name="mesh info">
     <Parameter name="filename" type="string" value="centroids"/>
   </ParameterList>
-
   <ParameterList name="mesh info fracture">
     <Parameter name="filename" type="string" value="centroids_fracture"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-1.0e+99,-1.0e+99,-1.0e+99}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-1.0e+99, -1.0e+99, -1.0e+99}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0e+99, 1.0e+99, 1.0e+99}"/>
       </ParameterList>
     </ParameterList>
@@ -34,22 +29,22 @@
     </ParameterList>
     <ParameterList name="fracture" type="ParameterList">
       <ParameterList name="region: labeled set" type="ParameterList">
-        <Parameter name="label" type="string" value="100" />
-        <Parameter name="file" type="string" value="single_fracture.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
-        <Parameter name="entity" type="string" value="face" />
+        <Parameter name="label" type="string" value="100"/>
+        <Parameter name="file" type="string" value="single_fracture.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
+        <Parameter name="entity" type="string" value="face"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,90.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 90.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,0.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FRACTURE_NETWORK_INTERNAL">
@@ -64,11 +59,10 @@
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <Parameter name="request edges" type="bool" value="true"/>
-
     <ParameterList name="unstructured">
       <ParameterList name="read mesh file" type="ParameterList">
-        <Parameter name="file" type="string" value="single_fracture.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
+        <Parameter name="file" type="string" value="single_fracture.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
       </ParameterList>
       <ParameterList name="submesh">
         <Parameter name="regions" type="Array(string)" value="{FRACTURE_NETWORK_INTERNAL}"/>
@@ -85,7 +79,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="units">
     <Parameter name="length" type="string" value="m"/>
     <Parameter name="time" type="string" value="s"/>
@@ -94,7 +87,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter name="temperature" type="string" value="K"/>
   </ParameterList>
-  
   <!--ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="single_fracture_ref0.out"/>
     <Parameter name="precision" type="int" value="10"/>
@@ -120,7 +112,6 @@
       <Parameter name="times start period stop 0" type="Array(double)" value="{0, 1e+7, -1}"/>
     </ParameterList>        
   </ParameterList-->
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -142,23 +133,23 @@
         <Parameter name="maximum timestep" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="TP 1">
-	<ParameterList name="PK tree">
+        <ParameterList name="PK tree">
           <ParameterList name="transient:coupled transport">
             <Parameter name="PK type" type="string" value="transport matrix fracture"/>
             <ParameterList name="transient:transport matrix">
               <Parameter name="PK type" type="string" value="transport"/>
             </ParameterList>
             <ParameterList name="transient:transport fracture">
-              <Parameter name="PK type" type="string" value="transport"/> 
+              <Parameter name="PK type" type="string" value="transport"/>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0e+9"/>
-	<Parameter name="initial timestep" type="double" value="1.0e+4"/>        
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0e+9"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
         <Parameter name="maximum timestep" type="double" value="1.0e+7"/>
-        <Parameter name="maximum cycle number" type="int" value="-1"/>        
-      </ParameterList>      
+        <Parameter name="maximum cycle number" type="int" value="-1"/>
+      </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{}"/>
@@ -172,7 +163,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -200,7 +190,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.55092978073827368e+01"/>
+                <Parameter name="value" type="double" value="55.5092978073827368"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -252,7 +242,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -275,7 +264,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.55092978073827368e+01"/>
+                <Parameter name="value" type="double" value="55.5092978073827368"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -336,13 +325,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-4"/>
+                <Parameter name="value" type="double" value="0.00010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -350,7 +338,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -365,7 +353,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -374,20 +362,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
@@ -405,6 +397,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -444,17 +437,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-5"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-5"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-5"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -475,6 +468,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -501,7 +495,7 @@
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
-              </ParameterList>     
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -517,13 +511,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0."/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
+      </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -531,12 +526,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0."/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
         <Parameter name="strong threshold" type="double" value="0.5"/>
@@ -548,9 +542,9 @@
     <ParameterList name="Block ILU">
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.0e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.0e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>
@@ -564,7 +558,7 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
         <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
@@ -577,7 +571,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -627,18 +620,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{steady:flow matrix, steady:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="PK type" type="string" value="darcy matrix fracture"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -648,12 +639,11 @@
             <Parameter name="timestep increase factor" type="double" value="1.0"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
@@ -668,12 +658,10 @@
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
           <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="initialization">
           <Parameter name="method" type="string" value="saturated solver"/>
           <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -684,17 +672,17 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
-
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="clipping parameters">
@@ -702,85 +690,84 @@
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
             <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="4.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="4.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="external aperture" type="bool" value="false"/>
       </ParameterList>
 
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
 
       <ParameterList name="clipping parameters">
@@ -788,56 +775,57 @@
       </ParameterList>
 
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for fracture">
-	  <Parameter name="region" type="string" value="fracture"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	  <Parameter name="aperture" type="double" value="1.0e-04"/>
-	</ParameterList>
+        <ParameterList name="FPM for fracture">
+          <Parameter name="region" type="string" value="fracture"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+          <Parameter name="aperture" type="double" value="0.00010"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled transport">
@@ -846,27 +834,26 @@
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <Parameter name="PK type" type="string" value="transport matrix fracture"/>
-    </ParameterList>
-    
-    <ParameterList name="transient:transport matrix">
-      <Parameter name="domain name" type="string" value="domain"/>      
 
+    </ParameterList>
+
+    <ParameterList name="transient:transport matrix">
+      <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="use dispersion solver" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
 
-      <Parameter name="cfl" type="double" value="1.0"/>   
+      <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="method" type="string" value="muscl"/>
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
+      <Parameter name="transport subcycling" type="bool" value="false"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      <Parameter name="enable internal tests" type="bool" value="false"/>   
-
+      <Parameter name="enable internal tests" type="bool" value="false"/>
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="weight" type="string" value="constant"/>
@@ -897,7 +884,7 @@
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <Parameter name="number of aqueous components" type="int" value="1"/>
@@ -909,23 +896,24 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="tracer">
-	    <ParameterList name="FrontBC">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="tracer">
+            <ParameterList name="FrontBC">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
               <Parameter name="use area fractions" type="bool" value="false"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-constant">
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="1.0"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-    </ParameterList>      
-      
+
+    </ParameterList>
+
     <ParameterList name="transient:transport fracture">
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
@@ -934,17 +922,16 @@
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
 
-      <Parameter name="domain name" type="string" value="fracture"/>      
-      <Parameter name="cfl" type="double" value="1.0"/>   
+      <Parameter name="domain name" type="string" value="fracture"/>
+      <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="method" type="string" value="muscl"/>
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      <Parameter name="enable internal tests" type="bool" value="false"/>   
-
+      <Parameter name="enable internal tests" type="bool" value="false"/>
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="molecular diffusion">
@@ -962,7 +949,7 @@
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -985,7 +972,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="analysis">

--- a/src/common/interface_platform/test/converter_u_validate06.xml
+++ b/src/common/interface_platform/test/converter_u_validate06.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -33,27 +32,25 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,    0.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,   0.0,  90.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 90.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,  0.0,  0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="fracture">
       <ParameterList name="region: labeled set">
         <Parameter name="file" type="string" value="single_fracture.exo"/>
@@ -65,7 +62,7 @@
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-1.0e+99, -1.0e+99, -1.0e+99}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+99,  1.0e+99,  1.0e+99}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+99, 1.0e+99, 1.0e+99}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FRACTURE_NETWORK_INTERNAL">
@@ -103,7 +100,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.55092978073827368e+01"/>
+                <Parameter name="value" type="double" value="55.5092978073827368"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -163,7 +160,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.55092978073827368e+01"/>
+                <Parameter name="value" type="double" value="55.5092978073827368"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -178,7 +175,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.0e-03"/>
+                <Parameter name="value" type="double" value="0.0040"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -246,7 +243,6 @@
         <Parameter name="number of dofs" type="int" value="1"/>
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
-
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -254,7 +250,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -269,7 +265,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -278,17 +274,20 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
@@ -306,6 +305,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -331,23 +331,24 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-05"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-05"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-05"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -361,6 +362,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -374,6 +376,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -391,6 +394,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -404,6 +408,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -425,6 +430,7 @@
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -432,7 +438,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -478,13 +483,12 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.0e+09"/>
+        <Parameter name="end period time" type="double" value="1.0e+9"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+04"/>
-        <Parameter name="maximum timestep" type="double" value="1.0e+07"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
+        <Parameter name="maximum timestep" type="double" value="1.0e+7"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
     <Parameter name="number of liquid components" type="int" value="1"/>
     <Parameter name="component molar masses" type="Array(double)" value="{1.0}"/>
@@ -497,18 +501,16 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{steady:flow matrix, steady:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="PK type" type="string" value="darcy matrix fracture"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -518,14 +520,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.0"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -547,88 +549,95 @@
           <Parameter name="active wells" type="bool" value="false"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
             <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="4.0e+00"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="use area fractions" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="4.0"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="use area fractions" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow fracture">
@@ -636,74 +645,82 @@
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for fracture">
-	  <Parameter name="region" type="string" value="fracture"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	  <Parameter name="aperture" type="double" value="0.0"/>
-	</ParameterList>
+        <ParameterList name="FPM for fracture">
+          <Parameter name="region" type="string" value="fracture"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+          <Parameter name="aperture" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="external aperture" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
-	<Parameter name="coordinate system" type="string" value="cartesian"/>
+        <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{transient:coupled chemistry, transient:coupled transport}"/>
       <Parameter name="master PK index" type="int" value="1"/>
       <Parameter name="PK type" type="string" value="reactive transport matrix fracture"/>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled chemistry">
       <Parameter name="PKs order" type="Array(string)" value="{transient:chemistry matrix, transient:chemistry fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="PK type" type="string" value="chemistry matrix fracture"/>
+
     </ParameterList>
 
     <ParameterList name="transient:chemistry matrix">
@@ -714,7 +731,7 @@
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+07"/>
+      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
       <Parameter name="timestep cut factor" type="double" value="2.0"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
@@ -724,13 +741,14 @@
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="false"/>
       <Parameter name="convergence criterion" type="string" value="linear algebra: max norm"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="physics module" type="string" value="Amanzi"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:chemistry fracture">
@@ -741,9 +759,9 @@
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+07"/>
+      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.0"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
       <Parameter name="timestep increase factor" type="double" value="1.2"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
@@ -751,13 +769,14 @@
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="false"/>
       <Parameter name="convergence criterion" type="string" value="linear algebra: max norm"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="physics module" type="string" value="Amanzi"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled transport">
@@ -766,6 +785,7 @@
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <Parameter name="PK type" type="string" value="transport matrix fracture"/>
+
     </ParameterList>
 
     <ParameterList name="transient:transport matrix">
@@ -786,11 +806,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tritium}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-09}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -799,7 +821,7 @@
             <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
             <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
             <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
           </ParameterList>
           <ParameterList name="preconditioner">
             <Parameter name="discretization primary" type="string" value="mfd: optimized for monotonicity"/>
@@ -807,7 +829,7 @@
             <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
             <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
             <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -819,7 +841,7 @@
               <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-03"/>
+                  <Parameter name="value" type="double" value="0.0010"/>
                 </ParameterList>
               </ParameterList>
               <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -828,6 +850,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -835,9 +858,11 @@
         <Parameter name="use dispersion solver" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:transport fracture">
@@ -851,7 +876,6 @@
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <Parameter name="enable internal tests" type="bool" value="false"/>
       <Parameter name="transport subcycling" type="bool" value="true"/>
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="weight" type="string" value="constant"/>
@@ -859,11 +883,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tritium}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-09}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -884,6 +910,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -892,10 +919,13 @@
         <Parameter name="permeability field is required" type="bool" value="false"/>
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -947,7 +977,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
@@ -993,7 +1022,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="A">
@@ -1030,21 +1058,20 @@
       <ParameterList name="complex_0">
         <Parameter name="reactant" type="string" value="A"/>
         <Parameter name="product" type="string" value="1.0 B"/>
-        <Parameter name="half life" type="double" value="3.9447e+08"/>
+        <Parameter name="half life" type="double" value="3.9447e+8"/>
       </ParameterList>
       <ParameterList name="complex_1">
         <Parameter name="reactant" type="string" value="B"/>
         <Parameter name="product" type="string" value="1.0 C"/>
-        <Parameter name="half life" type="double" value="7.8894e+08"/>
+        <Parameter name="half life" type="double" value="7.8894e+8"/>
       </ParameterList>
       <ParameterList name="complex_2">
         <Parameter name="reactant" type="string" value="C"/>
         <Parameter name="product" type="string" value=""/>
-        <Parameter name="half life" type="double" value="1.57788e+08"/>
+        <Parameter name="half life" type="double" value="1.57788e+8"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{SurfaceInlet, SurfaceOutlet, SurfaceInlet, SurfaceOutlet}"/>
@@ -1055,21 +1082,17 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 2, -1}"/>
   </ParameterList>
-
   <ParameterList name="visualization data fracture">
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 2, -1}"/>
   </ParameterList>
-
   <ParameterList name="mesh info">
     <Parameter isUsed="true" name="filename" type="string" value="centroids"/>
   </ParameterList>
-
   <ParameterList name="mesh info fracture">
     <Parameter name="filename" type="string" value="centroids_fracture"/>
   </ParameterList>

--- a/src/common/interface_platform/test/converter_u_validate07.xml
+++ b/src/common/interface_platform/test/converter_u_validate07.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -16,7 +15,7 @@
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{54, 60}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{2.16e+02, 1.2e+02}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{216.0, 1.2e+2}"/>
       </ParameterList>
       <ParameterList name="submesh">
         <Parameter name="regions" type="Array(string)" value="{FRACTURE_NETWORK_INTERNAL}"/>
@@ -29,6 +28,7 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
@@ -36,25 +36,25 @@
     <ParameterList name="Bottom Surface">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16e+02, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16e+02, 1.2e+02}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 1.2e+2}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{7.2e+01, 1.2e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{8.0e+01, 1.2e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.0, 1.2e+2}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{80.0, 1.2e+2}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.08e+02, 4.0e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.12e+02, 6.0e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{108.0, 40.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{112.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -83,7 +83,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.20599999999999991e-01"/>
+                <Parameter name="value" type="double" value="0.220599999999999991"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -92,7 +92,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.99999999999999989e-01"/>
+                <Parameter name="value" type="double" value="0.299999999999999989"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -136,20 +136,20 @@
             <Parameter name="regions" type="Array(string)" value="{TopRegion}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="lookup table"/>
-              <Parameter name="heat capacity" type="double" value="7.60999999999999943e+01"/>
+              <Parameter name="heat capacity" type="double" value="76.0999999999999943"/>
               <Parameter name="table name" type="string" value="h2o.eos"/>
               <Parameter name="field name" type="string" value="internal_energy"/>
-              <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+              <Parameter name="molar mass" type="double" value="0.018015"/>
             </ParameterList>
           </ParameterList>
           <ParameterList name="BottomRegion">
             <Parameter name="regions" type="Array(string)" value="{BottomRegion}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="lookup table"/>
-              <Parameter name="heat capacity" type="double" value="7.62000000000000028e+01"/>
+              <Parameter name="heat capacity" type="double" value="76.2000000000000028"/>
               <Parameter name="table name" type="string" value="h2o.eos"/>
               <Parameter name="field name" type="string" value="internal_energy"/>
-              <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+              <Parameter name="molar mass" type="double" value="0.018015"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -181,7 +181,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.0e-03"/>
+                <Parameter name="value" type="double" value="0.0040"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -196,7 +196,7 @@
           <Parameter name="eos type" type="string" value="lookup table"/>
           <Parameter name="table name" type="string" value="h2o.eos"/>
           <Parameter name="field name" type="string" value="density"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -209,13 +209,12 @@
           <Parameter name="eos type" type="string" value="lookup table"/>
           <Parameter name="table name" type="string" value="h2o.eos"/>
           <Parameter name="field name" type="string" value="density"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
         <Parameter name="eos basis" type="string" value="both"/>
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
@@ -223,7 +222,7 @@
           <Parameter name="eos type" type="string" value="lookup table"/>
           <Parameter name="table name" type="string" value="h2o.eos"/>
           <Parameter name="field name" type="string" value="viscosity"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
@@ -234,11 +233,10 @@
           <Parameter name="eos type" type="string" value="lookup table"/>
           <Parameter name="table name" type="string" value="h2o.eos"/>
           <Parameter name="field name" type="string" value="viscosity"/>
-          <Parameter name="molar mass" type="double" value="1.8015e-02"/>
+          <Parameter name="molar mass" type="double" value="0.018015"/>
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -270,14 +268,16 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -319,6 +319,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -332,6 +333,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -339,14 +341,15 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -364,6 +367,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -371,15 +375,17 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.01325e+05"/>
+                <Parameter name="value" type="double" value="101325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -393,6 +399,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -406,6 +413,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -419,6 +427,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -432,6 +441,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -465,7 +475,7 @@
         <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="6.17266656e+10"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+03"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+3"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -513,8 +523,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{steady:flow matrix, steady:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -536,14 +546,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -565,9 +575,11 @@
           <Parameter name="active wells" type="bool" value="false"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow matrix">
@@ -575,12 +587,15 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -616,12 +631,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="static head">
           <ParameterList name="BC 0">
@@ -635,7 +652,7 @@
                 <Parameter name="space dimension" type="int" value="2"/>
                 <Parameter name="density" type="double" value="998.2"/>
                 <Parameter name="gravity" type="double" value="9.80664999999999942"/>
-                <Parameter name="p0" type="double" value="1.01325e+05"/>
+                <Parameter name="p0" type="double" value="101325.0"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-constant">
                     <Parameter name="value" type="double" value="0.0"/>
@@ -652,7 +669,7 @@
             <ParameterList name="outward mass flux">
               <ParameterList name="function-tabular">
                 <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, -1.483984012e-06, -1.483984012e-06}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, -0.000001483984012, -0.000001483984012}"/>
                 <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
               </ParameterList>
             </ParameterList>
@@ -662,9 +679,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="steady:flow fracture">
@@ -672,6 +691,7 @@
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for fracture">
           <Parameter name="region" type="string" value="fracture"/>
@@ -679,14 +699,17 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
         <Parameter name="external aperture" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -719,15 +742,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled flow and energy">
@@ -737,6 +763,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -750,14 +777,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -773,9 +800,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow and energy">
@@ -787,15 +816,18 @@
         <Parameter name="vapor diffusion" type="bool" value="false"/>
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -803,9 +835,11 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -816,12 +850,13 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="Brooks Corey"/>
           <Parameter name="regions" type="Array(string)" value="{TopRegion}"/>
-          <Parameter name="Brooks Corey lambda" type="double" value="2.136e-01"/>
-          <Parameter name="Brooks Corey alpha" type="double" value="2.026e-03"/>
+          <Parameter name="Brooks Corey lambda" type="double" value="0.2136"/>
+          <Parameter name="Brooks Corey alpha" type="double" value="0.002026"/>
           <Parameter name="Brooks Corey l" type="double" value="0.5"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -834,8 +869,8 @@
         <ParameterList name="WRM_1">
           <Parameter name="water retention model" type="string" value="Brooks Corey"/>
           <Parameter name="regions" type="Array(string)" value="{BottomRegion}"/>
-          <Parameter name="Brooks Corey lambda" type="double" value="2.136e-01"/>
-          <Parameter name="Brooks Corey alpha" type="double" value="2.026e-03"/>
+          <Parameter name="Brooks Corey lambda" type="double" value="0.2136"/>
+          <Parameter name="Brooks Corey alpha" type="double" value="0.002026"/>
           <Parameter name="Brooks Corey l" type="double" value="0.5"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -846,9 +881,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -884,12 +921,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="static head">
           <ParameterList name="BC 0">
@@ -903,7 +942,7 @@
                 <Parameter name="space dimension" type="int" value="2"/>
                 <Parameter name="density" type="double" value="998.2"/>
                 <Parameter name="gravity" type="double" value="9.80664999999999942"/>
-                <Parameter name="p0" type="double" value="1.01325e+05"/>
+                <Parameter name="p0" type="double" value="101325.0"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-constant">
                     <Parameter name="value" type="double" value="0.0"/>
@@ -920,7 +959,7 @@
             <ParameterList name="outward mass flux">
               <ParameterList name="function-tabular">
                 <Parameter name="x values" type="Array(double)" value="{0.0, 6.17266656e+10, 6.1729344e+10, 9.4672798e+10}"/>
-                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-07, -2.535647604e-03, -1.483984012e-06, -1.483984012e-06}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10510722e-7, -0.002535647604, -0.000001483984012, -0.000001483984012}"/>
                 <Parameter name="forms" type="Array(string)" value="{constant, constant, constant}"/>
               </ParameterList>
             </ParameterList>
@@ -930,15 +969,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:energy">
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
@@ -968,19 +1010,20 @@
           <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="TCM_0">
           <Parameter name="regions" type="Array(string)" value="{TopRegion}"/>
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
           </ParameterList>
           <ParameterList name="liquid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
             <Parameter name="Sutherland constant" type="double" value="0.0"/>
           </ParameterList>
         </ParameterList>
@@ -989,23 +1032,25 @@
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
           </ParameterList>
           <ParameterList name="liquid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
             <Parameter name="Sutherland constant" type="double" value="0.0"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -1020,12 +1065,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="false"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="false"/>
@@ -1033,9 +1080,11 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow and energy fracture">
@@ -1047,15 +1096,18 @@
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow fracture">
@@ -1063,6 +1115,7 @@
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for fracture">
           <Parameter name="region" type="string" value="fracture"/>
@@ -1070,10 +1123,12 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -1084,12 +1139,13 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="Brooks Corey"/>
           <Parameter name="regions" type="Array(string)" value="{TopRegion}"/>
-          <Parameter name="Brooks Corey lambda" type="double" value="2.136e-01"/>
-          <Parameter name="Brooks Corey alpha" type="double" value="2.026e-03"/>
+          <Parameter name="Brooks Corey lambda" type="double" value="0.2136"/>
+          <Parameter name="Brooks Corey alpha" type="double" value="0.002026"/>
           <Parameter name="Brooks Corey l" type="double" value="0.5"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -1102,8 +1158,8 @@
         <ParameterList name="WRM_1">
           <Parameter name="water retention model" type="string" value="Brooks Corey"/>
           <Parameter name="regions" type="Array(string)" value="{BottomRegion}"/>
-          <Parameter name="Brooks Corey lambda" type="double" value="2.136e-01"/>
-          <Parameter name="Brooks Corey alpha" type="double" value="2.026e-03"/>
+          <Parameter name="Brooks Corey lambda" type="double" value="0.2136"/>
+          <Parameter name="Brooks Corey alpha" type="double" value="0.002026"/>
           <Parameter name="Brooks Corey l" type="double" value="0.5"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -1114,19 +1170,22 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture aperture models">
         <ParameterList name="FAM 0">
           <Parameter name="regions" type="Array(string)" value="{fracture}"/>
           <Parameter name="fracture aperture model" type="string" value="Barton-Bandis"/>
-          <Parameter name="undeformed aperture" type="double" value="1.0e-05"/>
-          <Parameter name="overburden pressure" type="double" value="1.0e+07"/>
+          <Parameter name="undeformed aperture" type="double" value="0.000010"/>
+          <Parameter name="overburden pressure" type="double" value="1.0e+7"/>
           <Parameter name="BartonBandis A" type="double" value="9.99999999999999939e-12"/>
-          <Parameter name="BartonBandis B" type="double" value="0.0e+00"/>
+          <Parameter name="BartonBandis B" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1159,15 +1218,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:energy fracture">
@@ -1176,6 +1238,7 @@
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="eos lookup table" type="string" value="h2o.eos"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1196,29 +1259,32 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="TCM_0">
           <Parameter name="regions" type="Array(string)" value="{fracture}"/>
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
           </ParameterList>
           <ParameterList name="liquid phase">
             <Parameter name="eos type" type="string" value=""/>
-            <Parameter name="reference conductivity" type="double" value="0.00000000000000000e+00"/>
-            <Parameter name="reference temperature" type="double" value="2.73149999999999977e+02"/>
+            <Parameter name="reference conductivity" type="double" value="0e-17"/>
+            <Parameter name="reference temperature" type="double" value="273.149999999999977"/>
             <Parameter name="Sutherland constant" type="double" value="0.0"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="source terms">
         <ParameterList name="Extraction Well">
           <Parameter name="regions" type="Array(string)" value="{Well}"/>
@@ -1226,17 +1292,19 @@
           <Parameter name="use volume fractions" type="bool" value="false"/>
           <ParameterList name="well">
             <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.2e+03"/>
+              <Parameter name="value" type="double" value="1.2e+3"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="false"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="false"/>
@@ -1244,10 +1312,13 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -1320,7 +1391,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>

--- a/src/common/interface_platform/test/converter_u_validate08.xml
+++ b/src/common/interface_platform/test/converter_u_validate08.xml
@@ -8,12 +8,10 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{6.172666560e+10, 1.31490e+06, 6.18528960e+10}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{6.172666560e+10, 1.31490e+6, 6.18528960e+10}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -54,7 +52,6 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -71,7 +68,7 @@
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{H2, H2}"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{2.0e-03, 2.0e-03}"/>
+    <Parameter name="component molar masses" type="Array(double)" value="{0.0020, 0.0020}"/>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{0.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{1.0}"/>
@@ -81,320 +78,316 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="transient:multiphase">
-    <Parameter name="domain name" type="string" value="domain"/>
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES for Newton-0"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-
-    <Parameter name="evaluators" type="Array(string)" value="{
-       ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, 
-       advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor,
-       mole_fraction_liquid, mole_fraction_vapor, adv_energy_liquid}"/>
-
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-        </ParameterList>
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-      </ParameterList>
-      <ParameterList name="solute eqn">
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 2">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 3">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="mole_fraction_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-        </ParameterList>
-        <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-      </ParameterList>
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
-      </ParameterList>
-      <ParameterList name="energy eqn">
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="adv_energy_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 2">
-            <Parameter name="coefficient" type="string" value="thermal_conductivity"/>
-            <Parameter name="argument" type="string" value="temperature"/>
-            <Parameter name="scaling factor" type="double" value="1.00000000000000000e+00"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-        </ParameterList>
-        <Parameter name="primary unknown" type="string" value="temperature"/>
-        <Parameter name="accumulation" type="string" value="energy"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="aqueous names" type="Array(string)" value="{H2}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-
-      <Parameter name="gaseous names" type="Array(string)" value="{H2}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5}"/>
-      <Parameter name="gaseous models" type="Array(string)" value="{Henry}"/>
-      <Parameter name="air-water partitioning coefficient" type="Array(double)" value="{1.39e-10}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
-    </ParameterList>
-
-    <Parameter name="number of aqueous components" type="int" value="1"/>
-    <Parameter name="number of gaseous components" type="int" value="1"/>
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <ParameterList name="thermal conductivity evaluator">
-      <ParameterList name="thermal conductivity parameters">
-        <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-        <Parameter name="thermal conductivity of gas" type="double" value="2.0e-02"/>
-        <Parameter name="unsaturated alpha" type="double" value="1.0"/>
-        <Parameter name="epsilon" type="double" value="1.0e-10"/>
-        <Parameter name="thermal conductivity of liquid" type="double" value="6.06e-01"/>
-        <Parameter name="thermal conductivity of rock" type="double" value="2.0e-01"/>
-        <Parameter name="reference temperature" type="double" value="2.7315e+02"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM_0">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49000208600292017"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-07"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.01"/>
-        <Parameter name="regularization interval pc" type="double" value="0.01"/>
-        <ParameterList name="output">
-          <Parameter name="file" type="string" value="WRM_0.txt"/>
-          <Parameter name="number of points" type="int" value="1000"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+    <!-- no shift -->
+    <ParameterList name="transient:multiphase">
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
       <Parameter name="linear solver" type="string" value="GMRES for Newton-0"/>
-      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      <Parameter name="preconditioner enhancement" type="string" value="GMRES for Newton-0"/>
-
-      <ParameterList name="dae constraint">
-        <Parameter name="method" type="string" value="projection"/>
-        <Parameter name="inflow krel correction" type="bool" value="true"/>
-        <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, mole_fraction_liquid, mole_fraction_vapor, adv_energy_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 2">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 3">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="mole_fraction_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+        <ParameterList name="energy eqn">
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="adv_energy_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 2">
+              <Parameter name="coefficient" type="string" value="thermal_conductivity"/>
+              <Parameter name="argument" type="string" value="temperature"/>
+              <Parameter name="scaling factor" type="double" value="1.00000000000000000"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="primary unknown" type="string" value="temperature"/>
+          <Parameter name="accumulation" type="string" value="energy"/>
+        </ParameterList>
       </ParameterList>
 
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.2"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-          <Parameter name="min timestep" type="double" value="1.0e-6"/>
-        </ParameterList>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="aqueous names" type="Array(string)" value="{H2}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous names" type="Array(string)" value="{H2}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030}"/>
+        <Parameter name="gaseous models" type="Array(string)" value="{Henry}"/>
+        <Parameter name="air-water partitioning coefficient" type="Array(double)" value="{1.39e-10}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
+      </ParameterList>
 
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <!--Parameter name="make one iteration" type="bool" value="true"/-->
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
+      <Parameter name="number of aqueous components" type="int" value="1"/>
+      <Parameter name="number of gaseous components" type="int" value="1"/>
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <ParameterList name="thermal conductivity evaluator">
+        <ParameterList name="thermal conductivity parameters">
+          <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
+          <Parameter name="thermal conductivity of gas" type="double" value="0.020"/>
+          <Parameter name="unsaturated alpha" type="double" value="1.0"/>
+          <Parameter name="epsilon" type="double" value="1.0e-10"/>
+          <Parameter name="thermal conductivity of liquid" type="double" value="0.606"/>
+          <Parameter name="thermal conductivity of rock" type="double" value="0.20"/>
+          <Parameter name="reference temperature" type="double" value="273.15"/>
         </ParameterList>
       </ParameterList>
+
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM_0">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49000208600292017"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.01"/>
+          <Parameter name="regularization interval pc" type="double" value="0.01"/>
+          <ParameterList name="output">
+            <Parameter name="file" type="string" value="WRM_0.txt"/>
+            <Parameter name="number of points" type="int" value="1000"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+        <Parameter name="linear solver" type="string" value="GMRES for Newton-0"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="preconditioner enhancement" type="string" value="GMRES for Newton-0"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.32340e+17"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <!--Parameter name="make one iteration" type="bool" value="true"/-->
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="H2"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.415588510e-10"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 0">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="H2"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.415588510e-10"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
+  </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-            <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-          <Parameter name="gravity" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-          <Parameter name="gravity" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="vapor matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="gravity" type="bool" value="true"/>
-          <Parameter name="exclude primary terms" type="bool" value="false"/>
-          <Parameter name="scaled constraint equation" type="bool" value="false"/>
-          <Parameter name="Newton correction" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-          <Parameter name="gravity" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-          <Parameter name="gravity" type="bool" value="true"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
-
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_gas_viscosity">
-        <Parameter name="value" type="double" value="9.0e-6"/>
+        <Parameter name="value" type="double" value="0.0000090"/>
       </ParameterList>
 
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
 
       <ParameterList name="pressure_liquid">
@@ -480,8 +473,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp mole fraction gas"/>
@@ -508,7 +501,6 @@
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
         <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
@@ -527,7 +519,6 @@
         <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
         <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, molar_density_liquid}"/>
@@ -546,7 +537,6 @@
         <Parameter name="powers" type="Array(int)" value="{1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_liquid">
         <Parameter name="evaluator type" type="string" value="mole fraction liquid"/>
         <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
@@ -560,7 +550,6 @@
         <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="adv_energy_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
         <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, enthalpy_liquid, viscosity_liquid}"/>
@@ -573,7 +562,6 @@
         <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="pressure key" type="string" value="pressure_liquid"/>
       </ParameterList>
@@ -583,7 +571,6 @@
       <ParameterList name="internal_energy_rock">
         <Parameter name="pressure key" type="string" value="pressure_liquid"/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="constant in time" type="bool" value="true"/>
@@ -599,17 +586,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="liquid water FEHM"/>
-          <Parameter name="molar mass" type="double" value="1.80149999999999998e-02"/>
-          <Parameter name="density" type="double" value="9.98200000000000045e+02"/>
+          <Parameter name="molar mass" type="double" value="0.0180149999999999998"/>
+          <Parameter name="density" type="double" value="998.200000000000045"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="constant in time" type="bool" value="true"/>
@@ -619,13 +604,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-06"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -634,24 +618,22 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.89646999999999995e-02"/>
+          <Parameter name="molar mass" type="double" value="0.0289646999999999995"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="liquid water FEHM"/>
-          <Parameter name="molar mass" type="double" value="1.80149999999999998e-02"/>
-          <Parameter name="density" type="double" value="9.98200000000000045e+02"/>
+          <Parameter name="molar mass" type="double" value="0.0180149999999999998"/>
+          <Parameter name="density" type="double" value="998.200000000000045"/>
         </ParameterList>
         <Parameter name="eos basis" type="string" value="both"/>
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
         <Parameter name="pressure key" type="string" value="pressure_liquid"/>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="constant in time" type="bool" value="true"/>
@@ -667,7 +649,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="constant in time" type="bool" value="true"/>
@@ -677,13 +658,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -691,7 +671,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.6e+03"/>
+                <Parameter name="value" type="double" value="2.6e+3"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -700,14 +680,12 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
@@ -735,7 +713,7 @@
     <ParameterList name="GMRES for Newton-0">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
-        <Parameter name="error tolerance" type="double" value="1.0e-07"/>
+        <Parameter name="error tolerance" type="double" value="1.0e-7"/>
         <Parameter name="maximum number of iterations" type="int" value="50"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, relative residual}"/>
         <Parameter name="controller training start" type="int" value="0"/>
@@ -754,7 +732,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -765,7 +742,7 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
         <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
@@ -808,7 +785,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{Outflow, Inflow, Outflow}"/>

--- a/src/common/interface_platform/test/converter_u_validate09.xml
+++ b/src/common/interface_platform/test/converter_u_validate09.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -33,7 +32,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="TopSurface">
       <ParameterList name="region: box">
@@ -82,7 +80,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.54093810713294515e+04"/>
+                <Parameter name="value" type="double" value="55409.3810713294515"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -97,7 +95,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -127,7 +125,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -137,18 +135,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -177,6 +180,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="surface-ponded_depth">
         <ParameterList name="function">
           <ParameterList name="TopSurface">
@@ -191,9 +195,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -201,12 +207,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter isUsed="true" name="file name base" type="string" value="plot"/>
     <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 40.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -215,10 +219,10 @@
             <Parameter name="PK type" type="string" value="richards"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="-3.15576e+08"/>
+        <Parameter name="start period time" type="double" value="-3.15576e+8"/>
         <Parameter name="end period time" type="double" value="0.0"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+04"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -236,7 +240,7 @@
         <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="40.0"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-02"/>
+        <Parameter name="initial timestep" type="double" value="0.010"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
     </ParameterList>
@@ -251,8 +255,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="steady:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -265,14 +269,15 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="van Genuchten"/>
           <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.294e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973e+00"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2294"/>
+          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973"/>
           <Parameter name="van Genuchten l" type="double" value="0.5"/>
-          <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="relative permeability model" type="string" value="Mualem"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -282,12 +287,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -320,6 +328,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -338,14 +347,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.25"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -361,13 +370,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{TopSurface}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -375,9 +385,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow and shallow water">
@@ -402,14 +414,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.25"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -425,10 +437,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -441,14 +456,15 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="van Genuchten"/>
           <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973e+00"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten n" type="double" value="1.29769011160134973"/>
           <Parameter name="van Genuchten l" type="double" value="0.5"/>
-          <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
           <Parameter name="relative permeability model" type="string" value="Mualem"/>
           <Parameter name="regularization interval" type="double" value="0.0"/>
@@ -458,12 +474,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -496,6 +515,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -514,14 +534,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.25"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -537,13 +557,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{TopSurface}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -551,10 +572,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
@@ -570,6 +594,7 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -603,9 +628,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -624,14 +651,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.25"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -647,7 +674,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -693,7 +722,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
@@ -703,7 +731,7 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
         <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>

--- a/src/common/interface_platform/test/converter_u_validate10.xml
+++ b/src/common/interface_platform/test/converter_u_validate10.xml
@@ -14,14 +14,15 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{10, 10, 10}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000000000000000e+00, 1.00000000000000000e+00, 1.00000000000000000e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000000000000000, 1.00000000000000000, 1.00000000000000000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
@@ -34,11 +35,12 @@
     </ParameterList>
     <ParameterList name="TopSurface">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 1.00000000000000000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000e+00, 1.00000000000000000e+00, 1.00000000000000000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0e-17, 0e-17, 1.00000000000000000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000, 1.00000000000000000, 1.00000000000000000}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="mass_density_liquid">
@@ -48,7 +50,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -63,7 +65,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="5.54093810713294515e+04"/>
+                <Parameter name="value" type="double" value="55409.3810713294515"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -78,7 +80,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+                <Parameter name="value" type="double" value="0.00100200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -93,7 +95,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.00000000000000022e-01"/>
+                <Parameter name="value" type="double" value="0.400000000000000022"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -103,21 +105,27 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0e-17, 0e-17, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -130,7 +138,7 @@
   </ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.00000000000000000e+00, 2.00000000000000000e+00, 4.00000000000000000e+01}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0e-17, 2.00000000000000000, 40.0000000000000000}"/>
   </ParameterList>
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
@@ -140,10 +148,10 @@
             <Parameter name="PK type" type="string" value="elastic"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="end period time" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="start period time" type="double" value="0e-17"/>
+        <Parameter name="end period time" type="double" value="0e-17"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="initial timestep" type="double" value="1.00000000000000000"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
     </ParameterList>
@@ -159,6 +167,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="steady:mechanics">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="physical models and assumptions">
@@ -166,6 +175,7 @@
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
         <Parameter name="linear solver" type="string" value="PCG for elasticity"/>
@@ -181,17 +191,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -199,14 +209,15 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -217,11 +228,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -248,7 +263,7 @@
     <ParameterList name="PCG for elasticity">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
-        <Parameter name="error tolerance" type="double" value="1.0e-08"/>
+        <Parameter name="error tolerance" type="double" value="1.0e-8"/>
         <Parameter name="maximum number of iterations" type="int" value="400"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative residual, relative rhs, make one iteration}"/>
         <ParameterList name="verbose object">
@@ -273,12 +288,12 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990e+00"/>
-        <Parameter name="aggregation: threshold" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.33332999999999990"/>
+        <Parameter name="aggregation: threshold" type="double" value="0e-17"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
         <Parameter name="smoother: sweeps" type="int" value="3"/>
-        <Parameter name="smoother: damping factor" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.00000000000000000"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: type" type="string" value="Jacobi"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -288,10 +303,10 @@
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -300,9 +315,9 @@
     <ParameterList name="Block ILU">
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.00000000000000000e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.00000000000000000"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0e-17"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.00000000000000000"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>

--- a/src/data_structures/test/operator_convergence.xml
+++ b/src/data_structures/test/operator_convergence.xml
@@ -1,31 +1,30 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="grid_option" type="string" value="unstructured"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -33,14 +32,12 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operators">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="mixed diffusion">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
     </ParameterList>
-
     <ParameterList name="nodal diffusion">
       <Parameter name="schema" type="Array(string)" value="{node}"/>
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
@@ -48,8 +45,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{node}"/>
     </ParameterList>
   </ParameterList>
-
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -63,7 +58,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -73,7 +67,7 @@
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="strong threshold" type="double" value="0.5"/>
-        <Parameter name="tolerance" type="double" value="0"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="relaxation type" type="int" value="6"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
@@ -82,4 +76,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/executables/inputfiles/gen.xml
+++ b/src/executables/inputfiles/gen.xml
@@ -1,28 +1,25 @@
 <ParameterList name="main">
   <ParameterList name="mesh">
     <ParameterList name="Generate">
-
       <!-- Set mesh resolution here -->
       <Parameter name="Number of Cells in X" type="int" value="10"/>
-      <Parameter name="Number of Cells in Y" type="int" value=" 3"/>
+      <Parameter name="Number of Cells in Y" type="int" value="3"/>
       <Parameter name="Number of Cells in Z" type="int" value="50"/>
-
-      <Parameter name="X_Min" type="double" value="0.0" />
-      <Parameter name="X_Max" type="double" value="1.0" />
-      <Parameter name="Y_Min" type="double" value="0.0" />
-      <Parameter name="Y_Max" type="double" value="0.1" />
-      <Parameter name="Z_Min" type="double" value="0.0" />
-      <Parameter name="Z_Max" type="double" value="1.0" />
-
+      <Parameter name="X_Min" type="double" value="0.0"/>
+      <Parameter name="X_Max" type="double" value="1.0"/>
+      <Parameter name="Y_Min" type="double" value="0.0"/>
+      <Parameter name="Y_Max" type="double" value="0.1"/>
+      <Parameter name="Z_Min" type="double" value="0.0"/>
+      <Parameter name="Z_Max" type="double" value="1.0"/>
       <Parameter name="Number of mesh blocks" type="int" value="2"/>
       <ParameterList name="Mesh block 1">
-        <Parameter name="Z0" type="double" value=" 0.3"/>
-        <Parameter name="Z1" type="double" value=" 0.5"/>
+        <Parameter name="Z0" type="double" value="0.3"/>
+        <Parameter name="Z1" type="double" value="0.5"/>
       </ParameterList>
       <ParameterList name="Mesh block 2">
-        <Parameter name="Z0" type="double" value=" 0.6"/>
-        <Parameter name="Z1" type="double" value=" 0.8"/>
+        <Parameter name="Z0" type="double" value="0.6"/>
+        <Parameter name="Z1" type="double" value="0.8"/>
       </ParameterList>
-    </ParameterList>   
+    </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/geometry/test/boxregion_2D.xml
+++ b/src/geometry/test/boxregion_2D.xml
@@ -1,8 +1,9 @@
 <ParameterList name="regions">
   <ParameterList name="Top Section">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{9, 8}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{11, 1.5}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{9.0, 8.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{11.0, 1.5}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/boxregion_3D.xml
+++ b/src/geometry/test/boxregion_3D.xml
@@ -1,8 +1,9 @@
 <ParameterList name="regions">
   <ParameterList name="Top Section">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{2, 3, 5}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{4, 5, 8}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{2.0, 3.0, 5.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{4.0, 5.0, 8.0}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/boxregion_vofs.xml
+++ b/src/geometry/test/boxregion_vofs.xml
@@ -6,3 +6,4 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/boxregion_vofs_3D.xml
+++ b/src/geometry/test/boxregion_vofs_3D.xml
@@ -6,3 +6,4 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/colorfunc_region.xml
+++ b/src/geometry/test/colorfunc_region.xml
@@ -12,3 +12,4 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/cylinderregion.xml
+++ b/src/geometry/test/cylinderregion.xml
@@ -1,13 +1,13 @@
 <ParameterList name="regions">
   <ParameterList name="Top Section">
     <ParameterList name="region: cylinder">
-      <Parameter name="axis" type="Array(double)" value="{0, 0, 2}"/>
-      <Parameter name="point" type="Array(double)" value="{0, 0, 0}"/>
+      <Parameter name="axis" type="Array(double)" value="{0.0, 0.0, 2.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
       <Parameter name="radius" type="double" value="2.0"/>
-
       <ParameterList name="expert parameters">
-	<Parameter name="tolerance" type="double" value="1e-06"/>
+        <Parameter name="tolerance" type="double" value="0.000001"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/enumeratedsetregion.xml
+++ b/src/geometry/test/enumeratedsetregion.xml
@@ -2,13 +2,14 @@
   <ParameterList name="Top Section">
     <ParameterList name="region: enumerated set">
       <Parameter name="entity" type="string" value="FACE"/>
-      <Parameter name="entity gids" type="Array(int)" value="{0,1,2}"/>
+      <Parameter name="entity gids" type="Array(int)" value="{0, 1, 2}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Middle">
     <ParameterList name="region: enumerated set">
       <Parameter name="entity" type="string" value="CELL"/>
-      <Parameter name="entity gids" type="Array(int)" value="{0,1,2}"/>
+      <Parameter name="entity gids" type="Array(int)" value="{0, 1, 2}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/labeledsetregion.xml
+++ b/src/geometry/test/labeledsetregion.xml
@@ -16,3 +16,4 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/manyregions.xml
+++ b/src/geometry/test/manyregions.xml
@@ -1,6 +1,6 @@
 <ParameterList name="regions">
   <ParameterList name="Top Section">
-<!--
+    <!--
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="Sideset1"/>
       <Parameter name="file" type="string" value="mesh.exo"/>
@@ -17,8 +17,8 @@
   <ParameterList name="Top Section">
 -->
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{2, 3, 5}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{4, 5, 8}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{2.0, 3.0, 5.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{4.0, 5.0, 8.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Middle">
@@ -31,8 +31,9 @@
   </ParameterList>
   <ParameterList name="Side Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{2, 3, 5}"/>
-      <Parameter name="normal" type="Array(double)" value="{1, 1, 0}"/>
+      <Parameter name="point" type="Array(double)" value="{2.0, 3.0, 5.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/planeregion.xml
+++ b/src/geometry/test/planeregion.xml
@@ -1,11 +1,12 @@
 <ParameterList name="regions">
   <ParameterList name="Top Section">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{2, 3, 5}"/>
-      <Parameter name="normal" type="Array(double)" value="{1, 1, 0}"/>
+      <Parameter name="point" type="Array(double)" value="{2.0, 3.0, 5.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       <ParameterList name="expert parameters">
-        <Parameter name="tolerance" type="double" value="1.0e-05"/>
+        <Parameter name="tolerance" type="double" value="0.000010"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/polygonregion_2D.xml
+++ b/src/geometry/test/polygonregion_2D.xml
@@ -2,11 +2,11 @@
   <ParameterList name="XY pentagon">
     <ParameterList name="region: polygon">
       <Parameter name="number of points" type="int" value="2"/>
-      <Parameter name="points" type="Array(double)" value="{0.5, -0.5,
-							   -0.5, 0.5}"/>
+      <Parameter name="points" type="Array(double)" value="{0.5, -0.5, -0.5, 0.5}"/>
       <ParameterList name="expert parameters">
-	<Parameter name="tolerance" type="double" value="1.0e-06"/>
+        <Parameter name="tolerance" type="double" value="0.0000010"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/geometry/test/polygonregion_3D.xml
+++ b/src/geometry/test/polygonregion_3D.xml
@@ -2,14 +2,11 @@
   <ParameterList name="XY pentagon">
     <ParameterList name="region: polygon">
       <Parameter name="number of points" type="int" value="5"/>
-      <Parameter name="points" type="Array(double)" value="{-0.5, -0.5, -0.5, 
-							   0.5, -0.5, -0.5,
-							   0.8, 0.0, 0.0,
-							   0.5,  0.5, 0.5,
-							   -0.5, 0.5, 0.5}"/>
+      <Parameter name="points" type="Array(double)" value="{-0.5, -0.5, -0.5, 0.5, -0.5, -0.5, 0.8, 0.0, 0.0, 0.5, 0.5, 0.5, -0.5, 0.5, 0.5}"/>
       <ParameterList name="expert parameters">
-        <Parameter name="tolerance" type="double" value="1.0e-3"/>
+        <Parameter name="tolerance" type="double" value="0.0010"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
+

--- a/src/interoperability/test/interoperability_flow_transport.xml
+++ b/src/interoperability/test/interoperability_flow_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_frt"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 1, -1}"/>
@@ -8,37 +7,37 @@
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_frt"/>
     <Parameter name="file name digits" type="int" value="5"/>
-    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 5, -1}" />
-  </ParameterList>  
+    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 5, -1}"/>
+  </ParameterList>
   <ParameterList name="regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00000e+00, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000e+00, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00000, 0.00000, 0.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00000, 1.00000, 1.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00000e+00, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.00000e+00, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00000, 0.00000, 0.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.00000, 1.00000, 1.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.00000e+00, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000e+00, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.00000, 0.00000, 0.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00000, 1.00000, 1.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00000e+00, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.00000000000000000e-01, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00000, 0.00000, 0.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.500000000000000000, 1.00000, 1.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{5.00000000000000000e-01, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000e+00, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.500000000000000000, 0.00000, 0.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00000, 1.00000, 1.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -48,12 +47,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{100, 1, 1}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00000e+00, 0.00000e+00, 0.00000e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000e+00, 1.00000e+00, 1.00000e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00000, 0.00000, 0.00000}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000, 1.00000, 1.00000}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -64,67 +64,69 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
+    <Parameter name="start time" type="double" value="0.0"/>
     <Parameter name="end time" type="double" value="1.0e+4"/>
     <Parameter name="component names" type="Array(string)" value="{Na+, Ca++, Mg++, Cl-}"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{23.0e-3, 40.0e-3, 24.3e-3, 35.5e-3}"/>
+    <Parameter name="component molar masses" type="Array(double)" value="{0.0230, 0.0400, 0.0243, 0.0355}"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="flow and reactive transport">
-	    <Parameter name="PK type" type="string" value="flow reactive transport"/>      
-	    <ParameterList name="flow">
-	      <Parameter name="PK type" type="string" value="ats richards flow"/>
-	    </ParameterList>    
-	    <ParameterList name="reactive transport">
-	      <Parameter name="PK type" type="string" value="reactive transport"/>
-	      <ParameterList name="transport">
-		<Parameter name="PK type" type="string" value="transport"/>
-	      </ParameterList>
-	      <ParameterList name="chemistry">
-		<Parameter name="PK type" type="string" value="chemistry amanzi"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>    
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0e+04"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="flow and reactive transport">
+            <Parameter name="PK type" type="string" value="flow reactive transport"/>
+            <ParameterList name="flow">
+              <Parameter name="PK type" type="string" value="ats richards flow"/>
+            </ParameterList>
+            <ParameterList name="reactive transport">
+              <Parameter name="PK type" type="string" value="reactive transport"/>
+              <ParameterList name="transport">
+                <Parameter name="PK type" type="string" value="transport"/>
+              </ParameterList>
+              <ParameterList name="chemistry">
+                <Parameter name="PK type" type="string" value="chemistry amanzi"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0e+4"/>
         <Parameter name="initial timestep" type="double" value="100.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow and reactive transport">
-      <Parameter name="PK type" type="string" value="flow reactive transport"/>      
-      <Parameter name="PKs order" type="Array(string)" value="{flow, reactive transport}"/> 
+      <Parameter name="PK type" type="string" value="flow reactive transport"/>
+      <Parameter name="PKs order" type="Array(string)" value="{flow, reactive transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="reactive transport">
-      <Parameter name="PK type" type="string" value="reactive transport"/>      
-      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/> 
+      <Parameter name="PK type" type="string" value="reactive transport"/>
+      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/>
+
     </ParameterList>
 
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
+
       <Parameter name="primary variable key" type="string" value="pressure"/>
       <Parameter name="PK type" type="string" value="richards flow"/>
       <Parameter name="initial timestep" type="double" value="100.0"/>
       <Parameter name="relative permeability method" type="string" value="upwind with Darcy flux"/>
       <Parameter name="modify predictor for flux BCs" type="bool" value="true"/>
       <Parameter name="permeability rescaling" type="double" value="1.0"/>
-
       <ParameterList name="water retention evaluator">
         <Parameter name="minimum rel perm cutoff" type="double" value="0.0"/>
         <ParameterList name="WRM parameters" type="ParameterList">
           <ParameterList name="all" type="ParameterList">
             <Parameter name="region" type="string" value="Entire Domain"/>
-            <Parameter name="WRM Type" type="string" value="van Genuchten" />
-            <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="0.0023e-8"/>
+            <Parameter name="WRM Type" type="string" value="van Genuchten"/>
+            <Parameter name="van Genuchten alpha [Pa^-1]" type="double" value="2.3e-11"/>
             <Parameter name="van Genuchten m [-]" type="double" value="0.2754"/>
             <Parameter name="residual saturation [-]" type="double" value="0.0"/>
             <Parameter name="smoothing interval width [saturation]" type="double" value="0.1"/>
@@ -133,42 +135,42 @@
       </ParameterList>
 
       <ParameterList name="diffusion">
-        <Parameter name="discretization primary" type="string" value="mfd: default" />
-	<Parameter name="gravity" type="bool" value="true"/>
+        <Parameter name="discretization primary" type="string" value="mfd: default"/>
+        <Parameter name="gravity" type="bool" value="true"/>
       </ParameterList>
 
       <ParameterList name="diffusion preconditioner">
         <Parameter name="include Newton correction" type="bool" value="true"/>
-	<Parameter name="gravity" type="bool" value="true"/>
+        <Parameter name="gravity" type="bool" value="true"/>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="water flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{West}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward water flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		<Parameter name="y values" type="Array(double)" value="{-7.9131785900e-06, -1.31785899999999989e-04}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{East}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		<Parameter name="y values" type="Array(double)" value="{2.01325e+05, 2.01325e+05}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="water flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{West}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward water flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.0000079131785900, -0.000131785899999999989}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{East}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                <Parameter name="y values" type="Array(double)" value="{201325.0, 201325.0}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="initial condition">
@@ -179,7 +181,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -187,53 +189,50 @@
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
         <Parameter name="timestep controller type" type="string" value="standard"/>
         <ParameterList name="timestep controller standard parameters">
           <Parameter name="max iterations" type="int" value="15"/>
           <Parameter name="min iterations" type="int" value="10"/>
           <Parameter name="timestep increase factor" type="double" value="1.0"/>
-          <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
+          <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
           <Parameter name="max timestep" type="double" value="6.00000e+10"/>
           <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
         </ParameterList>
-
         <Parameter name="solver type" type="string" value="nka"/>
         <ParameterList name="nka parameters">
           <Parameter name="nonlinear tolerance" type="double" value="1e-7"/>
           <Parameter name="diverged tolerance" type="double" value="1.00000e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.00000e+03"/>
+          <Parameter name="max du growth factor" type="double" value="1000.00"/>
           <Parameter name="max divergent iterations" type="int" value="3"/>
           <Parameter name="max nka vectors" type="int" value="10"/>
           <Parameter name="limit iterations" type="int" value="20"/>
           <Parameter name="modify correction" type="bool" value="false"/>
-	</ParameterList>
-	<Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	<Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	<Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	<Parameter name="restart tolerance relaxation factor" type="double" value="1.00000e+00"/>
-	<Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000e+00"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        </ParameterList>
+        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+        <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+        <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000"/>
+        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="inverse" type="ParameterList">
-        <Parameter name="preconditioning method" type="string" value="boomer amg" />
+        <Parameter name="preconditioning method" type="string" value="boomer amg"/>
         <ParameterList name="boomer amg parameters" type="ParameterList">
-          <Parameter name="cycle applications" type="int" value="1" />
-          <Parameter name="smoother sweeps" type="int" value="3" />
-          <Parameter name="strong threshold" type="double" value="0.65" />
-          <Parameter name="tolerance" type="double" value=" 0" />
-          <Parameter name="verbosity" type="int" value="0" />
+          <Parameter name="cycle applications" type="int" value="1"/>
+          <Parameter name="smoother sweeps" type="int" value="3"/>
+          <Parameter name="strong threshold" type="double" value="0.65"/>
+          <Parameter name="tolerance" type="double" value="0.0"/>
+          <Parameter name="verbosity" type="int" value="0"/>
         </ParameterList>
         <ParameterList name="verbose object" type="ParameterList">
-          <Parameter name="verbosity level" type="string" value="high" />
+          <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
         <!--Parameter name="iterative method" type="string" value="gmres" />
         <ParameterList name="gmres parameters" type="ParameterList">
@@ -243,6 +242,7 @@
           <Parameter name="maximum number of iteration" type="int" value="80" />
         </ParameterList-->
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="chemistry">
@@ -253,86 +253,90 @@
       <Parameter name="minerals" type="Array(string)" value="{Halite}"/>
       <Parameter name="number of component concentrations" type="int" value="4"/>
       <Parameter name="log formulation" type="bool" value="true"/>
+
     </ParameterList>
 
     <ParameterList name="transport">
       <!--Parameter name="PK type" type="string" value="transport pk"/-->
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="1.00000e+00"/>
+      <Parameter name="cfl" type="double" value="1.00000"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="advection limiter" type="string" value="Tensorial"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
-
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <Parameter name="enable internal tests" type="bool" value="false"/>
 
+      <Parameter name="enable internal tests" type="bool" value="false"/>
       <ParameterList name="molecular diffusion">
-	<Parameter name="aqueous names" type="Array(string)" value="{}"/>
-	<Parameter name="aqueous values" type="Array(double)" value="{}"/>
+        <Parameter name="aqueous names" type="Array(string)" value="{}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{}"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Na+">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Na+">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{9.42676899999999977e-03, 9.42676899999999977e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Ca++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00942676899999999977, 0.00942676899999999977}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Ca++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{5.01423899999999955e-04, 5.01423899999999955e-04}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Mg++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.000501423899999999955, 0.000501423899999999955}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Mg++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{2.13606599999999983e-03, 2.13606599999999983e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Cl-">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00213606599999999983, 0.00213606599999999983}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Cl-">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{1.47017488000000009e-02, 1.47017488000000009e-02}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.00000e+00, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.0147017488000000009, 0.0147017488000000009}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.00000, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="4"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <Parameter name="runtime diagnostics: regions" type="Array(string)" value="{}"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="thermodynamic database">
@@ -343,9 +347,9 @@
         <Parameter name="gram molecular weight" type="double" value="22.99"/>
       </ParameterList>
       <ParameterList name="Ca++">
-        <Parameter name="ion size parameter" type="double" value="6.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="6.00000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-       <Parameter name="gram molecular weight" type="double" value="4.00780000000000030e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="40.0780000000000030"/>
       </ParameterList>
       <ParameterList name="Mg++">
         <Parameter name="ion size parameter" type="double" value="8.0"/>
@@ -363,11 +367,11 @@
         <Parameter name="rate model" type="string" value="TST"/>
         <Parameter name="rate constant" type="double" value="-36.0"/>
         <Parameter name="modifiers" type="string" value=""/>
-        <Parameter name="gram molecular weight" type="double" value="5.84425E+01 "/>
+        <Parameter name="gram molecular weight" type="double" value="58.4425"/>
         <Parameter name="reaction" type="string" value="1.0 Na+   1.0 Cl-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.58550E+00"/>
-        <Parameter name="molar volume" type="double" value="2.70150E+01"/>
-        <Parameter name="specific surface area" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="1.58550"/>
+        <Parameter name="molar volume" type="double" value="27.0150"/>
+        <Parameter name="specific surface area" type="double" value="1.00000000000000000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="ion exchange sites">
@@ -379,19 +383,18 @@
     <ParameterList name="ion exchange complexes">
       <ParameterList name="Na+X">
         <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="1.00000000000000000"/>
       </ParameterList>
       <ParameterList name="Ca++X">
         <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="2.95300E-01"/>
+        <Parameter name="equilibrium constant" type="double" value="0.295300"/>
       </ParameterList>
       <ParameterList name="Mg++X">
         <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.66600E-01"/>
+        <Parameter name="equilibrium constant" type="double" value="0.166600"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
@@ -402,12 +405,11 @@
         <Parameter name="checkpoint" type="bool" value="true"/>
       </ParameterList>
       <ParameterList name="capillary_pressure_gas_liq">
-        <Parameter name="evaluator type" type="string" value="capillary pressure, atmospheric gas over liquid" />
+        <Parameter name="evaluator type" type="string" value="capillary pressure, atmospheric gas over liquid"/>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
-        <Parameter name="EOS basis" type="string" value="both" />
+        <Parameter name="EOS basis" type="string" value="both"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
         <ParameterList name="EOS parameters">
@@ -415,9 +417,9 @@
         </ParameterList>
       </ParameterList>
       <ParameterList name="molar_density_gas">
-        <Parameter name="evaluator type" type="string" value="eos" />
+        <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="EOS basis" type="string" value="molar"/>
-        <Parameter name="molar density key" type="string" value="molar_density_gas" />
+        <Parameter name="molar density key" type="string" value="molar_density_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="EOS type" type="string" value="vapor in gas"/>
           <ParameterList name="gas EOS parameters">
@@ -425,7 +427,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
@@ -441,7 +442,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -450,29 +451,28 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
       <ParameterList name="mass_density_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="permeability">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="permeability type" type="string" value="diagonal tensor"/>
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -500,7 +500,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <Parameter name="constant in time" type="bool" value="true"/>
@@ -510,21 +509,23 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="298.0" />
+                <Parameter name="value" type="double" value="298.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -536,12 +537,13 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -552,7 +554,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000005e-04"/>
+                  <Parameter name="value" type="double" value="0.000100000000000000005"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -565,13 +567,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0e-04"/>
+                  <Parameter name="value" type="double" value="0.00020"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -582,7 +585,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -595,13 +598,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000e+00"/>
+                  <Parameter name="value" type="double" value="2.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -612,7 +616,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000005e-04"/>
+                  <Parameter name="value" type="double" value="0.000100000000000000005"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -625,13 +629,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000000000000010e-04"/>
+                  <Parameter name="value" type="double" value="0.000200000000000000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_sites">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -642,7 +647,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="7.50000e+02"/>
+                  <Parameter name="value" type="double" value="750.000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -655,13 +660,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.50000e+02"/>
+                  <Parameter name="value" type="double" value="250.000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_ref_cation_conc">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -672,7 +678,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -685,13 +691,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="free_ion_species">
         <ParameterList name="function">
           <ParameterList name="Entire Domain">
@@ -702,22 +709,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -730,22 +737,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -758,28 +765,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <Parameter name="names" type="Array(string)" value="{total, total, total, total}"/>
         <ParameterList name="function">
@@ -791,28 +799,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -820,12 +829,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000e+00"/>
+        <Parameter name="tolerance" type="double" value="0.00000"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
         <Parameter name="strong threshold" type="double" value="0.5"/>
@@ -837,7 +845,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -860,7 +867,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{West, East, West, East}"/>

--- a/src/mesh/mesh_extracted/test/mesh_extracted_fracture.xml
+++ b/src/mesh/mesh_extracted/test/mesh_extracted_fracture.xml
@@ -1,50 +1,48 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="ALL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1z">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1y">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1x">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="fractures-two">
       <ParameterList name="region: logical">
         <Parameter name="operation" type="string" value="union"/>
@@ -58,6 +56,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/mesh/mesh_logical/test/demo_mesh.xml
+++ b/src/mesh/mesh_logical/test/demo_mesh.xml
@@ -1,145 +1,122 @@
 <ParameterList name="Main">
-
   <ParameterList name="logical mesh Y">
-
     <Parameter name="infer cell centroids" type="bool" value="true"/>
     <ParameterList name="segments">
       <ParameterList name="coarse_root">
-	<Parameter name="number of cells" type="int" value="3"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="1.e-4"/>
-	<Parameter name="segment length [m]" type="double" value="3.0"/>
-	<Parameter name="orientation" type="Array(double)" value="{0.,0.,1.}"/>
-	<Parameter name="first tip" type="Array(double)" value="{0.,0.,0.}"/>
-	<Parameter name="first tip type" type="string" value="boundary"/>
-	<Parameter name="last tip type" type="string" value="junction"/>
+        <Parameter name="number of cells" type="int" value="3"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="0.0001"/>
+        <Parameter name="segment length [m]" type="double" value="3.0"/>
+        <Parameter name="orientation" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="first tip" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="first tip type" type="string" value="boundary"/>
+        <Parameter name="last tip type" type="string" value="junction"/>
       </ParameterList>
-
       <ParameterList name="fine_root_1">
-	<Parameter name="orientation" type="Array(double)" value="{-1.,0.,1.}"/>
-	<Parameter name="segment length [m]" type="double" value="1.5"/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="2"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="0.25e-4"/>
+        <Parameter name="orientation" type="Array(double)" value="{-1.0, 0.0, 1.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.5"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="2"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="0.000025"/>
       </ParameterList>
-
       <ParameterList name="fine_root_2">
-	<Parameter name="orientation" type="Array(double)" value="{1.,0.,1.}"/>
-	<Parameter name="segment length [m]" type="double" value="1.5"/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="2"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="0.25e-4"/>
+        <Parameter name="orientation" type="Array(double)" value="{1.0, 0.0, 1.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.5"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="2"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="0.000025"/>
       </ParameterList>
-
       <ParameterList name="fine_root_3">
-	<Parameter name="orientation" type="Array(double)" value="{0.,-1.,1.}"/>
-	<Parameter name="segment length [m]" type="double" value="1.5"/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="2"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="0.25e-4"/>
+        <Parameter name="orientation" type="Array(double)" value="{0.0, -1.0, 1.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.5"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="2"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="0.000025"/>
       </ParameterList>
-
       <ParameterList name="fine_root_4">
-	<Parameter name="orientation" type="Array(double)" value="{0.,1.,1.}"/>
-	<Parameter name="segment length [m]" type="double" value="1.5"/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="2"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="0.25e-4"/>
+        <Parameter name="orientation" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.5"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="2"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="0.000025"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="sets">
-      <Parameter name="fine_root" type="Array(string)" value="{fine_root_1,fine_root_2,fine_root_3,fine_root_4}"/>
+      <Parameter name="fine_root" type="Array(string)" value="{fine_root_1, fine_root_2, fine_root_3, fine_root_4}"/>
     </ParameterList>
-    
   </ParameterList>
-
-
   <ParameterList name="logical mesh 2Y">
-
     <Parameter name="infer cell centroids" type="bool" value="true"/>
     <ParameterList name="segments">
       <ParameterList name="coarse_root">
-	<Parameter name="number of cells" type="int" value="1"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="2"/>
-	<Parameter name="segment length [m]" type="double" value="2.0"/>
-	<Parameter name="orientation" type="Array(double)" value="{1.,0.,0.}"/>
-	<Parameter name="first tip" type="Array(double)" value="{2.,0.,0.}"/>
-	<Parameter name="first tip type" type="string" value="boundary"/>
-	<Parameter name="last tip type" type="string" value="junction"/>
+        <Parameter name="number of cells" type="int" value="1"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="2.0"/>
+        <Parameter name="segment length [m]" type="double" value="2.0"/>
+        <Parameter name="orientation" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="first tip" type="Array(double)" value="{2.0, 0.0, 0.0}"/>
+        <Parameter name="first tip type" type="string" value="boundary"/>
+        <Parameter name="last tip type" type="string" value="junction"/>
       </ParameterList>
-
       <ParameterList name="fine_root_1">
-	<Parameter name="orientation" type="Array(double)" value="{1.,1.,0.}"/>
-	<Parameter name="segment length [m]" type="double" value="1."/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="1"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="1"/>
+        <Parameter name="orientation" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.0"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="1"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="1.0"/>
       </ParameterList>
-
       <ParameterList name="fine_root_2">
-	<Parameter name="orientation" type="Array(double)" value="{1.,-1.,0.}"/>
-	<Parameter name="segment length [m]" type="double" value="1."/>
-	<Parameter name="first tip type" type="string" value="branch"/>
-	<Parameter name="first tip branch segment" type="string" value="coarse_root"/>
-	<Parameter name="first tip branch segment tip" type="string" value="last"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="number of cells" type="int" value="1"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="1"/>
+        <Parameter name="orientation" type="Array(double)" value="{1.0, -1.0, 0.0}"/>
+        <Parameter name="segment length [m]" type="double" value="1.0"/>
+        <Parameter name="first tip type" type="string" value="branch"/>
+        <Parameter name="first tip branch segment" type="string" value="coarse_root"/>
+        <Parameter name="first tip branch segment tip" type="string" value="last"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="1"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="1.0"/>
       </ParameterList>
-
-
     </ParameterList>
-
     <ParameterList name="sets">
-      <Parameter name="fine_root" type="Array(string)" value="{fine_root_1,fine_root_2}"/>
+      <Parameter name="fine_root" type="Array(string)" value="{fine_root_1, fine_root_2}"/>
     </ParameterList>
-    
   </ParameterList>
-
-
   <ParameterList name="regular">
     <Parameter name="infer cell centroids" type="bool" value="true"/>
     <ParameterList name="segments">
       <ParameterList name="coarse_root">
-	<Parameter name="number of cells" type="int" value="4"/>
-	<Parameter name="cross sectional area [m^2]" type="double" value="1"/>
-	<Parameter name="segment length [m]" type="double" value="1.0"/>
-	<Parameter name="orientation" type="Array(double)" value="{1.,0.,0.}"/>
-	<Parameter name="first tip" type="Array(double)" value="{0.,0.,0.}"/>
-	<Parameter name="first tip type" type="string" value="boundary"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="number of cells" type="int" value="4"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="1.0"/>
+        <Parameter name="segment length [m]" type="double" value="1.0"/>
+        <Parameter name="orientation" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="first tip" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="first tip type" type="string" value="boundary"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="subgrid mesh">
-
     <ParameterList name="segments">
-
       <ParameterList name="subgrid">
-	<Parameter name="cross sectional area [m^2]" type="double" value="1.0"/>
-	<Parameter name="first tip" type="Array(double)" value="{0.,0.,0.}"/>
-	<Parameter name="last tip" type="Array(double)" value="{0.,0.,-10.0}"/>
-	<Parameter name="first tip type" type="string" value="boundary"/>
-	<Parameter name="last tip type" type="string" value="boundary"/>
-	<Parameter name="cell lengths [m]" type="Array(double)" value="{0.01,0.49,0.5,1,1,1,1,1,2, 2}"/>
+        <Parameter name="cross sectional area [m^2]" type="double" value="1.0"/>
+        <Parameter name="first tip" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="last tip" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
+        <Parameter name="first tip type" type="string" value="boundary"/>
+        <Parameter name="last tip type" type="string" value="boundary"/>
+        <Parameter name="cell lengths [m]" type="Array(double)" value="{0.01, 0.49, 0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/src/mesh/test/fracture.xml
+++ b/src/mesh/test/fracture.xml
@@ -1,34 +1,33 @@
-  <ParameterList name="regions">
-    <ParameterList name="Computational domain">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Left side">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,0.5}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 1">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 2">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fractures">
-      <ParameterList name="region: logical">
-        <Parameter name="operation" type="string" value="union"/>
-        <Parameter name="regions" type="Array(string)" value="{fracture 1,fracture 2}"/>
-      </ParameterList>
+<ParameterList name="regions">
+  <ParameterList name="Computational domain">
+    <ParameterList name="region: box">
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
-
+  <ParameterList name="Left side">
+    <ParameterList name="region: box">
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 0.5}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 1">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 2">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fractures">
+    <ParameterList name="region: logical">
+      <Parameter name="operation" type="string" value="union"/>
+      <Parameter name="regions" type="Array(string)" value="{fracture 1, fracture 2}"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>
 

--- a/src/mesh/test/fracture2.xml
+++ b/src/mesh/test/fracture2.xml
@@ -1,60 +1,57 @@
-  <ParameterList name="regions">
-    <ParameterList name="ALL">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Top side">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Left side">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,0.5,0.5}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 1z">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 1y">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 1x">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fracture 2">
-      <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="fractures-two">
-      <ParameterList name="region: logical">
-        <Parameter name="operation" type="string" value="union"/>
-        <Parameter name="regions" type="Array(string)" value="{fracture 1x, fracture 1y}"/>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="fractures-three">
-      <ParameterList name="region: logical">
-        <Parameter name="operation" type="string" value="union"/>
-        <Parameter name="regions" type="Array(string)" value="{fracture 1x, fracture 1z, fracture 2}"/>
-      </ParameterList>
+<ParameterList name="regions">
+  <ParameterList name="ALL">
+    <ParameterList name="region: box">
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
-
-
+  <ParameterList name="Top side">
+    <ParameterList name="region: box">
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Left side">
+    <ParameterList name="region: box">
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 1z">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 1y">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 1x">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+      <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fracture 2">
+    <ParameterList name="region: plane">
+      <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
+      <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 1.0}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fractures-two">
+    <ParameterList name="region: logical">
+      <Parameter name="operation" type="string" value="union"/>
+      <Parameter name="regions" type="Array(string)" value="{fracture 1x, fracture 1y}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="fractures-three">
+    <ParameterList name="region: logical">
+      <Parameter name="operation" type="string" value="union"/>
+      <Parameter name="regions" type="Array(string)" value="{fracture 1x, fracture 1z, fracture 2}"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>
 

--- a/src/mesh/test/hex_3x3x3.xml
+++ b/src/mesh/test/hex_3x3x3.xml
@@ -5,7 +5,6 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- CELL REGIONS -->
   <!-- labeled set, material IDs -->
   <ParameterList name="Bottom LS">
@@ -32,9 +31,9 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- labeled set, cell sets -->
-  <ParameterList name="Cell Set 1"> <!-- same as Bottom LS -->
+  <ParameterList name="Cell Set 1">
+    <!-- same as Bottom LS -->
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="1"/>
       <Parameter name="file" type="string" value="hex_3x3x3.exo"/>
@@ -42,7 +41,8 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-  <ParameterList name="Cell Set 2"> <!-- same as Middle LS -->
+  <ParameterList name="Cell Set 2">
+    <!-- same as Middle LS -->
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="2"/>
       <Parameter name="file" type="string" value="hex_3x3x3.exo"/>
@@ -50,7 +50,8 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-  <ParameterList name="Cell Set 3"> <!-- same as Top LS -->
+  <ParameterList name="Cell Set 3">
+    <!-- same as Top LS -->
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="3"/>
       <Parameter name="file" type="string" value="hex_3x3x3.exo"/>
@@ -58,7 +59,6 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- color functions -->
   <!-- NOT SUPPORTED IN TPETRA
   <ParameterList name="Bottom ColFunc">
@@ -80,38 +80,35 @@
     </ParameterList>
   </ParameterList>
   -->
-
   <!-- geometric regions -->
   <ParameterList name="Top Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.66}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.66}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Bottom+Middle Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.66}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.66}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Left Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{0.33,1.0,1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.33, 1.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Point">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- logical sets -->
   <ParameterList name="Bottom LS+Point">
     <ParameterList name="region: logical">
       <Parameter name="operation" type="string" value="union"/>
-      <Parameter name="regions" type="Array(string)" value="{Bottom LS,Point}"/>
+      <Parameter name="regions" type="Array(string)" value="{Bottom LS, Point}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="NOT_Bottom+Middle Box">
@@ -132,15 +129,13 @@
       <Parameter name="regions" type="Array(string)" value="{Left Box, Bottom LS}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- empty sets -->
   <ParameterList name="Empty Geometric">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{-2.0,-2.0,-2.}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{-1.0,-1.0,-1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{-2.0, -2.0, -2.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{-1.0, -1.0, -1.0}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Empty Labeled Set">
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="99999"/>
@@ -149,16 +144,13 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-  
-  
   <!-- enumerated sets -->
   <ParameterList name="Enumerated">
     <ParameterList name="region: enumerated set">
       <Parameter name="entity" type="string" value="CELL"/>
-      <Parameter name="entity gids" type="Array(int)" value="{1,2,3}"/>
+      <Parameter name="entity gids" type="Array(int)" value="{1, 2, 3}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- sidesets -->
   <ParameterList name="Face 103">
     <ParameterList name="region: labeled set">
@@ -178,20 +170,20 @@
   </ParameterList>
   <ParameterList name="Top Face Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{0.0,0.0,1.0}"/>
-      <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="West Face Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-      <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Central Face Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.4,0.4,1.0}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{0.6,0.6,1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.4, 0.4, 1.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.6, 0.6, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Face 106 - Central Face Box">
@@ -200,48 +192,45 @@
       <Parameter name="regions" type="Array(string)" value="{Face 106, Central Face Box}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- Miscellaneous -->
   <ParameterList name="Domain Boundary">
     <ParameterList name="region: boundary">
       <Parameter name="entity" type="string" value="face"/>
     </ParameterList>
   </ParameterList>
-
   <!-- Cells sets from point regions -->
   <ParameterList name="Sample Point InCell">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Sample Point OnFace">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333,0.5,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333, 0.5, 0.5}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Sample Point OnEdge">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333,0.3333333333333,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333, 0.3333333333333, 0.5}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Sample Point OnVertex">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333,0.3333333333333,0.3333333333333}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333, 0.3333333333333, 0.3333333333333}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- nodesets -->
   <ParameterList name="Interior XY Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.3333333333333}"/>
-      <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.3333333333333}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Top Box Nodes">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.2,0.2,1.0}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{0.8,0.8,1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.2, 0.2, 1.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.8, 0.8, 1.0}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
+

--- a/src/mesh/test/quad_3x3.xml
+++ b/src/mesh/test/quad_3x3.xml
@@ -5,7 +5,6 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- CELL REGIONS -->
   <!-- labeled set, material IDs -->
   <ParameterList name="Top LS">
@@ -16,9 +15,9 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- labeled set, cell sets -->
-  <ParameterList name="Cell Set 3"> <!-- same as Top LS -->
+  <ParameterList name="Cell Set 3">
+    <!-- same as Top LS -->
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="3"/>
       <Parameter name="file" type="string" value="hex_3x3x3.exo"/>
@@ -26,7 +25,6 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
   <!-- color functions -->
   <!-- NOT SUPPORTED IN TPETRA
   <ParameterList name="Top ColFunc">
@@ -36,26 +34,23 @@
     </ParameterList>
   </ParameterList>
   -->
-
   <!-- geometric regions -->
   <ParameterList name="Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.35}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.35}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Point">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.5,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.5, 0.5}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- logical sets -->
   <ParameterList name="Box+Point">
     <ParameterList name="region: logical">
       <Parameter name="operation" type="string" value="union"/>
-      <Parameter name="regions" type="Array(string)" value="{Box,Point}"/>
+      <Parameter name="regions" type="Array(string)" value="{Box, Point}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="NOT_Box">
@@ -76,23 +71,20 @@
       <Parameter name="regions" type="Array(string)" value="{Point, NOT_Box}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- enumerated sets -->
   <ParameterList name="Enumerated">
     <ParameterList name="region: enumerated set">
       <Parameter name="entity" type="string" value="CELL"/>
-      <Parameter name="entity gids" type="Array(int)" value="{1,2,3}"/>
+      <Parameter name="entity gids" type="Array(int)" value="{1, 2, 3}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- empty sets -->
   <ParameterList name="Empty Geometric">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{-2.0,-2.0}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{-1.0,-1.0}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{-2.0, -2.0}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{-1.0, -1.0}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Empty Labeled Set">
     <ParameterList name="region: labeled set">
       <Parameter name="label" type="string" value="99999"/>
@@ -101,8 +93,6 @@
       <Parameter name="entity" type="string" value="cell"/>
     </ParameterList>
   </ParameterList>
-
-  
   <!-- sidesets -->
   <ParameterList name="Face 103">
     <ParameterList name="region: labeled set">
@@ -122,14 +112,14 @@
   </ParameterList>
   <ParameterList name="Side Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-      <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Central Face Box">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.,0.4}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{0.,0.6}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.4}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.6}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Side Plane - Central Face Box">
@@ -144,43 +134,40 @@
       <Parameter name="regions" type="Array(string)" value="{Face 103, Central Face Box}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- Miscellaneous -->
   <ParameterList name="Domain Boundary">
     <ParameterList name="region: boundary">
       <Parameter name="entity" type="string" value="face"/>
     </ParameterList>
   </ParameterList>
-
   <!-- Cells sets from point regions -->
   <ParameterList name="Sample Point InCell">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.5,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.5, 0.5}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Sample Point OnFace">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333,0.5}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333, 0.5}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Sample Point OnVertex">
     <ParameterList name="region: point">
-      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333,0.3333333333333}"/>
+      <Parameter name="coordinate" type="Array(double)" value="{0.3333333333333, 0.3333333333333}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- nodesets -->
   <ParameterList name="Interior XY Plane">
     <ParameterList name="region: plane">
-      <Parameter name="point" type="Array(double)" value="{0.0,0.3333333333333}"/>
-      <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+      <Parameter name="point" type="Array(double)" value="{0.0, 0.3333333333333}"/>
+      <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Top Box Nodes">
     <ParameterList name="region: box">
-      <Parameter name="low coordinate" type="Array(double)" value="{0.2,0.2}"/>
-      <Parameter name="high coordinate" type="Array(double)" value="{0.8,0.8}"/>
+      <Parameter name="low coordinate" type="Array(double)" value="{0.2, 0.2}"/>
+      <Parameter name="high coordinate" type="Array(double)" value="{0.8, 0.8}"/>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
+

--- a/src/mpc/test/mpc_alquimia_transport.xml
+++ b/src/mpc/test/mpc_alquimia_transport.xml
@@ -13,11 +13,12 @@
       </ParameterList>
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{100, 1, 1}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000000000000000e+02, 1.00000000000000000e+00, 1.00000000000000000e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{100.000000000000000, 1.00000000000000000, 1.00000000000000000}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
@@ -30,45 +31,45 @@
     </ParameterList>
     <ParameterList name="west">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, 0.00000000000000000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.00000000000000000e+00, 1.00000000000000000e+00, 1.00000000000000000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0e-17, 0e-17, 0e-17}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0e-17, 1.00000000000000000, 1.00000000000000000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="east">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0e+02, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+02, 1.0, 1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0e+2, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+2, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_rt"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1556926e+07, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
   </ParameterList>
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_rt"/>
     <Parameter name="file name digits" type="int" value="5"/>
-    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
-  </ParameterList>  
-
+    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
+  </ParameterList>
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
       <ParameterList name="saturation_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
@@ -82,14 +83,14 @@
         </ParameterList>
       </ParameterList>
       <ParameterList name="mass_density_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -97,14 +98,17 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.00000000000000000e+00, 0.00000000000000000e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0e-17, 0e-17, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
 
       <ParameterList name="volumetric_flow_rate">
@@ -123,18 +127,19 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                  <Parameter name="value" type="double" value="0e-17"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.86340000000000002e-06"/>
+                  <Parameter name="value" type="double" value="0.00000186340000000000002"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -163,6 +168,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -170,20 +176,23 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325000000000000e+05"/>
+                <Parameter name="value" type="double" value="201325.000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="geochemical conditions">
         <ParameterList name="initial">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -194,13 +203,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000008e-05"/>
+                  <Parameter name="value" type="double" value="0.0000100000000000000008"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -211,13 +221,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000008e-05"/>
+                  <Parameter name="value" type="double" value="0.0000100000000000000008"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -228,13 +239,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000000000000000e+00"/>
+                  <Parameter name="value" type="double" value="2.00000000000000000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="free_ion_species">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -245,23 +257,24 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000006e-09"/>
+                  <Parameter name="value" type="double" value="1.00000000000000006e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000006e-09"/>
+                  <Parameter name="value" type="double" value="1.00000000000000006e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000006e-09"/>
+                  <Parameter name="value" type="double" value="1.00000000000000006e-9"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -283,11 +296,11 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="end period time" type="double" value="1.57784630000000000e+06"/>
+        <Parameter name="start period time" type="double" value="0e-17"/>
+        <Parameter name="end period time" type="double" value="1577846.30000000000"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.57680000000000000e+05"/>
-        <Parameter name="maximum timestep" type="double" value="6.00000000000000000e+10"/>
+        <Parameter name="initial timestep" type="double" value="157680.000000000000"/>
+        <Parameter name="maximum timestep" type="double" value="60000000000.0000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{H+, HCO3-, Ca++}"/>
@@ -302,13 +315,16 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/>
+
     </ParameterList>
+
     <ParameterList name="transport">
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="1.00000000000000000e+00"/>
+      <Parameter name="cfl" type="double" value="1.00000000000000000"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <Parameter name="enable internal tests" type="bool" value="false"/>
@@ -318,6 +334,7 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -336,26 +353,31 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="geochemical">
           <ParameterList name="west_bc">
             <Parameter name="regions" type="Array(string)" value="{west}"/>
             <Parameter name="solutes" type="Array(string)" value="{H+, HCO3-, Ca++}"/>
-            <Parameter name="times" type="Array(double)" value="{0.00000000000000000e+00, 1.00000000000000000e+20}"/>
+            <Parameter name="times" type="Array(double)" value="{0e-17, 1.00000000000000000e+20}"/>
             <Parameter name="geochemical conditions" type="Array(string)" value="{west, west}"/>
             <Parameter name="time functions" type="Array(string)" value="{constant}"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="3"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="chemistry">
       <Parameter name="engine" type="string" value="PFloTran"/>
       <Parameter name="chemistry model" type="string" value="Alquimia"/>
@@ -366,17 +388,19 @@
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+05"/>
+      <Parameter name="initial timestep (s)" type="double" value="1.0e+5"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -392,15 +416,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>

--- a/src/mpc/test/mpc_biot_consolidation.xml
+++ b/src/mpc/test/mpc_biot_consolidation.xml
@@ -8,14 +8,13 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{40, 6}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
@@ -24,38 +23,38 @@
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 10.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{10.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 3.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 3.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.999e+98, -9.999e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98,  9.999e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98, 9.999e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -154,20 +153,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -10.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -181,6 +184,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -194,6 +198,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -207,6 +212,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -230,6 +236,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -237,12 +244,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+07"/>
+                <Parameter name="value" type="double" value="1.0e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -256,6 +264,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -270,9 +279,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -283,12 +294,10 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 7.2e+03, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 7.2e+3, -1.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -304,10 +313,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="3.6e+04"/>
+        <Parameter name="end period time" type="double" value="3.6e+4"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0"/>
-        <Parameter name="maximum timestep" type="double" value="1.44e+04"/>
+        <Parameter name="maximum timestep" type="double" value="1.44e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -321,8 +330,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:mechanics}"/>
@@ -340,14 +349,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -364,9 +373,11 @@
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="200"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -381,30 +392,35 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.0e+07"/>
+          <Parameter name="reference pressure" type="double" value="1.0e+7"/>
           <Parameter name="pore compressibility" type="double" value="1.0e-10"/>
           <Parameter name="biot coefficient" type="double" value="1.0"/>
           <Parameter name="rock thermal dilation" type="double" value="0.0"/>
           <Parameter name="liquid thermal dilation" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -424,6 +440,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -442,14 +459,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -465,6 +482,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -479,9 +497,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -499,14 +519,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -522,6 +542,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -532,11 +553,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -567,7 +590,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e+07"/>
+                  <Parameter name="value" type="double" value="1.0e+7"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -579,10 +602,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -622,7 +648,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_biot_consolidation_darcy.xml
+++ b/src/mpc/test/mpc_biot_consolidation_darcy.xml
@@ -8,14 +8,13 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{40, 6}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
@@ -24,42 +23,41 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 10.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{10.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 3.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 3.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.999e+98, -9.999e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98,  9.999e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98, 9.999e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -102,7 +100,7 @@
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="4.333330e-07"/>
+            <Parameter name="value" type="double" value="4.333330e-7"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -136,23 +134,28 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -10.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -166,6 +169,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -179,6 +183,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -192,6 +197,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -215,6 +221,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -222,12 +229,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+07"/>
+                <Parameter name="value" type="double" value="1.0e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -241,6 +249,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -255,6 +264,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -266,12 +276,10 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 7.2e+03, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 7.2e+3, -1.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -287,10 +295,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="3.6e+04"/>
+        <Parameter name="end period time" type="double" value="3.6e+4"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0"/>
-        <Parameter name="maximum timestep" type="double" value="1.44e+04"/>
+        <Parameter name="maximum timestep" type="double" value="1.44e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -304,8 +312,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:mechanics}"/>
@@ -321,14 +329,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -345,9 +353,11 @@
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="200"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -355,6 +365,7 @@
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -371,6 +382,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -384,14 +396,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -407,6 +419,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -421,9 +434,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -441,14 +456,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -464,6 +479,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -474,11 +490,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -509,7 +527,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e+07"/>
+                  <Parameter name="value" type="double" value="1.0e+7"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -521,10 +539,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -552,7 +573,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_biot_mcnamee_gibson.xml
+++ b/src/mpc/test/mpc_biot_mcnamee_gibson.xml
@@ -8,14 +8,13 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{30, 45}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{6.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
@@ -24,50 +23,50 @@
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 8.99}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 6.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{6.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTopLoad">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 9.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{ 1.0, 9.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 9.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTopRest">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 1.0, 9.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 9.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 6.8}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{ 0.2, 7.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 6.8}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.2, 7.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.999e+98, -9.999e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98,  9.999e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98, 9.999e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -166,20 +165,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -10.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -193,6 +196,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -206,6 +210,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -219,6 +224,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -242,6 +248,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -255,6 +262,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -269,9 +277,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -282,7 +292,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!--ParameterList name="visualization data">
     <Parameter name="time units" type="string" value="s"/>
     <Parameter name="file name base" type="string" value="plot"/>
@@ -295,10 +304,9 @@
       <Parameter name="region" type="string" value="Well"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="aqueous pressure"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -331,14 +339,13 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:mechanics}"/>
       <Parameter name="domain name" type="string" value=""/>
       <Parameter name="initialize displacement" type="bool" value="true"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -352,14 +359,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -375,11 +382,13 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="200"/>
-        <Parameter name="error tolerance" type="double" value="1e-5"/>
+        <Parameter name="error tolerance" type="double" value="0.00001"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -394,12 +403,14 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
@@ -412,12 +423,15 @@
           <Parameter name="liquid thermal dilation" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -437,6 +451,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -455,14 +470,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.1"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -478,10 +493,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
-            <Parameter name="regions" type="Array(string)" value="{SurfaceTopLoad,SurfaceTopRest}"/>
+            <Parameter name="regions" type="Array(string)" value="{SurfaceTopLoad, SurfaceTopRest}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
@@ -492,9 +508,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -512,14 +530,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.1"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -535,6 +553,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -545,15 +564,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
-            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom,SurfaceRight}"/>
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom, SurfaceRight}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="no slip">
               <Parameter name="number of dofs" type="int" value="2"/>
@@ -603,10 +624,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -646,7 +670,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_biot_schiffman.xml
+++ b/src/mpc/test/mpc_biot_schiffman.xml
@@ -8,14 +8,13 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{40, 6}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
@@ -24,38 +23,38 @@
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 10.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{10.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 3.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 3.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{10.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.999e+98, -9.999e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98,  9.999e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.999e+98, 9.999e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -154,20 +153,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -10.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -181,6 +184,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -194,6 +198,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -207,6 +212,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -230,6 +236,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -243,6 +250,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -256,6 +264,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -270,9 +279,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -283,12 +294,10 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 20.0, -1.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -321,8 +330,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:mechanics}"/>
@@ -340,14 +349,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -363,11 +372,13 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="200"/>
-        <Parameter name="error tolerance" type="double" value="2e-6"/>
+        <Parameter name="error tolerance" type="double" value="0.000002"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -382,30 +393,35 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.0e+07"/>
+          <Parameter name="reference pressure" type="double" value="1.0e+7"/>
           <Parameter name="pore compressibility" type="double" value="1.0e-10"/>
           <Parameter name="biot coefficient" type="double" value="0.9"/>
           <Parameter name="rock thermal dilation" type="double" value="0.0"/>
           <Parameter name="liquid thermal dilation" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -425,6 +441,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -443,14 +460,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -466,6 +483,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -480,9 +498,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -500,14 +520,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-06"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -523,6 +543,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -533,11 +554,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -569,7 +592,7 @@
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-exprtk">
                   <Parameter name="number of arguments" type="int" value="2"/>
-                  <Parameter name="formula" type="string" value="if (t > 100, 1.0e+7, 1.0e+5 * t)"/>
+                  <Parameter name="formula" type="string" value="if (t &gt; 100, 1.0e+7, 1.0e+5 * t)"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -581,10 +604,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -624,7 +650,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_coupled_dispersive_transport.xml
+++ b/src/mpc/test/mpc_coupled_dispersive_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 50, -1}"/>
@@ -9,29 +8,28 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 50, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,3.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 3.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 6.0, 6.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 3.01, 0.0, 3.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{3.01, 0.0, 3.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{3.12, 6.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
@@ -60,12 +58,11 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="max timestep size" type="double" value="1.0e+6"/>    
+    <Parameter name="max timestep size" type="double" value="1.0e+6"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
+        <ParameterList name="PK tree">
           <ParameterList name="coupled transport">
             <Parameter name="PK type" type="string" value="transport matrix fracture"/>
             <ParameterList name="transport matrix">
@@ -75,29 +72,25 @@
               <Parameter name="PK type" type="string" value="transport"/>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="0.05"/>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0e+5"/>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="0.05"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0e+5"/>
         <Parameter name="maximum timestep" type="double" value="3.0e+3"/>
-        <Parameter name="maximum cycle number" type="int" value="-1"/> 
+        <Parameter name="maximum cycle number" type="int" value="-1"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{tracer}"/>
     <Parameter name="component molar masses" type="Array(double)" value="{0.0}"/>
-    
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{0.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{1.0}"/>
       <!--Parameter name="maximum timestep" type="Array(double)" value="{1000.0}"/-->
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
@@ -145,7 +138,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -174,7 +166,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="solute diffusion to matrix"/>
         <Parameter name="porosity key" type="string" value="porosity"/>
@@ -184,14 +175,16 @@
         <Parameter name="molecular diffusion" type="double" value="2.5e-9"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
@@ -224,6 +217,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -235,7 +229,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-06"/>
+                  <Parameter name="value" type="double" value="0.0000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -287,8 +281,8 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
-      
+      </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -302,6 +296,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -315,15 +310,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -332,7 +326,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="2"/>
         <Parameter name="cycle applications" type="int" value="3"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -340,7 +334,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -354,25 +347,25 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+
     </ParameterList>
-    
+
     <ParameterList name="transport matrix">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="domain"/>      
+      <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
+      <Parameter name="transport subcycling" type="bool" value="false"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
@@ -400,7 +393,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{tracer}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-5}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.00001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -415,18 +408,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>      
-      
+
+    </ParameterList>
+
     <ParameterList name="transport fracture">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="fracture"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/> 
+      <Parameter name="domain name" type="string" value="fracture"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
@@ -455,7 +448,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{tracer}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-5}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.00001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -470,26 +463,30 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions">      
-	<ParameterList name="concentration">
-	  <ParameterList name="tracer">
-	    <ParameterList name="BC 0">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="concentration">
+          <ParameterList name="tracer">
+            <ParameterList name="BC 0">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
+              <ParameterList name="boundary concentration">
                 <ParameterList name="function-exprtk">
                   <Parameter name="number of arguments" type="int" value="1"/>
                   <Parameter name="formula" type="string" value="1.0"/>
                 </ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="observation data">
@@ -502,7 +499,6 @@
       <Parameter name="region" type="string" value="Well"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{SurfaceLeft}"/>
@@ -514,4 +510,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_coupled_energy.xml
+++ b/src/mpc/test/mpc_coupled_energy.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -36,7 +35,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
@@ -125,7 +123,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                <Parameter name="value" type="double" value="0.00100000000000000002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -152,7 +150,7 @@
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+            <Parameter name="value" type="double" value="0e-17"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -163,7 +161,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+00"/>
+                <Parameter name="value" type="double" value="1.00000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -177,7 +175,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.65000000e+3"/>
+                <Parameter name="value" type="double" value="2650.00000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -192,7 +190,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="7.60e+1"/>
+              <Parameter name="heat capacity" type="double" value="76.0"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -205,7 +203,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.04600000e+3"/>
+              <Parameter name="heat capacity" type="double" value="1046.00000"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -255,7 +253,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.65000000e+3"/>
+                <Parameter name="value" type="double" value="2650.00000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -270,7 +268,7 @@
             <Parameter name="regions" type="Array(string)" value="{fracture}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="7.60e+1"/>
+              <Parameter name="heat capacity" type="double" value="76.0"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -310,7 +308,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                <Parameter name="value" type="double" value="0.00100000000000000002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -324,7 +322,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                <Parameter name="value" type="double" value="0.00100000000000000002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -358,26 +356,30 @@
             <Parameter name="regions" type="Array(string)" value="{fracture}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.04600000e+3"/>
+              <Parameter name="heat capacity" type="double" value="1046.00000"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81000000000000050e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81000000000000050}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+        <Parameter name="value" type="double" value="0.00100000000000000002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -406,6 +408,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -419,6 +422,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -432,6 +436,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -460,6 +465,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -474,6 +480,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -495,13 +502,14 @@
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45000000000000001e-04"/>
+                  <Parameter name="value" type="double" value="0.000145000000000000001"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -516,9 +524,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -529,7 +539,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -547,8 +556,8 @@
         <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="0.0"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+06"/>
-        <Parameter name="maximum timestep" type="double" value="1.0e+06"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+6"/>
+        <Parameter name="maximum timestep" type="double" value="1.0e+6"/>
       </ParameterList>
       <ParameterList name="TP 1">
         <ParameterList name="PK tree">
@@ -581,6 +590,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="steady:coupled flow">
       <Parameter isUsed="true" name="PK type" type="string" value="darcy matrix fracture"/>
       <Parameter name="PKs order" type="Array(string)" value="{steady:flow matrix, steady:flow fracture}"/>
@@ -600,17 +610,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000004e-10"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -619,8 +629,8 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
@@ -632,15 +642,19 @@
           <Parameter name="active wells" type="bool" value="false"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="steady:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -671,6 +685,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -682,13 +697,14 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.0e+05"/>
+                <Parameter name="value" type="double" value="2.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -698,7 +714,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -706,25 +722,31 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="steady:flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for fracture">
           <Parameter name="region" type="string" value="fracture"/>
           <Parameter name="model" type="string" value="cubic law"/>
-          <Parameter name="aperture" type="double" value="0.00000000000000000e+00"/>
+          <Parameter name="aperture" type="double" value="0e-17"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -751,6 +773,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -762,13 +785,14 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="mass flux">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="outward mass flux">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="-4.05000000000000027e-01"/>
+                <Parameter name="value" type="double" value="-0.405000000000000027"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -781,7 +805,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -789,10 +813,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:coupled energy">
       <Parameter isUsed="true" name="PK type" type="string" value="energy matrix fracture"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:energy matrix, transient:energy fracture}"/>
@@ -812,22 +839,22 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
             <Parameter name="max timestep" type="double" value="4.32340000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.00000000000e+12"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000e+10"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0"/>
+            <Parameter name="max du growth factor" type="double" value="10000000000.0"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
             <Parameter name="modify correction" type="bool" value="false"/>
-            <Parameter name="max error growth factor" type="double" value="1.00000000000e+10"/>
+            <Parameter name="max error growth factor" type="double" value="10000000000.0"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
@@ -840,10 +867,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:energy matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
@@ -866,22 +896,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="All">
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="2.594"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="constant"/>
+            <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="2.594"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -893,6 +925,7 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -906,20 +939,25 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:energy fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="operators">
@@ -938,22 +976,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="All">
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.0"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="constant"/>
+            <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.0"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -965,6 +1005,7 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -987,23 +1028,29 @@
           </ParameterList-->
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -1020,7 +1067,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -1028,7 +1074,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="2"/>
         <Parameter name="cycle applications" type="int" value="4"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -1036,29 +1082,27 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="energy.out"/>
     <Parameter name="precision" type="int" value="10"/>
     <ParameterList name="obs1">
       <Parameter name="region" type="string" value="All"/>
-      <Parameter name="domain name" type="string" value="fracture"/>      
+      <Parameter name="domain name" type="string" value="fracture"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
       <Parameter name="variable" type="string" value="temperature"/>
-      <Parameter name="times start period stop 0" type="Array(double)" value="{1e+6, 1e+6, -1}"/>
+      <Parameter name="times start period stop 0" type="Array(double)" value="{1e+6, 1e+6, -1.0}"/>
     </ParameterList>
     <ParameterList name="obs2">
       <Parameter name="region" type="string" value="All"/>
-      <Parameter name="domain name" type="string" value="domain"/>      
+      <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
       <Parameter name="variable" type="string" value="temperature"/>
-      <Parameter name="times start period stop 0" type="Array(double)" value="{1e+6, 1e+6, -1}"/>
+      <Parameter name="times start period stop 0" type="Array(double)" value="{1e+6, 1e+6, -1.0}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow.xml
+++ b/src/mpc/test/mpc_coupled_flow.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_coupled"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -14,7 +13,6 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 6, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Universe">
       <ParameterList name="region: all">
@@ -22,49 +20,49 @@
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,60.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 216.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{216.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 60.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -95,7 +93,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <Parameter name="io frequency" type="int" value="20"/>
     <ParameterList name="time periods">
@@ -127,7 +124,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
@@ -136,7 +132,7 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1e-3"/>
+            <Parameter name="value" type="double" value="0.001"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -146,11 +142,10 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1e-3"/>
+            <Parameter name="value" type="double" value="0.001"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -193,7 +188,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-aperture">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -202,7 +196,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -214,11 +208,10 @@
         <Parameter name="domain name" type="string" value="fracture"/>
         <Parameter name="variable name" type="string" value="fracture-aperture"/>
         <Parameter name="component name" type="string" value="cell"/>
-        <Parameter name="constant in time" type="bool" value="false"/>        
+        <Parameter name="constant in time" type="bool" value="false"/>
         <Parameter name="mesh entity" type="string" value="cell"/>
         <Parameter name="number of dofs" type="int" value="1"/>
       </ParameterList>
-
       <ParameterList name="fracture-compliance">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -248,20 +241,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -283,12 +280,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9240e-07"/>
+                <Parameter name="value" type="double" value="3.9240e-7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -347,7 +345,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -355,6 +353,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -362,7 +361,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -370,6 +369,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -377,7 +377,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -385,7 +384,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="1"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -405,7 +404,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -418,40 +416,37 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="maximum number of iterations" type="int" value="100"/>
-      <Parameter name="error tolerance" type="double" value="1e-6"/>
-      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>      
-
+      <Parameter name="error tolerance" type="double" value="0.000001"/>
+      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, pressure fracture}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25000e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="extreme"/>
-            </ParameterList>            
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-9"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -459,137 +454,139 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="freeze preconditioner" type="bool" value="true"/>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
-          </ParameterList>                        
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
-      </ParameterList>                        
+      </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="0.0"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
 
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-2.0e-3, -2.0e-3}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="0.0"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.0020, -0.0020}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for Entire Domain">
-	  <Parameter name="region" type="string" value="All"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	  <Parameter name="aperture" type="double" value="1.0"/>
-	</ParameterList>
+        <ParameterList name="FPM for Entire Domain">
+          <Parameter name="region" type="string" value="All"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+          <Parameter name="aperture" type="double" value="1.0"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow_aperture.xml
+++ b/src/mpc/test/mpc_coupled_flow_aperture.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -19,7 +18,7 @@
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{250, 10, 10}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{-12.5, -0.5, -0.5}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{12.5,  0.5,  0.5}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{12.5, 0.5, 0.5}"/>
       </ParameterList>
       <ParameterList name="submesh">
         <Parameter name="regions" type="Array(string)" value="{FRACTURE_NETWORK_INTERNAL}"/>
@@ -32,14 +31,15 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -5.0e-01, -5.0e-01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  5.0e-01,  5.0e-01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.50, -0.50}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.50, 0.50}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
@@ -92,7 +92,7 @@
           <ParameterList name="fracture">
             <Parameter name="regions" type="Array(string)" value="{fracture}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="5.0e-6"/>
+            <Parameter name="value" type="double" value="0.0000050"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -104,7 +104,7 @@
             <Parameter name="components" type="Array(string)" value="{*}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -118,13 +118,12 @@
             <Parameter name="components" type="Array(string)" value="{*}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -164,12 +163,10 @@
         </ParameterList>
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
-
       <ParameterList name="fracture-aperture">
         <Parameter name="evaluator type" type="string" value="aperture"/>
         <Parameter name="pressure key" type="string" value="fracture-pressure"/>
       </ParameterList>
-
       <ParameterList name="fracture-molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="fracture-molar_density_liquid"/>
@@ -210,20 +207,24 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -252,6 +253,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -265,6 +267,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -272,14 +275,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -293,6 +297,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -300,17 +305,19 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -321,7 +328,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -355,6 +361,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -378,7 +385,7 @@
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.00e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.00e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.00e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -395,10 +402,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -411,15 +421,18 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -443,21 +456,23 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.19e+07"/>
+                <Parameter name="y0" type="double" value="1.19e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -467,9 +482,9 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.1e+07"/>
+                <Parameter name="y0" type="double" value="1.1e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -477,9 +492,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow fracture">
@@ -491,9 +508,11 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -504,25 +523,29 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture aperture models">
         <ParameterList name="FAM_0">
           <Parameter name="fracture aperture model" type="string" value="Barton-Bandis"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
-          <Parameter name="undeformed aperture" type="double" value="1e-5"/>
-          <Parameter name="overburden pressure" type="double" value="11e+6"/>
+          <Parameter name="undeformed aperture" type="double" value="0.00001"/>
+          <Parameter name="overburden pressure" type="double" value="1.1e+7"/>
           <Parameter name="BartonBandis A" type="double" value="1e-11"/>
           <Parameter name="BartonBandis B" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -542,12 +565,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -566,9 +591,9 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -576,10 +601,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -596,7 +624,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_coupled_flow_aperture_darcy.xml
+++ b/src/mpc/test/mpc_coupled_flow_aperture_darcy.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -32,6 +31,7 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
@@ -82,7 +82,7 @@
           <ParameterList name="EntireDomain">
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="9.81e-07"/>
+            <Parameter name="value" type="double" value="9.81e-7"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -92,11 +92,10 @@
           <ParameterList name="fracture">
             <Parameter name="regions" type="Array(string)" value="{fracture}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="5.0e-6"/>
+            <Parameter name="value" type="double" value="0.0000050"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -104,7 +103,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00e+03"/>
+                <Parameter name="value" type="double" value="1.00e+3"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -158,7 +157,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00e+03"/>
+                <Parameter name="value" type="double" value="1.00e+3"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -242,7 +241,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00e+00"/>
+                <Parameter name="value" type="double" value="1.00"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -251,18 +250,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -291,6 +295,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -304,6 +309,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -311,14 +317,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -335,12 +342,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00e+00"/>
+                <Parameter name="value" type="double" value="1.00"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -348,17 +356,19 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -372,8 +382,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{EntireDomain}"/>
@@ -387,7 +397,6 @@
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 100.0, -1.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -403,9 +412,9 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.00e+03"/>
+        <Parameter name="end period time" type="double" value="1.00e+3"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-03"/>
+        <Parameter name="initial timestep" type="double" value="0.0010"/>
         <Parameter name="maximum timestep" type="double" value="20.0"/>
       </ParameterList>
     </ParameterList>
@@ -420,8 +429,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -438,14 +447,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.12"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -462,15 +471,19 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -484,6 +497,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
@@ -495,15 +509,16 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.190e+07"/>
+                <Parameter name="y0" type="double" value="1.190e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -513,9 +528,9 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -523,10 +538,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
@@ -536,12 +554,15 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -560,6 +581,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
@@ -571,15 +593,16 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.190e+07"/>
+                <Parameter name="y0" type="double" value="1.190e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -589,9 +612,9 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.10e+07"/>
+                <Parameter name="y0" type="double" value="1.10e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.80664999999999964e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9806.64999999999964}"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -599,10 +622,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -637,6 +663,6 @@
   </ParameterList>
   <ParameterList name="visualization data fracture">
     <Parameter name="file name base" type="string" value="plot_fracture"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.00e+02, -1.00e+00}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 200.0, -1.00}"/>
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow_reactive_transport.xml
+++ b/src/mpc/test/mpc_coupled_flow_reactive_transport.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -30,10 +29,10 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
@@ -91,7 +90,7 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -101,7 +100,7 @@
       </ParameterList>
       <ParameterList name="fracture-specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -109,7 +108,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -131,7 +129,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.5e-01"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -140,7 +138,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.00000000000000011e-01"/>
+                <Parameter name="value" type="double" value="0.200000000000000011"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -168,7 +166,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.00000000000000008e-03"/>
+                <Parameter name="value" type="double" value="0.00400000000000000008"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -182,7 +180,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0627e-03"/>
+                <Parameter name="value" type="double" value="0.0010627"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -231,7 +229,6 @@
         </ParameterList>
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -247,20 +244,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -320,7 +321,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.0e-03"/>
+                <Parameter name="value" type="double" value="0.0020"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -375,6 +376,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -388,6 +390,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <Parameter name="names" type="Array(string)" value="{total, total, total}"/>
         <ParameterList name="function">
@@ -416,9 +419,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="isotherm_kd">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -469,6 +474,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="isotherm_langmuir_b">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -519,6 +525,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="isotherm_freundlich_n">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -569,6 +576,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-isotherm_kd">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -596,6 +604,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-isotherm_langmuir_b">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -623,6 +632,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-isotherm_freundlich_n">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -650,6 +660,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -663,6 +674,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -676,6 +688,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -683,10 +696,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.15576000000000000e+07, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 31557600.0000000000, -1.0}"/>
   </ParameterList>
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="observation.out"/>
@@ -694,7 +706,7 @@
       <Parameter name="variable" type="string" value="A aqueous concentration"/>
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
-      <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.00000000000000000e+07, -1.0}"/>
+      <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 10000000.0000000000, -1.0}"/>
       <Parameter name="region" type="string" value="RegionBottom"/>
     </ParameterList>
   </ParameterList>
@@ -755,26 +767,26 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="6.31152000000000000e+07"/>
+        <Parameter name="end period time" type="double" value="63115200.0000000000"/>
         <Parameter name="maximum cycle number" type="int" value="10"/>
         <Parameter name="initial timestep" type="double" value="10.0"/>
-        <Parameter name="maximum timestep" type="double" value="1.72800000000000000e+05"/>
+        <Parameter name="maximum timestep" type="double" value="172800.000000000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{A, B, C}"/>
     <Parameter name="number of liquid components" type="int" value="3"/>
     <Parameter name="component molar masses" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
     <ParameterList name="time period control">
-      <Parameter name="start times" type="Array(double)" value="{8.64000000000000000e+06}"/>
+      <Parameter name="start times" type="Array(double)" value="{8640000.00000000000}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{10.0}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{1.72800000000000000e+05}"/>
+      <Parameter name="maximum timestep" type="Array(double)" value="{172800.000000000000}"/>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow steady">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix steady, flow fracture steady}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -794,13 +806,13 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1000.0"/>
@@ -826,12 +838,15 @@
           <Parameter name="active wells" type="bool" value="false"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix steady">
@@ -839,6 +854,7 @@
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -870,6 +886,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -881,6 +898,7 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="static head">
           <ParameterList name="BC 0">
@@ -894,11 +912,11 @@
                 <Parameter name="space dimension" type="int" value="3"/>
                 <Parameter name="density" type="double" value="1000.0"/>
                 <Parameter name="gravity" type="double" value="10.0"/>
-                <Parameter name="p0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="p0" type="double" value="101325.000000000000"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-tabular">
-                    <Parameter name="x values" type="Array(double)" value="{0.0, 8.64000000000000000e+06}"/>
-                    <Parameter name="y values" type="Array(double)" value="{4.00000000000000000e+00, 4.00000000000000000e+00}"/>
+                    <Parameter name="x values" type="Array(double)" value="{0.0, 8640000.00000000000}"/>
+                    <Parameter name="y values" type="Array(double)" value="{4.00000000000000000, 4.00000000000000000}"/>
                     <Parameter name="forms" type="Array(string)" value="{constant}"/>
                   </ParameterList>
                 </ParameterList>
@@ -917,7 +935,7 @@
                 <Parameter name="space dimension" type="int" value="3"/>
                 <Parameter name="density" type="double" value="1000.0"/>
                 <Parameter name="gravity" type="double" value="10.0"/>
-                <Parameter name="p0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="p0" type="double" value="101325.000000000000"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-constant">
                     <Parameter name="value" type="double" value="1.0"/>
@@ -929,12 +947,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture steady">
@@ -945,13 +966,16 @@
           <Parameter name="model" type="string" value="cubic law"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -982,6 +1006,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -993,17 +1018,22 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="coupled flow and reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{coupled flow, coupled reactive transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -1022,14 +1052,14 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1000.0"/>
@@ -1054,12 +1084,15 @@
           <Parameter name="active wells" type="bool" value="false"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
@@ -1067,6 +1100,7 @@
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1098,6 +1132,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -1109,6 +1144,7 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="static head">
           <ParameterList name="BC 0">
@@ -1122,11 +1158,11 @@
                 <Parameter name="space dimension" type="int" value="3"/>
                 <Parameter name="density" type="double" value="1000.0"/>
                 <Parameter name="gravity" type="double" value="10.0"/>
-                <Parameter name="p0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="p0" type="double" value="101325.000000000000"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-tabular">
-                    <Parameter name="x values" type="Array(double)" value="{0.0, 8.64000000000000000e+06}"/>
-                    <Parameter name="y values" type="Array(double)" value="{4.00000000000000000e+00, 4.00000000000000000e+00}"/>
+                    <Parameter name="x values" type="Array(double)" value="{0.0, 8640000.00000000000}"/>
+                    <Parameter name="y values" type="Array(double)" value="{4.00000000000000000, 4.00000000000000000}"/>
                     <Parameter name="forms" type="Array(string)" value="{constant}"/>
                   </ParameterList>
                 </ParameterList>
@@ -1145,7 +1181,7 @@
                 <Parameter name="space dimension" type="int" value="3"/>
                 <Parameter name="density" type="double" value="1000.0"/>
                 <Parameter name="gravity" type="double" value="10.0"/>
-                <Parameter name="p0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="p0" type="double" value="101325.000000000000"/>
                 <ParameterList name="water table elevation">
                   <ParameterList name="function-constant">
                     <Parameter name="value" type="double" value="1.0"/>
@@ -1157,29 +1193,36 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for fracture">
           <Parameter name="region" type="string" value="fracture"/>
           <Parameter name="model" type="string" value="cubic law"/>
-          <Parameter name="aperture" type="double" value="3.46410000000000026e-05"/>
+          <Parameter name="aperture" type="double" value="0.0000346410000000000026"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1210,6 +1253,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -1221,9 +1265,11 @@
         </ParameterList>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled reactive transport">
@@ -1232,6 +1278,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled chemistry">
@@ -1240,7 +1287,9 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="chemistry matrix">
       <Parameter isUsed="true" name="domain name" type="string" value="domain"/>
       <Parameter name="chemistry model" type="string" value="Amanzi"/>
@@ -1249,11 +1298,11 @@
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.00000000000000000e+07"/>
+      <Parameter name="initial timestep (s)" type="double" value="10000000.0000000000"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
@@ -1261,10 +1310,13 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="chemistry fracture">
       <Parameter isUsed="true" name="domain name" type="string" value="fracture"/>
       <Parameter name="chemistry model" type="string" value="Amanzi"/>
@@ -1273,11 +1325,11 @@
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.00000000000000000e+07"/>
+      <Parameter name="initial timestep (s)" type="double" value="10000000.0000000000"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
@@ -1285,10 +1337,13 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -1307,14 +1362,14 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1000.0"/>
@@ -1333,15 +1388,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transport matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="9.00000000000000022e-01"/>
+      <Parameter name="cfl" type="double" value="0.900000000000000022"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
@@ -1353,11 +1411,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{A, B, C}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{9.99999999999999943e-30, 9.99999999999999943e-30, 9.99999999999999943e-30}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1384,6 +1444,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="A">
@@ -1391,7 +1452,7 @@
               <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                  <Parameter name="value" type="double" value="0.00100000000000000002"/>
                 </ParameterList>
               </ParameterList>
               <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -1403,7 +1464,7 @@
               <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                  <Parameter name="value" type="double" value="0.00100000000000000002"/>
                 </ParameterList>
               </ParameterList>
               <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -1415,7 +1476,7 @@
               <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+                  <Parameter name="value" type="double" value="0.00100000000000000002"/>
                 </ParameterList>
               </ParameterList>
               <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -1424,6 +1485,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="3"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -1431,15 +1493,18 @@
         <Parameter name="permeability field is required" type="bool" value="false"/>
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transport fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="9.00000000000000022e-01"/>
+      <Parameter name="cfl" type="double" value="0.900000000000000022"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
@@ -1451,11 +1516,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{A, B, C}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{9.99999999999999943e-30, 9.99999999999999943e-30, 9.99999999999999943e-30}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1481,6 +1548,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="3"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -1488,10 +1556,13 @@
         <Parameter name="permeability field is required" type="bool" value="false"/>
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -1563,7 +1634,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -1583,41 +1654,39 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="A">
-        <Parameter name="ion size parameter" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="0e-17"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000"/>
       </ParameterList>
       <ParameterList name="B">
-        <Parameter name="ion size parameter" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="0e-17"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000"/>
       </ParameterList>
       <ParameterList name="C">
-        <Parameter name="ion size parameter" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="0e-17"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.00000000000000000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="isotherms">
       <ParameterList name="A">
         <Parameter name="model" type="string" value="linear"/>
-        <Parameter name="parameters" type="Array(double)" value="{1.20000000000000000e+08}"/>
+        <Parameter name="parameters" type="Array(double)" value="{120000000.000000000}"/>
       </ParameterList>
       <ParameterList name="B">
         <Parameter name="model" type="string" value="langmuir"/>
-        <Parameter name="parameters" type="Array(double)" value="{3.40000000000000000e+09, 1.23000000000000005e-11}"/>
+        <Parameter name="parameters" type="Array(double)" value="{3400000000.00000000, 1.23000000000000005e-11}"/>
       </ParameterList>
       <ParameterList name="C">
         <Parameter name="model" type="string" value="freundlich"/>
-        <Parameter name="parameters" type="Array(double)" value="{4.50000000000000000e+10, 4.55999999999999996e-12}"/>
+        <Parameter name="parameters" type="Array(double)" value="{45000000000.0000000, 4.55999999999999996e-12}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{SurfaceInlet, SurfaceOutlet}"/>
@@ -1630,7 +1699,6 @@
   </ParameterList>
   <ParameterList name="visualization data fracture">
     <Parameter name="file name base" type="string" value="plot_fracture"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.155760e+07, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.155760e+7, -1.0}"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_coupled_flow_richards.xml
+++ b/src/mpc/test/mpc_coupled_flow_richards.xml
@@ -8,11 +8,9 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="zoltan_rcb"/>
-
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{9, 2, 20}"/>
@@ -25,7 +23,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Universe">
       <ParameterList name="region: all">
@@ -33,49 +30,49 @@
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,60.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 216.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{216.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 60.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -111,7 +108,6 @@
         </ParameterList>
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
@@ -134,7 +130,6 @@
         <Parameter name="eos basis" type="string" value="both"/>
         <Parameter name="mass density key" type="string" value="fracture-mass_density_liquid"/>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -143,7 +138,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -157,13 +152,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-aperture">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -208,20 +202,24 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
@@ -285,7 +283,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9240e-07"/>
+                <Parameter name="value" type="double" value="3.9240e-7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -299,7 +297,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -307,6 +305,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -314,7 +313,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -336,6 +335,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -350,18 +350,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{RegionBottom, RegionTop}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="observation.out"/>
     <ParameterList name="obl 1">
@@ -372,7 +371,6 @@
       <Parameter name="region" type="string" value="fracture"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -404,8 +402,8 @@
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
@@ -413,24 +411,22 @@
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25000e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -447,9 +443,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow matrix">
@@ -464,15 +462,18 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -496,6 +497,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -509,45 +511,47 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="0.0"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-2.0e-3, -2.0e-3}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="0.0"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.0020, -0.0020}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow fracture">
@@ -574,12 +578,14 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
@@ -603,16 +609,20 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -641,7 +651,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -657,7 +666,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 1, -1}"/>

--- a/src/mpc/test/mpc_coupled_flow_source.xml
+++ b/src/mpc/test/mpc_coupled_flow_source.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Universe">
       <ParameterList name="region: all">
@@ -8,25 +7,25 @@
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0,0.0,5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,10.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WELL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 4.0, 4.0, 4.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{4.0, 4.0, 4.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 6.0, 6.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -49,7 +48,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -80,7 +78,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
@@ -103,7 +100,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -126,7 +122,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.6416e-04"/>
+                <Parameter name="value" type="double" value="0.00046416"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -160,7 +156,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -189,7 +184,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="bulk_modulus">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -205,20 +199,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -240,12 +238,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-03"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -281,7 +280,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -289,6 +288,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -296,7 +296,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -304,6 +304,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -311,7 +312,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -319,7 +319,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="1"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -338,7 +338,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -351,40 +350,37 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="maximum number of iterations" type="int" value="100"/>
-      <Parameter name="error tolerance" type="double" value="1e-6"/>
-      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>      
-
+      <Parameter name="error tolerance" type="double" value="0.000001"/>
+      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, pressure fracture}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25000e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="extreme"/>
-            </ParameterList>            
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-9"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -392,16 +388,16 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="freeze preconditioner" type="bool" value="true"/>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
@@ -409,6 +405,7 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -421,6 +418,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -439,13 +437,12 @@
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="none"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
@@ -453,6 +450,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for Entire Domain">
           <Parameter name="region" type="string" value="All"/>
@@ -477,7 +475,8 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions"/>
+      <ParameterList name="boundary conditions">
+      </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="wells">
@@ -493,19 +492,19 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="none"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--ParameterList name="visualization data">

--- a/src/mpc/test/mpc_coupled_flow_transport.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_coupled"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -14,59 +13,58 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 10, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,60.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 216.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{216.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceCenter">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 72.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{144.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{144.0, 10.0, 120.0}"/>
       </ParameterList>
-    </ParameterList>    
+    </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 60.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -95,7 +93,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -114,10 +111,10 @@
         <Parameter name="end period time" type="double" value="3.0e+10"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0e+5"/>
-        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>        
+        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>
       </ParameterList>
       <ParameterList name="TP 1">
-	<ParameterList name="PK tree">
+        <ParameterList name="PK tree">
           <ParameterList name="coupled transport">
             <Parameter name="PK type" type="string" value="transport matrix fracture"/>
             <ParameterList name="transport matrix">
@@ -127,51 +124,46 @@
               <Parameter name="PK type" type="string" value="transport"/>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="1.00000000000000000e+05"/>
-	<Parameter name="start period time" type="double" value="3.00000000000000000e+10"/>
-	<Parameter name="end period time" type="double" value="4.000000000000000e+10"/>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="100000.000000000000"/>
+        <Parameter name="start period time" type="double" value="30000000000.0000000"/>
+        <Parameter name="end period time" type="double" value="40000000000.00000"/>
         <Parameter name="maximum timestep" type="double" value="5e+5"/>
-        <Parameter name="maximum cycle number" type="int" value="200"/>        
+        <Parameter name="maximum cycle number" type="int" value="200"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
-    
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{6.153732e+10, 6.15688776e+10}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{10.0, 10.0}"/>
       <Parameter name="maximum timestep" type="Array(double)" value="{4.3234e+17, 4.3234e+17}"/>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
       <ParameterList name="fracture-specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -190,11 +182,11 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
-            <Parameter name="regions" type="Array(string)" value="{RegionBottom,RegionTop}"/>
+            <Parameter name="regions" type="Array(string)" value="{RegionBottom, RegionTop}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.6416e-4"/>
+                <Parameter name="value" type="double" value="0.00046416"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -228,7 +220,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -257,7 +248,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="bulk_modulus">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -272,7 +262,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -297,20 +286,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -398,7 +391,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -406,6 +399,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -413,7 +407,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -444,6 +438,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -454,18 +449,18 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0."/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0."/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
+      </ParameterList>
 
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
@@ -480,6 +475,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -493,15 +489,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{RegionBottom, RegionTop}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -509,7 +504,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -529,7 +524,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -542,18 +536,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>      
-
+      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -561,16 +553,15 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.5"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-9"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -578,210 +569,149 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
           <Parameter name="freeze preconditioner" type="bool" value="true"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="0.0"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
 
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-2.0e-3, -2.0e-3}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="0.0"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.0020, -0.0020}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for Entire Domain">
-	  <Parameter name="region" type="string" value="All"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	</ParameterList>
+        <ParameterList name="FPM for Entire Domain">
+          <Parameter name="region" type="string" value="All"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
-    
+
     <ParameterList name="transport matrix">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="domain"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
-      <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
-      <!-- end of developers parameters -->
-      <ParameterList name="reconstruction">
-        <Parameter name="polynomial order" type="int" value="0"/>
-        <Parameter name="limiter" type="string" value="tensorial"/>
-        <Parameter name="limiter extension for transport" type="bool" value="true"/>
-      </ParameterList>
-      <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-          <ParameterList name="coupling">
-            <ParameterList name="BC coupling">
-              <Parameter name="spatial distribution method" type="string" value="domain coupling" />
-              <Parameter name="submodel" type="string" value="field" />
-              <Parameter name="regions" type="Array(string)" value="{fracture}" />
-              <ParameterList name="boundary concentration">
-                <Parameter name="external field key" type="string" value="fracture-total_component_concentration" />
-                <Parameter name="external field copy key" type="string" value="" />
-              </ParameterList>
-            </ParameterList>
-          </ParameterList>          
-	  <ParameterList name="Tc-99">
-	    <ParameterList name="BC for center">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
-              <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Tc-98">
-	    <ParameterList name="BC for center">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
-              <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{0.5, 0.5}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-    </ParameterList>      
-      
-    <ParameterList name="transport fracture">
-      <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="fracture"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
       <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
@@ -789,27 +719,97 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="boundary conditions">      
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="concentration">
+          <ParameterList name="coupling">
+            <ParameterList name="BC coupling">
+              <Parameter name="spatial distribution method" type="string" value="domain coupling"/>
+              <Parameter name="submodel" type="string" value="field"/>
+              <Parameter name="regions" type="Array(string)" value="{fracture}"/>
+              <ParameterList name="boundary concentration">
+                <Parameter name="external field key" type="string" value="fracture-total_component_concentration"/>
+                <Parameter name="external field copy key" type="string" value=""/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Tc-99">
+            <ParameterList name="BC for center">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
+              <Parameter name="spatial distribution method" type="string" value="none"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Tc-98">
+            <ParameterList name="BC for center">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
+              <Parameter name="spatial distribution method" type="string" value="none"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0.5, 0.5}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+    </ParameterList>
+
+    <ParameterList name="transport fracture">
+      <Parameter name="PK type" type="string" value="transport"/>
+      <Parameter name="domain name" type="string" value="fracture"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <Parameter name="transport subcycling" type="bool" value="false"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
+      <!-- end of developers parameters -->
+      <ParameterList name="reconstruction">
+        <Parameter name="polynomial order" type="int" value="0"/>
+        <Parameter name="limiter" type="string" value="tensorial"/>
+        <Parameter name="limiter extension for transport" type="bool" value="true"/>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="concentration">
           <ParameterList name="coupling">
             <ParameterList name="fracture">
-              <Parameter name="regions" type="Array(string)" value="{fracture}" />
-              <Parameter name="spatial distribution method" type="string" value="domain coupling" />
-              <Parameter name="submodel" type="string" value="rate" />
+              <Parameter name="regions" type="Array(string)" value="{fracture}"/>
+              <Parameter name="spatial distribution method" type="string" value="domain coupling"/>
+              <Parameter name="submodel" type="string" value="rate"/>
               <ParameterList name="sink">
-                <Parameter name="flux key" type="string" value="volumetric_flow_rate" />
-                <Parameter name="external field key" type="string" value="total_component_concentration" />
+                <Parameter name="flux key" type="string" value="volumetric_flow_rate"/>
+                <Parameter name="external field key" type="string" value="total_component_concentration"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow_transport_gas.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport_gas.xml
@@ -8,14 +8,13 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{20, 2, 25}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{   0.0,-5.0,   0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, -5.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{100.0, 5.0, 100.0}"/>
       </ParameterList>
       <ParameterList name="submesh">
@@ -34,18 +33,17 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0,-5.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 5.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Source">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0, 2.00000000000000000e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.00000000000000000e+01, 5.0, 4.00000000000000000e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0, 20.0000000000000000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{20.0000000000000000, 5.0, 40.0000000000000000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Rest">
@@ -56,19 +54,19 @@
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 100.0,-5.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{100.0, -5.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 5.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 30.0,-5.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{30.0, -5.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{30.0, 5.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  30.0,-5.0, 52.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{30.0, -5.0, 52.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 5.0, 52.0}"/>
       </ParameterList>
     </ParameterList>
@@ -91,7 +89,7 @@
       <ParameterList name="porosity">
         <ParameterList name="function">
           <ParameterList name="Source">
-            <Parameter name="regions" type="Array(string)" value="{Source,Rest}"/>
+            <Parameter name="regions" type="Array(string)" value="{Source, Rest}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
@@ -106,7 +104,7 @@
       <ParameterList name="particle_density">
         <ParameterList name="function">
           <ParameterList name="Source">
-            <Parameter name="regions" type="Array(string)" value="{Source,Rest}"/>
+            <Parameter name="regions" type="Array(string)" value="{Source, Rest}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
@@ -163,9 +161,9 @@
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.896e-02"/>
+          <Parameter name="molar mass" type="double" value="0.02896"/>
           <Parameter name="density" type="double" value="0.0"/>
-          <Parameter name="reference viscosity" type="double" value="1.716e-05"/>
+          <Parameter name="reference viscosity" type="double" value="0.00001716"/>
           <Parameter name="reference temperature" type="double" value="293.15"/>
           <Parameter name="Sutherland constant" type="double" value="111.0"/>
         </ParameterList>
@@ -177,9 +175,9 @@
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.896e-02"/>
+          <Parameter name="molar mass" type="double" value="0.02896"/>
           <Parameter name="density" type="double" value="0.0"/>
-          <Parameter name="reference viscosity" type="double" value="1.7163e-05"/>
+          <Parameter name="reference viscosity" type="double" value="0.000017163"/>
           <Parameter name="reference temperature" type="double" value="293.15"/>
           <Parameter name="Sutherland constant" type="double" value="111.0"/>
         </ParameterList>
@@ -249,7 +247,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-04"/>
+                <Parameter name="value" type="double" value="0.00010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -287,9 +285,9 @@
         <Parameter name="molar density key" type="string" value="fracture-molar_density_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.896e-02"/>
+          <Parameter name="molar mass" type="double" value="0.02896"/>
           <Parameter name="density" type="double" value="0.0"/>
-          <Parameter name="reference viscosity" type="double" value="1.716e-05"/>
+          <Parameter name="reference viscosity" type="double" value="0.00001716"/>
           <Parameter name="reference temperature" type="double" value="293.15"/>
           <Parameter name="Sutherland constant" type="double" value="111.0"/>
         </ParameterList>
@@ -301,7 +299,7 @@
         <Parameter name="viscosity key" type="string" value="fracture-viscosity_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.896e-02"/>
+          <Parameter name="molar mass" type="double" value="0.02896"/>
           <Parameter name="density" type="double" value="0.0"/>
           <Parameter name="reference viscosity" type="double" value="1.716"/>
           <Parameter name="reference temperature" type="double" value="293.15"/>
@@ -349,12 +347,15 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
-        <Parameter name="value" type="double" value="2.896e-02"/>
+        <Parameter name="value" type="double" value="0.02896"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -406,6 +407,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -413,12 +415,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-05"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="Source">
@@ -426,7 +429,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+07"/>
+                <Parameter name="value" type="double" value="1.0e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -435,16 +438,17 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="Source">
-            <Parameter name="regions" type="Array(string)" value="{Source,Rest}"/>
+            <Parameter name="regions" type="Array(string)" value="{Source, Rest}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
@@ -454,6 +458,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="Source">
@@ -464,7 +469,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-03"/>
+                  <Parameter name="value" type="double" value="0.0010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -484,6 +489,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="Source">
@@ -506,6 +512,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -513,12 +520,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -536,6 +544,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -550,9 +559,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -564,7 +575,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -592,10 +602,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="8.64e+05"/>
+        <Parameter name="end period time" type="double" value="8.64e+5"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0"/>
-        <Parameter name="maximum timestep" type="double" value="1.44e+04"/>
+        <Parameter name="maximum timestep" type="double" value="1.44e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{tracer}"/>
@@ -609,13 +619,15 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:coupled flow and transport">
       <Parameter isUsed="true" name="PK type" type="string" value="flow reactive transport"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:coupled flow, transient:coupled transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="transient:coupled flow">
       <Parameter isUsed="true" name="PK type" type="string" value="darcy matrix fracture"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
@@ -633,11 +645,11 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.2"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1e-06"/>
+            <Parameter name="min timestep" type="double" value="0.000001"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1000.0"/>
@@ -657,14 +669,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow matrix">
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="0.1"/>
       </ParameterList>
+
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
@@ -676,6 +692,7 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
@@ -686,9 +703,11 @@
           <Parameter name="regions" type="Array(string)" value="{Rest}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -724,19 +743,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -744,15 +765,18 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow fracture">
       <ParameterList name="clipping parameters">
         <Parameter name="maximum correction change" type="double" value="0.1"/>
       </ParameterList>
+
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for fracture">
@@ -761,9 +785,11 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -774,6 +800,7 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
@@ -784,9 +811,11 @@
           <Parameter name="regions" type="Array(string)" value="{Rest}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -819,19 +848,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+05"/>
+                <Parameter name="value" type="double" value="100000.000000000000"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -850,9 +881,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:coupled transport">
@@ -872,11 +905,11 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.2"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
             <Parameter name="max du growth factor" type="double" value="1000.0"/>
@@ -895,9 +928,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:transport matrix">
@@ -918,11 +953,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{tracer}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -951,6 +988,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="auxiliary data" type="string" value="molar_concentration"/>
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
@@ -959,9 +997,11 @@
         <Parameter name="use dispersion solver" type="bool" value="true"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:transport fracture">
@@ -982,11 +1022,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{tracer}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -1014,6 +1056,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="auxiliary data" type="string" value="molar_concentration"/>
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
@@ -1023,10 +1066,13 @@
         <Parameter name="permeability field is required" type="bool" value="false"/>
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -1067,7 +1113,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -1082,7 +1127,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>

--- a/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
@@ -8,59 +8,58 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{10, 10, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,60.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 216.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{216.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceCenter">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 72.0, 0.0,120.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{144.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.0, 0.0, 120.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{144.0, 10.0, 120.0}"/>
       </ParameterList>
-    </ParameterList>    
+    </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 60.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{216.0,10.0,120.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 60.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.0, 10.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -83,9 +82,8 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="max timestep size" type="double" value="1.0e+06"/>    
+    <Parameter name="max timestep size" type="double" value="1.0e+6"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
         <ParameterList name="PK tree">
@@ -103,10 +101,10 @@
         <Parameter name="end period time" type="double" value="3.0e+7"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0e+5"/>
-        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>        
+        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>
       </ParameterList>
       <ParameterList name="TP 1">
-	<ParameterList name="PK tree">
+        <ParameterList name="PK tree">
           <ParameterList name="coupled transport">
             <Parameter name="PK type" type="string" value="transport matrix fracture implicit"/>
             <ParameterList name="transport matrix">
@@ -116,52 +114,47 @@
               <Parameter name="PK type" type="string" value="transport implicit"/>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="1.0e+5"/>
-	<Parameter name="start period time" type="double" value="3.0e+7"/>
-	<Parameter name="end period time" type="double" value="4.0e+7"/>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="1.0e+5"/>
+        <Parameter name="start period time" type="double" value="3.0e+7"/>
+        <Parameter name="end period time" type="double" value="4.0e+7"/>
         <Parameter name="maximum timestep" type="double" value="5e+5"/>
         <Parameter name="maximum cycle number" type="int" value="100"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{Tc-99, CO2}"/>
     <Parameter name="component molar masses" type="Array(double)" value="{1.0, 1.0}"/>
-    
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{6.153732e+10, 6.15688776e+10}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{10.0, 10.0}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{4.3234e+4, 4.3234e+4}"/>
+      <Parameter name="maximum timestep" type="Array(double)" value="{43234.0, 43234.0}"/>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
       <ParameterList name="fracture-specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -180,11 +173,11 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
-            <Parameter name="regions" type="Array(string)" value="{RegionBottom,RegionTop}"/>
+            <Parameter name="regions" type="Array(string)" value="{RegionBottom, RegionTop}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.6416e-4"/>
+                <Parameter name="value" type="double" value="0.00046416"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -218,7 +211,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -247,7 +239,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="bulk_modulus">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -262,7 +253,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -271,27 +261,31 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -313,7 +307,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9240e-07"/>
+                <Parameter name="value" type="double" value="3.9240e-7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -378,7 +372,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -386,6 +380,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -393,7 +388,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 60.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9792.3}"/>
               </ParameterList>
@@ -419,6 +414,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -435,17 +431,15 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
-    </ParameterList>
+      </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{RegionBottom, RegionTop}"/>
       </ParameterList>
     </ParameterList>
-    
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -453,14 +447,13 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -483,18 +476,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>      
-
+      <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -502,7 +493,7 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.5"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
@@ -510,7 +501,7 @@
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -523,131 +514,132 @@
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         </ParameterList>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="0.0"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
 
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-2.0e-3, -2.0e-3}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="0.0"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceTop}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.0020, -0.0020}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for Entire Domain">
-	  <Parameter name="region" type="string" value="All"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	</ParameterList>
+        <ParameterList name="FPM for Entire Domain">
+          <Parameter name="region" type="string" value="All"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{}"/>
         <Parameter name="linear solver" type="string" value="GMRES with Hypre AMG"/>
@@ -659,7 +651,7 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.5"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
@@ -668,23 +660,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transport matrix">
-      <Parameter name="domain name" type="string" value="domain"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
       <Parameter name="temporal discretization order" type="int" value="2"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <Parameter name="transport subcycling" type="bool" value="false"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{Tc-99, CO2}"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
@@ -697,8 +690,9 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="material properties">
@@ -715,7 +709,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99, CO2}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-5, 1e-5}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.00001, 0.00001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -740,49 +734,49 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Tc-99">
-	    <ParameterList name="BC for center">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Tc-99">
+            <ParameterList name="BC for center">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="CO2">
-	    <ParameterList name="BC for center">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="CO2">
+            <ParameterList name="BC for center">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceCenter}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-    </ParameterList>      
-      
+
+    </ParameterList>
+
     <ParameterList name="transport fracture">
-      <Parameter name="domain name" type="string" value="fracture"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
+      <Parameter name="domain name" type="string" value="fracture"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
       <Parameter name="temporal discretization order" type="int" value="2"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{Tc-99, CO2}"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
@@ -796,8 +790,9 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="material properties">
@@ -814,7 +809,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99, CO2}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-5, 1e-5}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.00001, 0.00001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -836,9 +831,11 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions">      
+      <ParameterList name="boundary conditions">
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="observation data">
@@ -848,14 +845,14 @@
       <Parameter name="region" type="string" value="All"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
       <Parameter name="variable" type="string" value="Tc-99 aqueous concentration"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-2">
       <Parameter name="region" type="string" value="All"/>
       <Parameter name="domain name" type="string" value="fracture"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
       <Parameter name="variable" type="string" value="Tc-99 aqueous concentration"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_mechanics_flow.xml
+++ b/src/mpc/test/mpc_coupled_mechanics_flow.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -16,7 +15,7 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{10, 10, 10}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
       <ParameterList name="submesh">
@@ -34,35 +33,34 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 1.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
@@ -76,7 +74,7 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1e-6"/>
+            <Parameter name="value" type="double" value="0.000001"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -86,7 +84,7 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1e-3"/>
+            <Parameter name="value" type="double" value="0.001"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -98,7 +96,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -227,7 +225,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -292,20 +290,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -319,6 +321,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -326,12 +329,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="6.0e+06"/>
+                <Parameter name="value" type="double" value="6.0e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -360,6 +364,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-ref_aperture">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -373,6 +378,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -386,6 +392,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -393,14 +400,15 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.19e+07"/>
+                <Parameter name="y0" type="double" value="1.19e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.81e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.81e+3}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -415,6 +423,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -422,12 +431,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.1e+07"/>
+                <Parameter name="value" type="double" value="1.1e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -442,9 +452,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -455,7 +467,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <Parameter name="io frequency" type="int" value="10"/>
     <ParameterList name="time periods">
@@ -495,8 +506,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics">
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="time integrator">
@@ -512,14 +523,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -535,6 +546,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -546,19 +558,22 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="small strain models">
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Hardin Drnevich"/>
-          <Parameter name="reference shear strain" type="double" value="0.8e+6"/>
-          <Parameter name="maximum shear stress" type="double" value="70.0e+6"/>
+          <Parameter name="reference shear strain" type="double" value="8e+5"/>
+          <Parameter name="maximum shear stress" type="double" value="7.00e+7"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="true"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -586,9 +601,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics and coupled flow">
@@ -609,14 +626,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -630,10 +647,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:coupled flow">
       <Parameter isUsed="true" name="PK type" type="string" value="darcy matrix fracture"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
@@ -651,14 +671,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -675,10 +695,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -691,25 +714,29 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.01325e+05"/>
-          <Parameter name="pore compressibility" type="double" value="3.0e-09"/>
+          <Parameter name="reference pressure" type="double" value="101325.0"/>
+          <Parameter name="pore compressibility" type="double" value="3.0e-9"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
         <Parameter name="permeability porosity model" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="permeability porosity models">
         <ParameterList name="PPM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
@@ -718,9 +745,11 @@
           <Parameter name="power law exponent" type="double" value="3.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -734,19 +763,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.19e+07"/>
+                <Parameter name="value" type="double" value="1.19e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -756,7 +787,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.10e+07"/>
+                <Parameter name="value" type="double" value="1.10e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -764,10 +795,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
@@ -777,9 +811,11 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -790,15 +826,18 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -811,12 +850,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="GMRES"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -825,7 +866,7 @@
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.19e+07"/>
+                <Parameter name="value" type="double" value="1.19e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -835,16 +876,19 @@
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.10e+07"/>
+                <Parameter name="value" type="double" value="1.10e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -872,7 +916,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>

--- a/src/mpc/test/mpc_coupled_reactive_transport.xml
+++ b/src/mpc/test/mpc_coupled_reactive_transport.xml
@@ -8,50 +8,49 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 10, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture" type="ParameterList">
       <ParameterList name="region: labeled set" type="ParameterList">
-        <Parameter name="label" type="string" value="100" />
-        <Parameter name="file" type="string" value="test/single_fracture_ref0.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
-        <Parameter name="entity" type="string" value="Face" />
+        <Parameter name="label" type="string" value="100"/>
+        <Parameter name="file" type="string" value="test/single_fracture_ref0.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
+        <Parameter name="entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,  0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,  0.0, 90.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 90.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0,0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,0.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,   0.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0,  0.0, 10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0, 100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FRACTURE_NETWORK_INTERNAL">
@@ -62,7 +61,7 @@
     </ParameterList>
     <ParameterList name="fracture region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -71,8 +70,8 @@
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="read mesh file" type="ParameterList">
-        <Parameter name="file" type="string" value="test/single_fracture_ref0.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
+        <Parameter name="file" type="string" value="test/single_fracture_ref0.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -84,15 +83,13 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="max timestep size" type="double" value="1.0e+06"/>    
+    <Parameter name="max timestep size" type="double" value="1.0e+6"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
         <ParameterList name="PK tree">
           <ParameterList name="coupled reactive transport">
             <Parameter name="PK type" type="string" value="reactive transport matrix fracture"/>
-
             <ParameterList name="coupled chemistry">
               <Parameter name="PK type" type="string" value="chemistry matrix fracture"/>
               <ParameterList name="chemistry matrix">
@@ -102,7 +99,6 @@
                 <Parameter name="PK type" type="string" value="chemistry amanzi"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="coupled transport">
               <Parameter name="PK type" type="string" value="transport matrix fracture implicit"/>
               <ParameterList name="transport matrix">
@@ -118,25 +114,21 @@
         <Parameter name="end period time" type="double" value="3.0e+6"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0e+5"/>
-        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>        
+        <Parameter name="maximum timestep" type="double" value="1.0e+10"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
     <Parameter name="number of liquid components" type="int" value="1"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{1.00000000000000000e+00}"/>
-    
+    <Parameter name="component molar masses" type="Array(double)" value="{1.00000000000000000}"/>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{6.153732e+10, 6.15688776e+10}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{10.0, 10.0}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{4.3234e+4, 4.3234e+4}"/>
+      <Parameter name="maximum timestep" type="Array(double)" value="{43234.0, 43234.0}"/>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -175,7 +167,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -189,7 +181,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -209,7 +201,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-       <ParameterList name="fracture-saturation_liquid">
+      <ParameterList name="fracture-saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -223,7 +215,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -239,17 +230,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -275,23 +269,24 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-06"/>
+                  <Parameter name="value" type="double" value="0.0000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                  <Parameter name="value" type="double" value="0e-17"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-2.0e-06"/>
+                  <Parameter name="value" type="double" value="-0.0000020"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -303,17 +298,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-06"/>
+                  <Parameter name="value" type="double" value="0.0000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                  <Parameter name="value" type="double" value="0e-17"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-2.0e-06"/>
+                  <Parameter name="value" type="double" value="-0.0000020"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -328,12 +323,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1e-3"/>
+                <Parameter name="value" type="double" value="0.001"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-specific_storage">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -341,7 +337,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1e-3"/>
+                <Parameter name="value" type="double" value="0.001"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -355,7 +351,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9240e-07"/>
+                <Parameter name="value" type="double" value="3.9240e-7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -412,16 +408,15 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
-    </ParameterList>
+      </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{RegionBottom, RegionTop}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -430,7 +425,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -438,7 +433,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -461,11 +455,12 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{coupled chemistry, coupled transport}"/>
       <Parameter name="master PK index" type="int" value="1"/>
+
     </ParameterList>
 
     <ParameterList name="coupled chemistry">
@@ -474,12 +469,12 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
@@ -491,7 +486,7 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.5"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
@@ -500,20 +495,22 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transport matrix">
-      <Parameter name="domain name" type="string" value="domain"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <Parameter name="transport subcycling" type="bool" value="false"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
       <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
       <Parameter name="number of aqueous components" type="int" value="1"/>
@@ -523,8 +520,9 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -539,31 +537,32 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Tritium">
-	    <ParameterList name="Inlet">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Tritium">
+            <ParameterList name="Inlet">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="0.00100000000000000002"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-    </ParameterList>      
-      
+
+    </ParameterList>
+
     <ParameterList name="transport fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
       <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
       <Parameter name="number of aqueous components" type="int" value="1"/>
@@ -573,8 +572,9 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -587,14 +587,14 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions">      
+      <ParameterList name="boundary conditions">
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="chemistry matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
-
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
@@ -606,24 +606,28 @@
       <Parameter name="timestep increase threshold" type="int" value="4"/>
       <Parameter name="timestep increase factor" type="double" value="1.20"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
-      <Parameter name="initial conditions time" type="double" value="0.00000000000000000e+00"/>
+      <Parameter name="initial conditions time" type="double" value="0e-17"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="true"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="initial conditions"/>
+
+      <ParameterList name="initial conditions">
+
+      </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="chemistry fracture">
-      <Parameter name="domain name" type="string" value="fracture"/>      
+      <Parameter name="domain name" type="string" value="fracture"/>
       <Parameter name="component names" type="Array(string)" value="{Tritium}"/>
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
       <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+4"/>
-      <Parameter name="initial timestep (s)" type="double" value="2.0e+05"/>
+      <Parameter name="initial timestep (s)" type="double" value="2.0e+5"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
       <Parameter name="timestep cut factor" type="double" value="2.0"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
@@ -635,26 +639,30 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="initial conditions"/>
+
+      <ParameterList name="initial conditions">
+
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="Tritium">
-        <Parameter name="ion size parameter" type="double" value="9.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="9.00000000000000000"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="1.01000000000000001e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.01000000000000001"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="general kinetics">
       <ParameterList name="general_0">
         <Parameter name="reactants" type="string" value="1.0 Tritium"/>
         <Parameter name="products" type="string" value=""/>
-        <Parameter name="forward rate" type="double" value="1.78576999999999992e-09"/>
-        <Parameter name="backward rate" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="forward rate" type="double" value="1.78576999999999992e-9"/>
+        <Parameter name="backward rate" type="double" value="0e-17"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
 </ParameterList>

--- a/src/mpc/test/mpc_coupled_thermal_flow.xml
+++ b/src/mpc/test/mpc_coupled_thermal_flow.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_coupled_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 20, -1}"/>
@@ -9,47 +8,46 @@
     <Parameter name="file name base" type="string" value="plot_coupled_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 20, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -59,7 +57,7 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{10, 10, 10}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="domain high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
       <ParameterList name="expert">
@@ -78,7 +76,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -98,7 +95,6 @@
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="1.0e+9"/>
       </ParameterList>
-
       <ParameterList name="TP 1">
         <ParameterList name="PK tree">
           <ParameterList name="coupled thermal flow">
@@ -139,7 +135,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -147,25 +142,24 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
       <ParameterList name="fracture-specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
-            <Parameter name="value" type="double" value="1.0e-3"/>
+            <Parameter name="value" type="double" value="0.0010"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -194,7 +188,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -217,7 +210,6 @@
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
@@ -232,7 +224,6 @@
           <Parameter name="eos type" type="string" value="liquid water 0-30C"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_liquid"/>
@@ -267,7 +258,6 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_rock">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_rock"/>
@@ -294,7 +284,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -323,16 +312,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-aperture">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
-            <Parameter name="regions" type="Array(string)" value="{RegionBottom,RegionTop}"/>
+            <Parameter name="regions" type="Array(string)" value="{RegionBottom, RegionTop}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -352,7 +340,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-heat_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -367,7 +354,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -396,7 +382,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="bulk_modulus">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -412,20 +397,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -439,6 +428,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -460,12 +450,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9240e-05"/>
+                <Parameter name="value" type="double" value="0.000039240"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -523,42 +514,44 @@
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -566,7 +559,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -576,7 +568,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="1"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -584,7 +576,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -607,16 +598,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
@@ -627,12 +616,11 @@
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="1.0e-20"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-9"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -640,24 +628,23 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      	<ParameterList name="initialization">
-      	  <Parameter name="method" type="string" value="saturated solver"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled thermal flow">
       <Parameter name="PKs order" type="Array(string)" value="{thermal flow matrix, thermal flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -670,14 +657,13 @@
             <Parameter name="min timestep" type="double" value="1.0e-10"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>            
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -685,9 +671,8 @@
             <Parameter name="monitor" type="string" value="monitor update"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="freeze preconditioner" type="bool" value="true"/>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
@@ -695,293 +680,308 @@
           <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="thermal flow matrix">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, energy matrix}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="domain name" type="string" value="domain"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="thermal flow fracture">
       <Parameter name="PKs order" type="Array(string)" value="{flow fracture, energy fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="domain name" type="string" value="fracture"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
-	<Parameter name="time integration method" type="string" value="none"/>
-
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for Entire Domain">
-	  <Parameter name="region" type="string" value="All"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	  <Parameter name="aperture" type="double" value="1.0"/>
-	</ParameterList>
+        <ParameterList name="FPM for Entire Domain">
+          <Parameter name="region" type="string" value="All"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+          <Parameter name="aperture" type="double" value="1.0"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="energy evaluator"/>
+
+      <ParameterList name="energy evaluator">
+      </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
+        <Parameter name="include work term" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="liquid water"/>
+            <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="0.5"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
           <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="300.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceBottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="300.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="none"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="energy evaluator"/>
+
+      <ParameterList name="energy evaluator">
+      </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
+        <Parameter name="include work term" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="liquid water"/>
+            <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="0.5"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="none"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_coupled_thermal_flow_methalpy.xml
+++ b/src/mpc/test/mpc_coupled_thermal_flow_methalpy.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -27,7 +26,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
@@ -43,8 +41,8 @@
     </ParameterList>
     <ParameterList name="Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 1.0e+03}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 1.0e+03}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 1.0e+3}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 1.0e+3}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -79,7 +77,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.757e+03"/>
+                <Parameter name="value" type="double" value="2757.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -108,7 +106,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.180e+03"/>
+              <Parameter name="heat capacity" type="double" value="1180.0"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -151,18 +149,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -186,6 +189,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -193,14 +197,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.15e+07"/>
+                <Parameter name="y0" type="double" value="1.15e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -1.05e+04}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -1.05e+4}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -214,6 +219,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -228,9 +234,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -241,7 +249,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -257,7 +264,7 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.728e+07"/>
+        <Parameter name="end period time" type="double" value="1.728e+7"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="100.0"/>
         <Parameter name="maximum timestep" type="double" value="2.0e+5"/>
@@ -274,8 +281,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and energy">
       <Parameter isUsed="true" name="PK type" type="string" value="thermal flow"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:energy}"/>
@@ -284,6 +291,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -302,14 +310,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -325,10 +333,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -341,15 +352,18 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -371,6 +385,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -388,15 +403,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -412,13 +427,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{Bottom}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.15e+07"/>
+                <Parameter name="value" type="double" value="1.15e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -428,7 +444,7 @@
             <Parameter name="regions" type="Array(string)" value="{Top}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+06"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -436,10 +452,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:energy">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
@@ -462,10 +481,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="All">
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.1"/>
@@ -475,9 +495,10 @@
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.1"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -496,14 +517,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -519,6 +540,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -526,18 +548,20 @@
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary temperature">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.93149999999999977e+02"/>
+                <Parameter name="value" type="double" value="293.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="true"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="true"/>
@@ -545,11 +569,15 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -590,7 +618,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>

--- a/src/mpc/test/mpc_coupled_thermal_flow_richards.xml
+++ b/src/mpc/test/mpc_coupled_thermal_flow_richards.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_coupled_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 5, -1}"/>
@@ -9,62 +8,61 @@
     <Parameter name="file name base" type="string" value="plot_coupled_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 5, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: labeled set" type="ParameterList">
-        <Parameter name="label" type="string" value="100" />
-        <Parameter name="file" type="string" value="test/single_fracture_tet.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
-        <Parameter name="entity" type="string" value="Face" />
+        <Parameter name="label" type="string" value="100"/>
+        <Parameter name="file" type="string" value="test/single_fracture_tet.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
+        <Parameter name="entity" type="string" value="Face"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,90.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 90.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,0.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,100.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 100.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0,50.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 50.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,50.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 50.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FractureInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,80.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 80.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -72,8 +70,8 @@
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="read mesh file">
-        <Parameter name="file" type="string" value="test/single_fracture_tet.exo" />
-        <Parameter name="format" type="string" value="Exodus II" />
+        <Parameter name="file" type="string" value="test/single_fracture_tet.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -90,7 +88,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -110,7 +107,6 @@
         <Parameter name="maximum cycle number" type="int" value="-1"/>
         <Parameter name="initial timestep" type="double" value="10.0"/>
       </ParameterList>
-
       <ParameterList name="TP 1">
         <ParameterList name="PK tree">
           <ParameterList name="coupled thermal flow">
@@ -151,7 +147,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -185,7 +180,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_liquid"/>
@@ -220,7 +214,6 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_rock">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_rock"/>
@@ -261,7 +254,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -276,7 +268,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
@@ -299,7 +290,6 @@
           <Parameter name="density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
@@ -314,18 +304,16 @@
           <Parameter name="eos type" type="string" value="liquid water FEHM"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-aperture">
         <Parameter name="evaluator type" type="string" value="independent variable from file"/>
         <Parameter name="filename" type="string" value="test/aperture_dynamic_test.h5"/>
         <Parameter name="domain name" type="string" value="fracture"/>
         <Parameter name="variable name" type="string" value="fracture-aperture"/>
         <Parameter name="component name" type="string" value="cell"/>
-        <Parameter name="constant in time" type="bool" value="false"/>        
+        <Parameter name="constant in time" type="bool" value="false"/>
         <Parameter name="mesh entity" type="string" value="cell"/>
         <Parameter name="number of dofs" type="int" value="1"/>
       </ParameterList>
-
       <ParameterList name="fracture-heat_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -340,7 +328,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -370,23 +357,28 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -400,6 +392,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -421,12 +414,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.9311e-05"/>
+                <Parameter name="value" type="double" value="0.000039311"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="RegionBottom">
@@ -484,38 +478,39 @@
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -534,6 +529,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -555,12 +551,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.9820e+02"/>
+                <Parameter name="value" type="double" value="998.20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -568,12 +565,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.9820e+02"/>
+                <Parameter name="value" type="double" value="998.20"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -581,7 +579,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -598,7 +595,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -621,16 +617,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled flow">
       <Parameter name="PKs order" type="Array(string)" value="{flow matrix, flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
@@ -641,12 +635,11 @@
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="1.0e-20"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-4"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.00010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="10"/>
             <Parameter name="max nka vectors" type="int" value="15"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -654,20 +647,20 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      	<ParameterList name="initialization">
-      	  <Parameter name="method" type="string" value="saturated solver"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="coupled thermal flow">
       <Parameter name="PKs order" type="Array(string)" value="{thermal flow matrix, thermal flow fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -675,7 +668,6 @@
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -688,14 +680,13 @@
             <Parameter name="min timestep" type="double" value="1.0e-10"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>            
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="5"/>
             <Parameter name="max nka vectors" type="int" value="15"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -703,9 +694,8 @@
             <Parameter name="monitor" type="string" value="monitor update"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
           <Parameter name="freeze preconditioner" type="bool" value="false"/>
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
@@ -714,9 +704,10 @@
           <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
-          </ParameterList>            
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="thermal flow matrix">
@@ -724,33 +715,34 @@
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="thermal flow fracture">
@@ -758,55 +750,60 @@
       <Parameter name="master PK index" type="int" value="0"/>
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="none"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="water retention model" type="string" value="saturated"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	</ParameterList>
+        <ParameterList name="WRM for All">
+          <Parameter name="water retention model" type="string" value="saturated"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
             <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <!--Parameter name="Newton correction" type="string" value="approximate Jacobian"/-->
-	  </ParameterList>
+            <!--Parameter name="Newton correction" type="string" value="approximate Jacobian"/-->
+          </ParameterList>
           <ParameterList name="vapor matrix">
             <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
             <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -818,284 +815,301 @@
             <Parameter name="scaled constraint equation" type="bool" value="false"/>
             <Parameter name="Newton correction" type="string" value="none"/>
           </ParameterList>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="100.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="10.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="100.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="10.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
-	<Parameter name="flow and transport in fractures" type="bool" value="true"/>
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
-	<ParameterList name="FPM for Entire Domain">
-	  <Parameter name="region" type="string" value="All"/>
-	  <Parameter name="model" type="string" value="cubic law"/>
-	</ParameterList>
+        <ParameterList name="FPM for Entire Domain">
+          <Parameter name="region" type="string" value="All"/>
+          <Parameter name="model" type="string" value="cubic law"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="water retention model" type="string" value="saturated"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	</ParameterList>
+        <ParameterList name="WRM for All">
+          <Parameter name="water retention model" type="string" value="saturated"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: default"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: default"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: default"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: default"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{FractureInlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="100.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{FractureInlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="100.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="energy evaluator"/>
+
+      <ParameterList name="energy evaluator">
+      </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
+        <Parameter name="include work term" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="liquid water"/>
+            <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="0.5"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
           <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="292.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="292.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="none"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <ParameterList name="energy evaluator"/>
+
+      <ParameterList name="energy evaluator">
+      </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
+        <Parameter name="include work term" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="liquid water"/>
+            <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="2.0"/>
             <Parameter name="reference temperature" type="double" value="275.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{FractureInlet}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="293.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{FractureInlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="293.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="none"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="none"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_coupled_transport.xml
+++ b/src/mpc/test/mpc_coupled_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_matrix"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 1, -1}"/>
@@ -9,23 +8,22 @@
     <Parameter name="file name base" type="string" value="plot_fracture"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 1, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,3.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 3.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 6.0, 6.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -54,12 +52,11 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="max timestep size" type="double" value="1.00000000000000000e+06"/>    
+    <Parameter name="max timestep size" type="double" value="1000000.00000000000"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
+        <ParameterList name="PK tree">
           <ParameterList name="coupled transport">
             <Parameter name="PK type" type="string" value="transport matrix fracture implicit"/>
             <ParameterList name="transport matrix">
@@ -69,28 +66,24 @@
               <Parameter name="PK type" type="string" value="transport implicit"/>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="1.0e+4"/>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="2.0e+5"/>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="2.0e+5"/>
         <Parameter name="maximum timestep" type="double" value="5.0e+5"/>
-        <Parameter name="maximum cycle number" type="int" value="20"/>        
+        <Parameter name="maximum cycle number" type="int" value="20"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="component names" type="Array(string)" value="{tracer}"/>
-    
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{0.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{1.0e+4}"/>
       <Parameter name="maximum timestep" type="Array(double)" value="{5.0e+5}"/>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -111,11 +104,11 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
-            <Parameter name="regions" type="Array(string)" value="{RegionBottom,RegionTop}"/>
+            <Parameter name="regions" type="Array(string)" value="{RegionBottom, RegionTop}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -135,7 +128,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -164,7 +156,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-solute_diffusion_to_matrix">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -180,14 +171,16 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
@@ -203,7 +196,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.0e-07"/>
+                  <Parameter name="value" type="double" value="5.0e-7"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -220,6 +213,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -231,7 +225,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.0e-07"/>
+                  <Parameter name="value" type="double" value="5.0e-7"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -266,6 +260,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -282,8 +277,8 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>      
-      
+      </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -297,6 +292,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -310,15 +306,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -327,7 +322,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -335,7 +330,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -348,12 +342,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="coupled transport">
       <Parameter name="PKs order" type="Array(string)" value="{transport matrix, transport fracture}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{}"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
@@ -365,7 +358,7 @@
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.5"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
           </ParameterList>
@@ -373,7 +366,7 @@
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-12"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="100"/>
@@ -381,25 +374,25 @@
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
-    
+
     <ParameterList name="transport matrix">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="domain"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="transport subcycling" type="bool" value="false"/>      
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <Parameter name="transport subcycling" type="bool" value="false"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{tracer}"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
@@ -408,8 +401,9 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -424,41 +418,41 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="tracer">
-	    <ParameterList name="BC 0">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="tracer">
+            <ParameterList name="BC 0">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-constant">
-		  <Parameter name="value" type="double" value="1.0"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.0"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="time integration method" type="string" value="none"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       </ParameterList>
-    </ParameterList>      
-      
+
+    </ParameterList>
+
     <ParameterList name="transport fracture">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="domain name" type="string" value="fracture"/>      
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="domain name" type="string" value="fracture"/>
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{tracer}"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="physical models and assumptions">
         <!--Parameter name="flow and transport in fractures" type="bool" value="true"/-->
       </ParameterList>
@@ -473,7 +467,7 @@
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -486,28 +480,30 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions">      
-	<ParameterList name="concentration">
-	  <ParameterList name="tracer">
-	    <ParameterList name="BC 0">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="concentration">
+          <ParameterList name="tracer">
+            <ParameterList name="BC 0">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-constant">
-		  <Parameter name="value" type="double" value="1.0"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.0"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="time integration method" type="string" value="none"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="analysis">
@@ -521,4 +517,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_default.xml
+++ b/src/mpc/test/mpc_default.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
@@ -13,33 +12,29 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="pk0">
-	    <Parameter name="PK type" type="string" value="implicit pk"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0"/>
-	<Parameter name="initial timestep" type="double" value="0.002"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="pk0">
+            <Parameter name="PK type" type="string" value="implicit pk"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0"/>
+        <Parameter name="initial timestep" type="double" value="0.002"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="none"/>
     </ParameterList>
   </ParameterList>
-
-
   <!-- PK TREEs -->
   <ParameterList name="PK tree 1">
     <ParameterList name="pk0">
       <Parameter name="PK type" type="string" value="implicit pk"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 2">
     <ParameterList name="mpc_weak">
       <Parameter name="PK type" type="string" value="mpc weak"/>
@@ -51,7 +46,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 3">
     <ParameterList name="mpc_weak_flipped">
       <Parameter name="PK type" type="string" value="mpc weak"/>
@@ -63,7 +57,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 4">
     <ParameterList name="mpc_weak_three">
       <Parameter name="PK type" type="string" value="mpc weak"/>
@@ -78,7 +71,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 5">
     <ParameterList name="mpc_subcycled">
       <Parameter name="PK type" type="string" value="mpc subcycled"/>
@@ -90,7 +82,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 6">
     <ParameterList name="mpc_strong">
       <Parameter name="PK type" type="string" value="mpc strong"/>
@@ -102,7 +93,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 7">
     <ParameterList name="mpc_strong1a">
       <Parameter name="PK type" type="string" value="mpc strong"/>
@@ -120,7 +110,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree 8">
     <ParameterList name="mpc_weak1c">
       <Parameter name="PK type" type="string" value="mpc subcycled"/>
@@ -138,8 +127,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <!-- STATE -->
   <ParameterList name="state">
     <ParameterList name="mesh partitions">
@@ -148,80 +135,108 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
-
   <ParameterList name="PKs">
+
     <!-- SINGLE PKs -->
     <ParameterList name="pk0">
       <Parameter name="start id" type="int" value="0"/>
       <Parameter name="end id" type="int" value="11"/>
+
     </ParameterList>
+
     <ParameterList name="pk1">
       <Parameter name="start id" type="int" value="0"/>
       <Parameter name="end id" type="int" value="5"/>
+
     </ParameterList>
+
     <ParameterList name="pk2">
       <Parameter name="start id" type="int" value="6"/>
       <Parameter name="end id" type="int" value="11"/>
+
     </ParameterList>
+
     <ParameterList name="pk2a">
       <Parameter name="start id" type="int" value="6"/>
       <Parameter name="end id" type="int" value="11"/>
       <Parameter name="cfl" type="double" value="0.25"/>
+
     </ParameterList>
+
     <ParameterList name="pk1b">
       <Parameter name="start id" type="int" value="0"/>
       <Parameter name="end id" type="int" value="3"/>
+
     </ParameterList>
+
     <ParameterList name="pk2b">
       <Parameter name="start id" type="int" value="4"/>
       <Parameter name="end id" type="int" value="7"/>
+
     </ParameterList>
+
     <ParameterList name="pk3b">
       <Parameter name="start id" type="int" value="8"/>
       <Parameter name="end id" type="int" value="11"/>
+
     </ParameterList>
+
     <ParameterList name="pk1c">
       <Parameter name="start id" type="int" value="0"/>
       <Parameter name="end id" type="int" value="3"/>
       <Parameter name="cfl" type="double" value="2.0"/>
+
     </ParameterList>
+
     <ParameterList name="pk2c">
       <Parameter name="start id" type="int" value="4"/>
       <Parameter name="end id" type="int" value="7"/>
+
     </ParameterList>
+
     <ParameterList name="pk3c">
       <Parameter name="start id" type="int" value="8"/>
       <Parameter name="end id" type="int" value="11"/>
       <Parameter name="cfl" type="double" value="0.5"/>
+
     </ParameterList>
 
     <!-- MPC WEAK -->
     <ParameterList name="mpc_weak">
       <Parameter name="PKs order" type="Array(string)" value="{pk1, pk2}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="mpc_weak_flipped">
       <Parameter name="PKs order" type="Array(string)" value="{pk2, pk1}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="mpc_weak_three">
       <Parameter name="PKs order" type="Array(string)" value="{pk1b, pk2b, pk3b}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="mpc_weak1c">
       <Parameter name="PKs order" type="Array(string)" value="{pk1c, mpc_weak2c}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="mpc_weak2c">
       <Parameter name="PKs order" type="Array(string)" value="{pk2c, pk3c}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
 
     <!-- MPC SUBCYCLED -->
     <ParameterList name="mpc_subcycled">
       <Parameter name="PKs order" type="Array(string)" value="{pk1, pk2a}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
 
     <!-- MPC STRONG -->
@@ -239,7 +254,6 @@
             <Parameter name="max timestep" type="double" value="1.0"/>
             <Parameter name="min timestep" type="double" value="1.0e-10"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
@@ -251,6 +265,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <!-- MPC STRONG TWO-LEVEL -->
@@ -268,7 +283,6 @@
             <Parameter name="max timestep" type="double" value="1.0"/>
             <Parameter name="min timestep" type="double" value="1.0e-10"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
@@ -280,11 +294,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="mpc_strong2a">
       <Parameter name="PKs order" type="Array(string)" value="{pk2b, pk3b}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="verbose object">

--- a/src/mpc/test/mpc_dummy.xml
+++ b/src/mpc/test/mpc_dummy.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_dummy"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -13,44 +12,44 @@
   <ParameterList name="regions">
     <ParameterList name="Bottom Surface">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 0.0e+00}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 4.0e+01}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 40.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionMiddle">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 8.0e+01}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 4.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 80.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 40.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 8.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 80.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface West">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{7.20000e+01, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{72.0000, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib-1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{7.20000e+01, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{8.0e+01, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.0000, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{80.0, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface East">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{8.0e+01, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{80.0, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -65,8 +64,8 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{54, 60}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -77,7 +76,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -104,27 +102,30 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
-      <Parameter name="start times" type="Array(double)" value="{ 6.0e+4, 6.5e+4, 6.9e+4}"/>
-      <Parameter name="initial timestep" type="Array(double)" value="{100.0, 50, 50}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{1e+10, 1e+10, 1e+10 }"/>
+      <Parameter name="start times" type="Array(double)" value="{6.0e+4, 6.5e+4, 6.9e+4}"/>
+      <Parameter name="initial timestep" type="Array(double)" value="{100.0, 50.0, 50.0}"/>
+      <Parameter name="maximum timestep" type="Array(double)" value="{1e+10, 1e+10, 1e+10}"/>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.9820e+02"/>
+        <Parameter name="value" type="double" value="998.20"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -132,7 +133,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -141,7 +141,7 @@
         <Parameter name="tolerance" type="double" value="0.001"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -152,16 +152,15 @@
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.0e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.0e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -174,9 +173,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="Dummy">
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_flow.xml
+++ b/src/mpc/test/mpc_flow.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_flow"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -10,37 +9,36 @@
     <Parameter name="file name base" type="string" value="plot_flow"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Bottom Surface Outside All">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 0.0e+00}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region Bottom">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 4.0e+01}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 40.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region Middle">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 8.0e+01}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 4.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 80.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 40.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Region Top">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 8.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 80.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.36000e+02, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{136.000, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -50,6 +48,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
@@ -66,28 +65,26 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="flow">
-	    <Parameter name="PK type" type="string" value="richards"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="15000.0"/>
-	<Parameter name="initial timestep" type="double" value="15.0"/>
-	<Parameter name="maximum timestep" type="double" value="2000.0"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="flow">
+            <Parameter name="PK type" type="string" value="richards"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="15000.0"/>
+        <Parameter name="initial timestep" type="double" value="15.0"/>
+        <Parameter name="maximum timestep" type="double" value="2000.0"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{}"/>		 
+      <Parameter name="maximum timestep" type="Array(double)" value="{}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="viscosity_liquid">
@@ -98,7 +95,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+                <Parameter name="value" type="double" value="0.00100200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -112,7 +109,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.08200000000000007e-01"/>
+                <Parameter name="value" type="double" value="0.408200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -121,7 +118,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.20599999999999991e-01"/>
+                <Parameter name="value" type="double" value="0.220599999999999991"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -130,7 +127,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.34000000000000014e-01"/>
+                <Parameter name="value" type="double" value="0.234000000000000014"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -165,20 +162,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -229,7 +230,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.07059999999999986e-09"/>
+                  <Parameter name="value" type="double" value="2.07059999999999986e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -241,6 +242,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -248,14 +250,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.013250000e+05"/>
-                <Parameter name="x0" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0e+00, 0.0e+00, -9.79351920000000064e+03}"/>
+                <Parameter name="y0" type="double" value="101325.0000"/>
+                <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.51920000000064}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -269,6 +272,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -279,13 +283,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.0e+00"/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -293,144 +298,149 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
-          <ParameterList name="upwind parameters">
+        <ParameterList name="upwind parameters">
           <Parameter name="tolerance" type="double" value="1e-12"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="water retention models">
-      	<ParameterList name="Water Retention Model for Region Middle">
-      	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-      	  <Parameter name="regions" type="Array(string)" value="{Region Middle}"/>
-      	  <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-      	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-      	  <Parameter name="van Genuchten alpha" type="double" value="1.94670000000000005e-04"/>
-      	  <Parameter name="residual saturation liquid" type="double" value="0.0e+00"/>
-      	  <Parameter name="regularization interval" type="double" value="0.0e+00"/>
-      	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-      	</ParameterList>
-      	<ParameterList name="Water Retention Model for Region Bottom">
-      	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-      	  <Parameter name="regions" type="Array(string)" value="{Region Bottom}"/>
-      	  <Parameter name="van Genuchten m" type="double" value="2.13600000000000012e-01"/>
-      	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-      	  <Parameter name="van Genuchten alpha" type="double" value="2.02600000000000002e-03"/>
-      	  <Parameter name="residual saturation liquid" type="double" value="0.0e+00"/>
-      	  <Parameter name="regularization interval" type="double" value="0.0e+00"/>
-      	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-      	</ParameterList>
-      	<ParameterList name="Water Retention Model for Region Top">
-      	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-      	  <Parameter name="regions" type="Array(string)" value="{Region Top}"/>
-      	  <Parameter name="van Genuchten m" type="double" value="3.00599999999999978e-01"/>
-      	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-      	  <Parameter name="van Genuchten alpha" type="double" value="2.06740000000000005e-03"/>
-      	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-      	  <Parameter name="regularization interval" type="double" value="0.0"/>
-      	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-      	</ParameterList>
+        <ParameterList name="Water Retention Model for Region Middle">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{Region Middle}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000194670000000000005"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="Water Retention Model for Region Bottom">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{Region Bottom}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.213600000000000012"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00202600000000000002"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="Water Retention Model for Region Top">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{Region Top}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.300599999999999978"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00206740000000000005"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
       </ParameterList>
 
       <!--ParameterList name="clipping parameters">
       	<Parameter name="maximum correction change" type="double" value="-1.0"/>
       </ParameterList-->
-
       <ParameterList name="operators">
-      	<ParameterList name="diffusion operator">
-      	  <ParameterList name="matrix">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	  <ParameterList name="preconditioner">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-      	<ParameterList name="pressure">
-      	  <ParameterList name="BC 0">
-      	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface Outside All}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <ParameterList name="boundary pressure">
-      	      <ParameterList name="function-constant">
-      		<Parameter name="value" type="double" value="101325.0"/>
-      	      </ParameterList>
-      	    </ParameterList>
-      	  </ParameterList>
-      	</ParameterList>
-      	<ParameterList name="mass flux">
-      	  <ParameterList name="BC 1">
-      	    <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <Parameter name="rainfall" type="bool" value="false"/>
-      	    <ParameterList name="outward mass flux">
-      	      <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="-1.1071e-04"/>
-      	      </ParameterList>
-      	    </ParameterList>
-      	  </ParameterList>
-      	</ParameterList>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-0.00011071"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="start interval time" type="double" value="0.0e+00"/>
-	<Parameter name="initial timestep" type="double" value="1.0e+00"/>
-	<Parameter name="maximal timestep" type="double" value="1.0e+07"/>
-      	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-      	<Parameter name="linear solver" type="string" value="AztecOO"/>
-      	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      	<ParameterList name="dae constraint">
-      	  <Parameter name="method" type="string" value="projection"/>
-      	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
-      	<Parameter name="time integration method" type="string" value="BDF1"/>
-      	<ParameterList name="BDF1">
-      	  <Parameter name="timestep controller type" type="string" value="standard"/>
-      	  <ParameterList name="timestep controller standard parameters">
-      	    <Parameter name="max iterations" type="int" value="15"/>
-      	    <Parameter name="min iterations" type="int" value="10"/>
-      	    <Parameter name="timestep increase factor" type="double" value="1.5"/>
-      	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-      	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-      	    <Parameter name="min timestep" type="double" value="1e-20"/>
-      	  </ParameterList>
-      	  <Parameter name="solver type" type="string" value="nka"/>
-      	  <ParameterList name="nka parameters">
-      	    <Parameter name="nonlinear tolerance" type="double" value="1.0000e-05"/>
-      	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-      	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-      	    <Parameter name="max divergent iterations" type="int" value="3"/>
-      	    <Parameter name="max nka vectors" type="int" value="10"/>
-      	    <Parameter name="limit iterations" type="int" value="20"/>
-      	    <Parameter name="modify correction" type="bool" value="false"/>
-      	  </ParameterList>
-      	  <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
-      	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-      	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-      	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-      	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-      	</ParameterList>
-      	<ParameterList name="initialization">
-      	  <Parameter name="method" type="string" value="saturated solver"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
+        <Parameter name="start interval time" type="double" value="0.0"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
+        <Parameter name="maximal timestep" type="double" value="1.0e+7"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.5"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010000"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="preconditioners">
@@ -438,10 +448,10 @@
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="optimized mfd scaled"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="relaxation type" type="int" value="3"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
@@ -449,7 +459,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>

--- a/src/mpc/test/mpc_flow_reactive_transport.xml
+++ b/src/mpc/test/mpc_flow_reactive_transport.xml
@@ -1,11 +1,10 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_frt"/>
     <Parameter name="file name digits" type="int" value="5"/>
-    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 5, -1}" />
-  </ParameterList>  
+    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 5, -1}"/>
+  </ParameterList>
   <ParameterList name="regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="region: box">
@@ -44,6 +43,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
@@ -60,139 +60,146 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
+    <Parameter name="start time" type="double" value="0.0"/>
     <Parameter name="end time" type="double" value="1.0e+4"/>
     <Parameter name="component names" type="Array(string)" value="{Na+, Ca++, Mg++, Cl-}"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{23.0e-3, 40.0e-3, 24.3e-3, 35.5e-3}"/>
+    <Parameter name="component molar masses" type="Array(double)" value="{0.0230, 0.0400, 0.0243, 0.0355}"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="flow and reactive transport">
-	    <Parameter name="PK type" type="string" value="flow reactive transport"/>      
-	    <ParameterList name="flow">
-	      <Parameter name="PK type" type="string" value="darcy"/>
-	    </ParameterList>    
-	    <ParameterList name="reactive transport">
-	      <Parameter name="PK type" type="string" value="reactive transport"/>
-	      <ParameterList name="transport">
-		<Parameter name="PK type" type="string" value="transport"/>
-	      </ParameterList>
-	      <ParameterList name="chemistry">
-		<Parameter name="PK type" type="string" value="chemistry amanzi"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>    
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0e+04"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="flow and reactive transport">
+            <Parameter name="PK type" type="string" value="flow reactive transport"/>
+            <ParameterList name="flow">
+              <Parameter name="PK type" type="string" value="darcy"/>
+            </ParameterList>
+            <ParameterList name="reactive transport">
+              <Parameter name="PK type" type="string" value="reactive transport"/>
+              <ParameterList name="transport">
+                <Parameter name="PK type" type="string" value="transport"/>
+              </ParameterList>
+              <ParameterList name="chemistry">
+                <Parameter name="PK type" type="string" value="chemistry amanzi"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0e+4"/>
         <Parameter name="initial timestep" type="double" value="1000.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow and reactive transport">
-      <Parameter name="PK type" type="string" value="flow reactive transport"/>      
-      <Parameter name="PKs order" type="Array(string)" value="{flow, reactive transport}"/> 
+      <Parameter name="PK type" type="string" value="flow reactive transport"/>
+      <Parameter name="PKs order" type="Array(string)" value="{flow, reactive transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="reactive transport">
-      <Parameter name="PK type" type="string" value="reactive transport"/>      
-      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/> 
+      <Parameter name="PK type" type="string" value="reactive transport"/>
+      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/>
+
     </ParameterList>
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: default"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: default"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: default"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: default"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: default"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: default"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{West}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		<Parameter name="y values" type="Array(double)" value="{-7.91317859000000037e-06, -1.31785899999999989e+00}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{East}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		<Parameter name="y values" type="Array(double)" value="{2.01325e+05, 2.01325e+05}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{West}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                <Parameter name="y values" type="Array(double)" value="{-0.00000791317859000000037, -1.31785899999999989}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{East}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                <Parameter name="y values" type="Array(double)" value="{201325.0, 201325.0}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.0"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-	    <Parameter name="min timestep" type="double" value="1.0e-20"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999945e-21"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1000.0"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	</ParameterList>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.0"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999945e-21"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="chemistry">
@@ -203,14 +210,14 @@
       <Parameter name="minerals" type="Array(string)" value="{Halite}"/>
       <Parameter name="number of component concentrations" type="int" value="4"/>
       <Parameter name="log formulation" type="bool" value="true"/>
-
       <ParameterList name="thermodynamic database">
         <Parameter name="file" type="string" value="test/mpc_flow_reactive_transport_bgd.xml"/>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transport">
@@ -222,73 +229,78 @@
       <Parameter name="advection limiter" type="string" value="Tensorial"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <Parameter name="enable internal tests" type="bool" value="false"/>
       <ParameterList name="molecular diffusion">
-	<Parameter name="aqueous names" type="Array(string)" value="{}"/>
-	<Parameter name="aqueous values" type="Array(double)" value="{}"/>
+        <Parameter name="aqueous names" type="Array(string)" value="{}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{}"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Na+">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Na+">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{9.42676899999999977e-03, 9.42676899999999977e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Ca++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00942676899999999977, 0.00942676899999999977}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Ca++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{5.01423899999999955e-04, 5.01423899999999955e-04}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Mg++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.000501423899999999955, 0.000501423899999999955}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Mg++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{2.13606599999999983e-03, 2.13606599999999983e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Cl-">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00213606599999999983, 0.00213606599999999983}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Cl-">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{1.47017488000000009e-02, 1.47017488000000009e-02}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.0147017488000000009, 0.0147017488000000009}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 3.15360e+7}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="4"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <Parameter name="runtime diagnostics: regions" type="Array(string)" value="{}"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -314,7 +326,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -358,31 +370,34 @@
         </ParameterList>
       </ParameterList>
       <ParameterList name="mass_density_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -414,6 +429,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="Entire DomainSoil_1Soil_2">
@@ -421,12 +437,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -437,7 +454,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-04"/>
+                  <Parameter name="value" type="double" value="0.00010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -450,13 +467,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0e-04"/>
+                  <Parameter name="value" type="double" value="0.00020"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -487,6 +505,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -497,7 +516,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-04"/>
+                  <Parameter name="value" type="double" value="0.00010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -510,13 +529,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0e-04"/>
+                  <Parameter name="value" type="double" value="0.00020"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_sites">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -547,6 +567,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_ref_cation_conc">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -577,6 +598,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="free_ion_species">
         <ParameterList name="function">
           <ParameterList name="Entire Domain">
@@ -587,22 +609,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -615,22 +637,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -643,28 +665,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <Parameter name="names" type="Array(string)" value="{total, total, total, total}"/>
         <ParameterList name="function">
@@ -676,28 +699,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -711,6 +735,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -718,7 +743,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -748,7 +772,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -771,7 +794,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="obs_output.out"/>
     <Parameter name="precision" type="int" value="10"/>
@@ -779,52 +801,51 @@
       <Parameter name="region" type="string" value="Soil_1"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="drawdown"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-2">
       <Parameter name="region" type="string" value="Soil_2"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="drawdown"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-3">
       <Parameter name="region" type="string" value="Soil_2"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="Cl- aqueous concentration"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-4">
       <Parameter name="region" type="string" value="Soil_1"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="Na+ aqueous concentration"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-5">
       <Parameter name="region" type="string" value="West"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="Na+ volumetric flow rate"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-6">
       <Parameter name="region" type="string" value="Soil_1"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="water table"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-7">
       <Parameter name="region" type="string" value="Soil_1"/>
       <Parameter name="functional" type="string" value="observation data: integral"/>
       <Parameter name="variable" type="string" value="permeability-weighted hydraulic head"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
     <ParameterList name="OBS-8">
       <Parameter name="region" type="string" value="West"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="aqueous volumetric flow rate"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{West, East, West, East}"/>

--- a/src/mpc/test/mpc_flow_reactive_transport_bgd.xml
+++ b/src/mpc/test/mpc_flow_reactive_transport_bgd.xml
@@ -1,56 +1,56 @@
-  <ParameterList name="thermodynamic database">
-    <ParameterList name="primary species">
-      <ParameterList name="Na+">
-        <Parameter name="ion size parameter" type="double" value="4.0"/>
-        <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="22.99"/>
-      </ParameterList>
-      <ParameterList name="Ca++">
-        <Parameter name="ion size parameter" type="double" value="6.00000000000000000e+00"/>
-        <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="4.00780000000000030e+01"/>
-      </ParameterList>
-      <ParameterList name="Mg++">
-        <Parameter name="ion size parameter" type="double" value="8.0"/>
-        <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="24.30"/>
-      </ParameterList>
-      <ParameterList name="Cl-">
-        <Parameter name="ion size parameter" type="double" value="3.0"/>
-        <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="35.45"/>
-      </ParameterList>
+<ParameterList name="thermodynamic database">
+  <ParameterList name="primary species">
+    <ParameterList name="Na+">
+      <Parameter name="ion size parameter" type="double" value="4.0"/>
+      <Parameter name="charge" type="int" value="1"/>
+      <Parameter name="gram molecular weight" type="double" value="22.99"/>
     </ParameterList>
-    <ParameterList name="mineral kinetics">
-      <ParameterList name="Halite">
-        <Parameter name="rate model" type="string" value="TST"/>
-        <Parameter name="rate constant" type="double" value="-36.0"/>
-        <Parameter name="modifiers" type="string" value=""/>
-        <Parameter name="gram molecular weight" type="double" value="5.84425E+01 "/>
-        <Parameter name="reaction" type="string" value="1.0 Na+   1.0 Cl-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.58550E+00"/>
-        <Parameter name="molar volume" type="double" value="2.70150E+01"/>
-        <Parameter name="specific surface area" type="double" value="1.00000000000000000e+00"/>
-      </ParameterList>
+    <ParameterList name="Ca++">
+      <Parameter name="ion size parameter" type="double" value="6.00000000000000000"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="40.0780000000000030"/>
     </ParameterList>
-    <ParameterList name="ion exchange sites">
-      <ParameterList name="X-">
-        <Parameter name="location" type="string" value="Halite"/>
-        <Parameter name="charge" type="int" value="-1"/>
-      </ParameterList>
+    <ParameterList name="Mg++">
+      <Parameter name="ion size parameter" type="double" value="8.0"/>
+      <Parameter name="charge" type="int" value="2"/>
+      <Parameter name="gram molecular weight" type="double" value="24.30"/>
     </ParameterList>
-    <ParameterList name="ion exchange complexes">
-      <ParameterList name="Na+X">
-        <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.00000000000000000e+00"/>
-      </ParameterList>
-      <ParameterList name="Ca++X">
-        <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="2.95300E-01"/>
-      </ParameterList>
-      <ParameterList name="Mg++X">
-        <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.66600E-01"/>
-      </ParameterList>
+    <ParameterList name="Cl-">
+      <Parameter name="ion size parameter" type="double" value="3.0"/>
+      <Parameter name="charge" type="int" value="-1"/>
+      <Parameter name="gram molecular weight" type="double" value="35.45"/>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="mineral kinetics">
+    <ParameterList name="Halite">
+      <Parameter name="rate model" type="string" value="TST"/>
+      <Parameter name="rate constant" type="double" value="-36.0"/>
+      <Parameter name="modifiers" type="string" value=""/>
+      <Parameter name="gram molecular weight" type="double" value="58.4425"/>
+      <Parameter name="reaction" type="string" value="1.0 Na+   1.0 Cl-"/>
+      <Parameter name="equilibrium constant" type="double" value="1.58550"/>
+      <Parameter name="molar volume" type="double" value="27.0150"/>
+      <Parameter name="specific surface area" type="double" value="1.00000000000000000"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="ion exchange sites">
+    <ParameterList name="X-">
+      <Parameter name="location" type="string" value="Halite"/>
+      <Parameter name="charge" type="int" value="-1"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="ion exchange complexes">
+    <ParameterList name="Na+X">
+      <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="1.00000000000000000"/>
+    </ParameterList>
+    <ParameterList name="Ca++X">
+      <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="0.295300"/>
+    </ParameterList>
+    <ParameterList name="Mg++X">
+      <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
+      <Parameter name="equilibrium constant" type="double" value="0.166600"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/src/mpc/test/mpc_ihm_shallow_water_transport.xml
+++ b/src/mpc/test/mpc_ihm_shallow_water_transport.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -21,7 +20,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
@@ -31,11 +29,12 @@
     </ParameterList>
     <ParameterList name="LeftEdgeMiddle">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 2.0e+01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 3.0e+01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 20.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 30.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="mass_density_liquid">
@@ -45,7 +44,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -67,17 +66,20 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -95,6 +97,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ponded_depth">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -108,9 +111,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -118,12 +123,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter isUsed="true" name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+02}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+2}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -139,9 +142,9 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="3.0e+02"/>
+        <Parameter name="end period time" type="double" value="3.0e+2"/>
         <Parameter name="maximum cycle number" type="int" value="30"/>
-        <Parameter name="initial timestep" type="double" value="1.00000000000000002e-02"/>
+        <Parameter name="initial timestep" type="double" value="0.0100000000000000002"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
       </ParameterList>
     </ParameterList>
@@ -156,18 +159,21 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:shallow water and transport">
       <Parameter name="PKs order" type="Array(string)" value="{transient:shallow water, transient:transport}"/>
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:shallow water">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
-      <Parameter name="cfl" type="double" value="5.00000000000000000e-01"/>
+      <Parameter name="cfl" type="double" value="0.500000000000000000"/>
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
@@ -175,6 +181,7 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -209,9 +216,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -227,17 +236,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000000000000000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -253,10 +262,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:transport">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
@@ -273,11 +285,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -296,6 +310,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Tc-99">
@@ -312,6 +327,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -321,11 +337,15 @@
         <Parameter name="volumetric flow rate key" type="string" value="riemann_flux"/>
         <Parameter name="saturation key" type="string" value="ponded_depth"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -374,7 +394,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -382,9 +402,8 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data surface">
     <Parameter name="file name base" type="string" value="plot_surface"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+02}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+2}"/>
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_ihm_shallow_water_transport_Thacker.xml
+++ b/src/mpc/test/mpc_ihm_shallow_water_transport_Thacker.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -21,7 +20,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
@@ -48,7 +46,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -70,18 +68,21 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <Parameter name="time" type="double" value="0.0"/>
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -105,6 +106,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -123,6 +125,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ponded_depth">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -138,6 +141,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="velocity">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -163,23 +167,22 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
-      </ParameterList>
-    </ParameterList>
 
+      <ParameterList name="atmospheric_pressure">
+        <Parameter name="value" type="double" value="101325.000000000000"/>
+      </ParameterList>
+
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter isUsed="true" name="file name base" type="string" value="plot"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+02}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+2}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -212,13 +215,16 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:shallow water and transport">
       <Parameter name="PKs order" type="Array(string)" value="{transient:shallow water, transient:transport}"/>
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:shallow water">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
@@ -233,6 +239,7 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -269,9 +276,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -287,17 +296,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000000000000000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000008e-05"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000100000000000000008"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -313,9 +322,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:transport">
@@ -334,11 +345,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Tc-99}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -357,6 +370,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Tc-99">
@@ -374,6 +388,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
@@ -383,11 +398,15 @@
         <Parameter name="volumetric flow rate key" type="string" value="riemann_flux"/>
         <Parameter name="saturation key" type="string" value="ponded_depth"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -436,7 +455,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -444,9 +463,8 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data surface">
     <Parameter name="file name base" type="string" value="plot_surface"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+02}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 2.0, 3.0e+2}"/>
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_mechanics_flow_aperture.xml
+++ b/src/mpc/test/mpc_mechanics_flow_aperture.xml
@@ -15,7 +15,7 @@
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{100, 1, 4}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{-12.5, -0.5, -0.25}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{12.5,  0.5,  0.25}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{12.5, 0.5, 0.25}"/>
       </ParameterList>
       <ParameterList name="submesh">
         <Parameter name="regions" type="Array(string)" value="{FRACTURE_NETWORK_INTERNAL}"/>
@@ -29,6 +29,7 @@
     </ParameterList>
     <Parameter name="request edges" type="bool" value="true"/>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
@@ -36,43 +37,43 @@
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.5, -0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  0.5,  0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceInlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -12.5, -0.5, -0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{-12.5,  0.5,  0.25}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.5, -0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{-12.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceOutlet">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 12.5, -0.5, -0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  0.5,  0.25}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{12.5, -0.5, -0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.5, -0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  0.5, -0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.5, -0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.5, 0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  0.5, 0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-12.5, -0.5, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.5,  0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.5, 0.5, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.99e+98, -9.99e+98, -9.99e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.99e+98,  9.99e+98,  9.99e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.99e+98, 9.99e+98, 9.99e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="FRACTURE_NETWORK_INTERNAL">
@@ -82,6 +83,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -260,7 +262,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.98149999999999977e+02"/>
+                <Parameter name="value" type="double" value="298.149999999999977"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -270,18 +272,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -295,6 +302,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -302,12 +310,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="6.0e+06"/>
+                <Parameter name="value" type="double" value="6.0e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -336,6 +345,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-diffusion_to_matrix">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -349,6 +359,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -356,14 +367,15 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.19e+07"/>
+                <Parameter name="y0" type="double" value="1.19e+7"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.81e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.81e+3}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -377,6 +389,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -391,6 +404,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -398,12 +412,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.1e+07"/>
+                <Parameter name="value" type="double" value="1.1e+7"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-temperature">
         <ParameterList name="function">
           <ParameterList name="fracture">
@@ -418,9 +433,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -440,9 +457,9 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.0e-03"/>
+        <Parameter name="end period time" type="double" value="0.0010"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-03"/>
+        <Parameter name="initial timestep" type="double" value="0.0010"/>
         <Parameter name="maximum timestep" type="double" value="300.0"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -463,10 +480,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="1.0e-03"/>
+        <Parameter name="start period time" type="double" value="0.0010"/>
         <Parameter name="end period time" type="double" value="1000.0"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-03"/>
+        <Parameter name="initial timestep" type="double" value="0.0010"/>
         <Parameter name="maximum timestep" type="double" value="300.0"/>
       </ParameterList>
     </ParameterList>
@@ -482,6 +499,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics">
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="time integrator">
@@ -497,14 +515,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -520,6 +538,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -530,11 +549,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="true"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -580,17 +601,20 @@
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.101e+07"/>
+                  <Parameter name="value" type="double" value="-1.101e+7"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:mechanics and coupled flow">
       <Parameter isUsed="true" name="PK type" type="string" value="mechanics and coupled flow"/>
       <Parameter name="PKs order" type="Array(string)" value="{mechanics, transient:coupled flow}"/>
@@ -608,14 +632,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -631,10 +655,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:coupled flow">
       <Parameter isUsed="true" name="PK type" type="string" value="darcy matrix fracture"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow matrix, transient:flow fracture}"/>
@@ -652,14 +679,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-06"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -676,10 +703,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow matrix">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -692,25 +722,29 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.01325e+05"/>
-          <Parameter name="pore compressibility" type="double" value="3.0e-09"/>
+          <Parameter name="reference pressure" type="double" value="101325.0"/>
+          <Parameter name="pore compressibility" type="double" value="3.0e-9"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
         <Parameter name="permeability porosity model" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="permeability porosity models">
         <ParameterList name="PPM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
@@ -719,9 +753,11 @@
           <Parameter name="power law exponent" type="double" value="3.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -745,19 +781,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.19e+07"/>
+                <Parameter name="value" type="double" value="1.19e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -767,7 +805,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.10e+07"/>
+                <Parameter name="value" type="double" value="1.10e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -775,10 +813,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow fracture">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="fracture permeability models">
@@ -788,9 +829,11 @@
           <Parameter name="aperture" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
         <Parameter name="upwind frequency" type="string" value="every timestep"/>
@@ -801,25 +844,29 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture aperture models">
         <ParameterList name="FAM 0">
           <Parameter name="regions" type="Array(string)" value="{fracture}"/>
           <Parameter name="fracture aperture model" type="string" value="Barton-Bandis"/>
-          <Parameter name="undeformed aperture" type="double" value="1.0e-05"/>
-          <Parameter name="overburden pressure" type="double" value="1.1e+07"/>
+          <Parameter name="undeformed aperture" type="double" value="0.000010"/>
+          <Parameter name="overburden pressure" type="double" value="1.1e+7"/>
           <Parameter name="BartonBandis A" type="double" value="1.0e-11"/>
           <Parameter name="BartonBandis B" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -841,19 +888,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.19e+07"/>
+                <Parameter name="value" type="double" value="1.19e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -863,7 +912,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.10e+07"/>
+                <Parameter name="value" type="double" value="1.10e+7"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -871,11 +920,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>

--- a/src/mpc/test/mpc_mechanics_mandel.xml
+++ b/src/mpc/test/mpc_mechanics_mandel.xml
@@ -6,8 +6,8 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{50, 20}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{-1.00000000000000000e+01, -3.00000e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00000000000000000e+01, 3.00000e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{-10.0000000000000000, -3.00000}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{10.0000000000000000, 3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="verbose object">
@@ -18,42 +18,41 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-1.00000000000000000e+01, -3.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000e+01, 3.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0000000000000000, -3.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0000000000000000, 3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-1.00000000000000000e+01, -3.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{-1.00000000000000000e+01, 3.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0000000000000000, -3.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{-10.0000000000000000, 3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.00000000000000000e+01, -3.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000e+01, 3.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{10.0000000000000000, -3.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0000000000000000, 3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-1.00000000000000000e+01, -3.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000e+01, -3.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0000000000000000, -3.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0000000000000000, -3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-1.00000000000000000e+01, 3.00000e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00000000000000000e+01, 3.00000e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0000000000000000, 3.00000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0000000000000000, 3.00000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Center">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-1.0, -1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,  1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -65,10 +64,9 @@
       <Parameter name="region" type="string" value="Center"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="aqueous pressure"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{3, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{3, 1, -1}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -78,7 +76,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000006e-01"/>
+                <Parameter name="value" type="double" value="0.100000000000000006"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -93,7 +91,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.71600000000000000e+03"/>
+                <Parameter name="value" type="double" value="2716.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -109,7 +107,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="7.60000000000000000e+01"/>
+              <Parameter name="heat capacity" type="double" value="76.0000000000000000"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -122,7 +120,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.18000000000000000e+03"/>
+              <Parameter name="heat capacity" type="double" value="1180.00000000000000"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -163,12 +161,15 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.00000e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.00000, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -176,12 +177,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.00000000000000011e-01"/>
+                <Parameter name="value" type="double" value="0.200000000000000011"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -189,12 +191,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="6.00000000000000000e+10"/>
+                <Parameter name="value" type="double" value="60000000000.0000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -208,6 +211,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -231,6 +235,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -238,12 +243,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.40000000000000000e+06"/>
+                <Parameter name="value" type="double" value="1400000.00000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -251,12 +257,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000e+00"/>
+                <Parameter name="value" type="double" value="1.00000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -271,9 +278,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -284,12 +293,10 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 5.0, 5.0}"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -299,9 +306,9 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.0e-03"/>
+        <Parameter name="end period time" type="double" value="0.0010"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-03"/>
+        <Parameter name="initial timestep" type="double" value="0.0010"/>
         <Parameter name="maximum timestep" type="double" value="10.0"/>
       </ParameterList>
       <ParameterList name="TP 1">
@@ -316,11 +323,11 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="1.0e-03"/>
+        <Parameter name="start period time" type="double" value="0.0010"/>
         <Parameter name="end period time" type="double" value="150.0"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.0e-03"/>
-        <Parameter name="maximum timestep" type="double" value="6.00000e+00"/>
+        <Parameter name="initial timestep" type="double" value="0.0010"/>
+        <Parameter name="maximum timestep" type="double" value="6.00000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -334,8 +341,8 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transient:mechanics and flow">
       <Parameter isUsed="true" name="PK type" type="string" value="mechanics and flow"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:mechanics, transient:flow}"/>
@@ -355,17 +362,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-08"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.00000000000000002e-8"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -373,17 +380,19 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -405,15 +414,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -429,6 +438,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -439,11 +449,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="traction">
           <ParameterList name="BC 0">
@@ -506,9 +518,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -523,25 +537,29 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.01325000000000000e+05"/>
-          <Parameter name="pore compressibility" type="double" value="3.0e-09"/>
+          <Parameter name="reference pressure" type="double" value="101325.000000000000"/>
+          <Parameter name="pore compressibility" type="double" value="3.0e-9"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
         <Parameter name="permeability porosity model" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="permeability porosity models">
         <ParameterList name="PPM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
@@ -550,9 +568,11 @@
           <Parameter name="power law exponent" type="double" value="3.0"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -582,6 +602,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -599,15 +620,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -623,6 +644,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -637,10 +659,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -680,15 +705,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000e+00"/>
+        <Parameter name="tolerance" type="double" value="0.00000"/>
         <Parameter name="smoother sweeps" type="int" value="2"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -696,7 +720,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>

--- a/src/mpc/test/mpc_mechanics_stress_split.xml
+++ b/src/mpc/test/mpc_mechanics_stress_split.xml
@@ -22,49 +22,50 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
   <ParameterList name="regions">
     <ParameterList name="EntireDomain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,  0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{11.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,  0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceRight">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 11.0,  0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{11.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{11.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceBottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{11.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SurfaceTop">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 10.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{11.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="TopLoad">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 5.0, 10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{5.0, 10.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{6.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="CentralPoint">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 5.40, 4.90}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{5.40, 4.90}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{5.60, 5.10}"/>
       </ParameterList>
     </ParameterList>
@@ -115,7 +116,7 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-03"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -130,7 +131,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.716e+03"/>
+                <Parameter name="value" type="double" value="2716.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -156,18 +157,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -181,6 +187,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -188,12 +195,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.94945e+06"/>
+                <Parameter name="value" type="double" value="3.94945e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -207,6 +215,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -230,6 +239,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -243,6 +253,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -256,6 +267,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -270,9 +282,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -283,7 +297,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="obs_load.out"/>
     <ParameterList name="obl 1">
@@ -293,7 +306,6 @@
       <Parameter name="region" type="string" value="CentralPoint"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -309,10 +321,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="6.00460e+08"/>
+        <Parameter name="end period time" type="double" value="6.00460e+8"/>
         <Parameter name="maximum cycle number" type="int" value="8"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+03"/>
-        <Parameter name="maximum timestep" type="double" value="2.592e+06"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+3"/>
+        <Parameter name="maximum timestep" type="double" value="2.592e+6"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -327,6 +339,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:mechanics}"/>
@@ -349,14 +362,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -373,10 +386,13 @@
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="20"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -389,28 +405,33 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
           <Parameter name="reference pressure" type="double" value="0.0"/>
-          <Parameter name="pore compressibility" type="double" value="3.9056e-06"/>
-          <Parameter name="biot coefficient" type="double" value="9.45770000000000000e-01"/>
+          <Parameter name="pore compressibility" type="double" value="0.0000039056"/>
+          <Parameter name="biot coefficient" type="double" value="0.945770000000000000"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -440,6 +461,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -457,15 +479,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -482,6 +504,7 @@
         </ParameterList>
         <Parameter name="maximum number of iterations" type="int" value="20"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
@@ -496,9 +519,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -520,15 +545,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -544,6 +569,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -554,11 +580,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="traction">
           <ParameterList name="BC 0">
@@ -610,7 +638,7 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-6.5e+04"/>
+                  <Parameter name="value" type="double" value="-6.5e+4"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -637,11 +665,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>

--- a/src/mpc/test/mpc_mechanics_thermal_flow.xml
+++ b/src/mpc/test/mpc_mechanics_thermal_flow.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -22,21 +21,21 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="BigBox">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-4.0, -4.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{4.0,  4.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{4.0, 4.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SmallBox">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-2.00, -2.00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.00,  2.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{2.00, 2.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="EntireDomainDoesNotWork">
@@ -94,7 +93,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.757e+03"/>
+                <Parameter name="value" type="double" value="2757.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -123,7 +122,7 @@
             <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.180e+03"/>
+              <Parameter name="heat capacity" type="double" value="1180.0"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -164,12 +163,15 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -183,6 +185,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -196,6 +199,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -209,6 +213,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -232,6 +237,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -239,12 +245,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+06"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -258,6 +265,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -272,9 +280,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -306,10 +316,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.0368e+06"/>
+        <Parameter name="end period time" type="double" value="1.0368e+6"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="7.20e+03"/>
-        <Parameter name="maximum timestep" type="double" value="8.64e+04"/>
+        <Parameter name="initial timestep" type="double" value="7.20e+3"/>
+        <Parameter name="maximum timestep" type="double" value="8.64e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -324,6 +334,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:thermal flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow and energy, transient:mechanics}"/>
@@ -340,15 +351,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -356,18 +367,21 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow and energy">
       <Parameter isUsed="true" name="PK type" type="string" value="thermal flow"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:energy}"/>
@@ -376,6 +390,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -386,17 +401,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-07"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+04"/>
+            <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-7"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="10000.0000000000000"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -404,18 +419,21 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="relative permeability">
@@ -428,30 +446,35 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
-          <Parameter name="undeformed soil porosity" type="double" value="1.00000000000000006e-01"/>
-          <Parameter name="reference pressure" type="double" value="1.01325000000000000e+05"/>
-          <Parameter name="pore compressibility" type="double" value="2.99999999999999998e-09"/>
-          <Parameter name="biot coefficient" type="double" value="9.00000000000000022e-01"/>
-          <Parameter name="rock thermal dilation" type="double" value="2.09999999999999988e-05"/>
-          <Parameter name="liquid thermal dilation" type="double" value="2.10000000000000009e-04"/>
+          <Parameter name="undeformed soil porosity" type="double" value="0.100000000000000006"/>
+          <Parameter name="reference pressure" type="double" value="101325.000000000000"/>
+          <Parameter name="pore compressibility" type="double" value="2.99999999999999998e-9"/>
+          <Parameter name="biot coefficient" type="double" value="0.900000000000000022"/>
+          <Parameter name="rock thermal dilation" type="double" value="0.0000209999999999999988"/>
+          <Parameter name="liquid thermal dilation" type="double" value="0.000210000000000000009"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -471,6 +494,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -488,15 +512,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -512,13 +536,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+06"/>
+                <Parameter name="value" type="double" value="1000000.00000000000"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -528,7 +553,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+06"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -536,10 +561,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:energy">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
@@ -560,22 +588,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="All">
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
+          <Parameter name="regions" type="Array(string)" value="{EntireDomain}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.5"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="constant"/>
+            <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.598"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -589,14 +619,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -612,6 +642,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -625,12 +656,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="false"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="false"/>
@@ -638,10 +671,13 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:mechanics">
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="time integrator">
@@ -657,14 +693,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -680,6 +716,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -690,11 +727,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -717,11 +756,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -750,7 +793,7 @@
     <ParameterList name="PCG for elasticity">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
-        <Parameter name="error tolerance" type="double" value="1.0e-08"/>
+        <Parameter name="error tolerance" type="double" value="1.0e-8"/>
         <Parameter name="maximum number of iterations" type="int" value="400"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative residual, relative rhs, make one iteration}"/>
         <ParameterList name="verbose object">
@@ -774,7 +817,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="obs_elasticity.out"/>
     <Parameter name="precision" type="int" value="10"/>
@@ -782,10 +824,9 @@
       <Parameter name="region" type="string" value="EntireDomain"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="aqueous pressure"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>

--- a/src/mpc/test/mpc_mechanics_thermal_flow_3D.xml
+++ b/src/mpc/test/mpc_mechanics_thermal_flow_3D.xml
@@ -8,7 +8,6 @@
     <Parameter name="amount" type="string" value="mol"/>
     <Parameter isUsed="true" name="temperature" type="string" value="K"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
     <Parameter name="partitioner" type="string" value="metis"/>
@@ -24,21 +23,21 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="BigBox">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-4.0, -4.0, -4.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{4.0,  4.0,  4.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{4.0, 4.0, 4.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SmallBox">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-2.0, -2.0, -2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.0,  2.0,  2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{2.0, 2.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="DoughnutLogical">  <!-- this does not work -->
+    <ParameterList name="DoughnutLogical">
+      <!-- this does not work -->
       <ParameterList name="region: logical">
         <Parameter name="operation" type="string" value="subtract"/>
         <Parameter name="regions" type="Array(string)" value="{BigBox, SmallBox}"/>
@@ -64,7 +63,7 @@
     <ParameterList name="Doughnut">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.99e+98, -9.99e+98, -9.99e+99}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.99e+98,  9.99e+98,  9.99e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.99e+98, 9.99e+98, 9.99e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -93,7 +92,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.757e+03"/>
+                <Parameter name="value" type="double" value="2757.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -122,7 +121,7 @@
             <Parameter name="regions" type="Array(string)" value="{Doughnut}"/>
             <ParameterList name="IEM parameters">
               <Parameter name="iem type" type="string" value="linear"/>
-              <Parameter name="heat capacity" type="double" value="1.180e+03"/>
+              <Parameter name="heat capacity" type="double" value="1180.0"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -162,20 +161,24 @@
         <Parameter name="constant in time" type="bool" value="true"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-03"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="1.0e+03"/>
+        <Parameter name="value" type="double" value="1.0e+3"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="displacement">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -203,6 +206,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -216,6 +220,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="young_modulus">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -229,6 +234,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="biot_coefficient">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -242,6 +248,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -270,6 +277,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -277,12 +285,13 @@
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+06"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -296,6 +305,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="EntireDomain">
@@ -310,9 +320,11 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -344,10 +356,10 @@
           </ParameterList>
         </ParameterList>
         <Parameter name="start period time" type="double" value="0.0"/>
-        <Parameter name="end period time" type="double" value="1.0368e+06"/>
+        <Parameter name="end period time" type="double" value="1.0368e+6"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="7.20e+03"/>
-        <Parameter name="maximum timestep" type="double" value="8.64e+04"/>
+        <Parameter name="initial timestep" type="double" value="7.20e+3"/>
+        <Parameter name="maximum timestep" type="double" value="8.64e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
@@ -362,6 +374,7 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="transient:thermal flow and mechanics">
       <Parameter isUsed="true" name="PK type" type="string" value="flow and mechanics"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow and energy, transient:mechanics}"/>
@@ -378,15 +391,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -394,18 +407,21 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:flow and energy">
       <Parameter isUsed="true" name="PK type" type="string" value="thermal flow"/>
       <Parameter name="PKs order" type="Array(string)" value="{transient:flow, transient:energy}"/>
@@ -414,6 +430,7 @@
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, temperature}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -424,17 +441,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1e-7"/>
-            <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="diverged l2 tolerance" type="double" value="1.00000000000000000e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+04"/>
+            <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="diverged l2 tolerance" type="double" value="10000000000.0000000"/>
+            <Parameter name="max du growth factor" type="double" value="10000.0000000000000"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -442,17 +459,19 @@
           </ParameterList>
           <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
           <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000e+00"/>
-          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000e+00"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.00000000000000000"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.00000000000000000"/>
           <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:flow">
@@ -467,30 +486,35 @@
           <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
         <ParameterList name="WRM_0">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{Doughnut}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="porosity models">
         <ParameterList name="POM 0">
           <Parameter name="regions" type="Array(string)" value="{Doughnut}"/>
           <Parameter name="porosity model" type="string" value="compressible"/>
           <Parameter name="undeformed soil porosity" type="double" value="0.1"/>
-          <Parameter name="reference pressure" type="double" value="1.01325e+05"/>
-          <Parameter name="pore compressibility" type="double" value="3.0e-09"/>
+          <Parameter name="reference pressure" type="double" value="101325.0"/>
+          <Parameter name="pore compressibility" type="double" value="3.0e-9"/>
           <Parameter name="biot coefficient" type="double" value="0.9"/>
-          <Parameter name="rock thermal dilation" type="double" value="2.1e-05"/>
-          <Parameter name="liquid thermal dilation" type="double" value="2.1e-04"/>
+          <Parameter name="rock thermal dilation" type="double" value="0.000021"/>
+          <Parameter name="liquid thermal dilation" type="double" value="0.00021"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
+
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -510,6 +534,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -527,15 +552,15 @@
             <Parameter name="min iterations" type="int" value="10"/>
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -551,13 +576,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{SurfaceInlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+06"/>
+                <Parameter name="value" type="double" value="1000000.00000000000"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -567,7 +593,7 @@
             <Parameter name="regions" type="Array(string)" value="{SurfaceOutlet}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+06"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="use area fractions" type="bool" value="false"/>
@@ -575,10 +601,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="transient:energy">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="operators">
@@ -599,22 +628,24 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
         <ParameterList name="All">
           <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{Doughnut}"/>
+          <Parameter name="regions" type="Array(string)" value="{Doughnut}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.5"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="constant"/>
+            <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.598"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{energy}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -633,14 +664,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -656,6 +687,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="temperature">
           <ParameterList name="BC 0">
@@ -669,12 +701,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
         <Parameter name="include potential term" type="bool" value="false"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
         <Parameter name="include work term" type="bool" value="true"/>
         <Parameter name="include potential term" type="bool" value="false"/>
@@ -682,9 +716,11 @@
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transient:mechanics">
@@ -707,14 +743,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.2"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="1.0e-6"/>
+            <Parameter name="min timestep" type="double" value="0.0000010"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -730,6 +766,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -740,11 +777,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="displacement">
           <ParameterList name="BC 0">
@@ -772,10 +811,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -818,16 +860,15 @@
     <ParameterList name="PCG for elasticity">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
-        <Parameter name="error tolerance" type="double" value="1.0e-09"/>
+        <Parameter name="error tolerance" type="double" value="1.0e-9"/>
         <Parameter name="maximum number of iterations" type="int" value="400"/>
-        <Parameter name="convergence criteria" type="Array(string)" value="{relative residual,relative rhs,make one iteration}"/>
+        <Parameter name="convergence criteria" type="Array(string)" value="{relative residual, relative rhs, make one iteration}"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="low"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -843,7 +884,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="observation data">
     <Parameter name="observation output filename" type="string" value="obs_elasticity.out"/>
     <Parameter name="precision" type="int" value="10"/>
@@ -851,10 +891,9 @@
       <Parameter name="region" type="string" value="Doughnut"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="aqueous pressure"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>

--- a/src/mpc/test/mpc_multiphase_fractures.xml
+++ b/src/mpc/test/mpc_multiphase_fractures.xml
@@ -3,38 +3,36 @@
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="times start period stop" type="Array(double)" value="{0, 1.57e+11, -1}"/>
   </ParameterList-->
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,12.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 12.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Outflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 200.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{200.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,6.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,6.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 6.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 6.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 100.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,12.0,60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 12.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fractures">
@@ -43,17 +41,15 @@
         <Parameter name="regions" type="Array(string)" value="{fracture 1, fracture 2}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="AllBoundary">
       <ParameterList name="region: boundary">
         <Parameter name="entity" type="string" value="face"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="FirstCell">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{4.0,12.0, 60.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{4.0, 12.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -67,16 +63,15 @@
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="pressure liquid"/>
       <!--Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}" /-->
-      <Parameter name="times start period stop" type="Array(double)" value="{0, 1.57e+11, -1}"/>
+      <Parameter name="times start period stop" type="Array(double)" value="{0.0, 1.57e+11, -1.0}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{100, 2, 20}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0,12.0,60.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0, 12.0, 60.0}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -92,589 +87,554 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="domain name" type="string" value="domain"/>
-    <Parameter name="special pc term" type="bool" value="false"/>
-    
-    <ParameterList name="physical models and assumptions">
-      <Parameter name="flow and transport in fractures" type="bool" value="true"/>
-    </ParameterList>
-    
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                                  total_water_storage,
-                                                                  total_component_storage,
-                                                                  advection_water,
-                                                                  advection_liquid,
-                                                                  advection_gas,
-                                                                  diffusion_liquid }"/>
-       <ParameterList name="system">
-         <ParameterList name="pressure eqn">
-           <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-           <Parameter name="accumulation" type="string" value="total_water_storage"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="special pc term" type="bool" value="false"/>
+      <ParameterList name="physical models and assumptions">
+        <Parameter name="flow and transport in fractures" type="bool" value="true"/>
+      </ParameterList>
 
-           <ParameterList name="terms">
-             <ParameterList name="advection">
-               <Parameter name="coefficient" type="string" value="advection_water"/>
-               <Parameter name="argument" type="string" value="pressure_liquid"/>
-               <Parameter name="scaling factor" type="double" value="1.0"/>
-               <Parameter name="phase" type="int" value="0"/>
-             </ParameterList>
-             <ParameterList name="diffusion">
-               <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-               <Parameter name="argument" type="string" value="molar_density_liquid"/>
-               <Parameter name="scaling factor" type="double" value="-0.2"/>
-               <Parameter name="phase" type="int" value="0"/>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-0.2"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="solute eqn">
-           <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-           <Parameter name="accumulation" type="string" value="total_component_storage"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
 
-           <ParameterList name="terms">
-             <ParameterList name="advection 0">
-               <Parameter name="coefficient" type="string" value="advection_liquid"/>
-               <Parameter name="argument" type="string" value="pressure_liquid"/>
-               <Parameter name="scaling factor" type="double" value="1.0"/>
-               <Parameter name="phase" type="int" value="0"/>
-             </ParameterList>
-             <ParameterList name="advection 1">
-               <Parameter name="coefficient" type="string" value="advection_gas"/>
-               <Parameter name="argument" type="string" value="pressure_gas"/>
-               <Parameter name="scaling factor" type="double" value="1.0"/>
-               <Parameter name="phase" type="int" value="1"/>
-             </ParameterList>
-             <ParameterList name="diffusion">
-               <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-               <Parameter name="argument" type="string" value="molar_density_liquid"/>
-               <Parameter name="scaling factor" type="double" value="1.0"/>
-               <Parameter name="phase" type="int" value="0"/>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
 
-         <ParameterList name="constraint eqn">
-           <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-           <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-         </ParameterList>
-       </ParameterList>
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
+        </ParameterList>
+      </ParameterList>
 
-       <Parameter name="Jacobian type" type="string" value="analytic"/>
-       <Parameter name="linear solver" type="string" value="GMRES"/>
-       <Parameter name="preconditioner" type="string" value="ILU"/>
-       <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-       <Parameter name="number aqueous components" type="int" value="1"/>
-       <Parameter name="number gaseous components" type="int" value="0"/>
-
-       <ParameterList name="molecular diffusion">
-         <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-         <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-         <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-         <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-         <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
-       </ParameterList>
-
-       <Parameter name="molar mass of water" type="double" value="1.0e-2"/>
-
-       <Parameter name="CPR enhancement" type="bool" value="false"/>
-       <ParameterList name="CPR parameters">
-         <Parameter name="global solve" type="bool" value="true"/>
-         <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-         <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-       </ParameterList>
-
-       <ParameterList name="water retention models">
-         <ParameterList name="WRM for All">
-           <Parameter name="regions" type="Array(string)" value="{All}"/>
-           <Parameter name="water retention model" type="string" value="van Genuchten"/>
-           <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-           <Parameter name="van Genuchten n" type="double" value="1.49"/>
-           <Parameter name="van Genuchten l" type="double" value="0.5"/>
-           <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-           <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-           <Parameter name="residual saturation gas" type="double" value="0.0"/>
-           <Parameter name="relative permeability model" type="string" value="Mualem"/>
-           <Parameter name="regularization interval kr" type="double" value="0.005"/>
-           <Parameter name="regularization interval pc" type="double" value="0.001"/>
-         </ParameterList>
-       </ParameterList>
-
-       <ParameterList name="time integrator">
-         <Parameter name="time integration method" type="string" value="BDF1"/>
-         <ParameterList name="BDF1">
-           <Parameter name="timestep controller type" type="string" value="standard"/>
-           <ParameterList name="timestep controller standard parameters">
-             <Parameter name="max iterations" type="int" value="15"/>
-             <Parameter name="min iterations" type="int" value="10"/>
-             <Parameter name="timestep increase factor" type="double" value="1.25"/>
-             <Parameter name="timestep reduction factor" type="double" value="0.2"/>
-             <Parameter name="max timestep" type="double" value="6.0e+10"/>
-             <Parameter name="min timestep" type="double" value="1.0e-20"/>
-           </ParameterList>
-
-           <Parameter name="solver type" type="string" value="Newton"/>
-           <ParameterList name="Newton parameters">
-             <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-             <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-             <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-             <Parameter name="max divergent iterations" type="int" value="10"/>
-             <Parameter name="limit iterations" type="int" value="20"/>
-             <Parameter name="modify correction" type="bool" value="true"/>
-             <Parameter name="monitor" type="string" value="monitor update"/>
-             <Parameter name="make one iteration" type="bool" value="true"/>
-             <ParameterList name="verbose object">
-               <Parameter name="verbosity level" type="string" value="high"/>
-             </ParameterList>                        
-           </ParameterList>
-          
-           <!--
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.2"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
+          <!--
            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
            <Parameter name="extrapolate initial guess" type="bool" value="false"/>
            <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
            <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
            <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
            -->
-           <ParameterList name="verbose object">
-             <Parameter name="verbosity level" type="string" value="high"/>
-           </ParameterList>
-         </ParameterList>
-       </ParameterList>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-       <ParameterList name="boundary conditions">
-         <ParameterList name="pressure liquid">
-           <ParameterList name="BC 1">
-             <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <ParameterList name="boundary pressure">
-               <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="1.0e6"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-         <ParameterList name="mass flux total">
-           <ParameterList name="BC 2">
-             <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <Parameter name="name" type="string" value="water"/>
-             <ParameterList name="outward mass flux">
-               <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="0.0"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-           <ParameterList name="BC 3">
-             <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <Parameter name="name" type="string" value="SH4"/>
-             <ParameterList name="outward mass flux">
-               <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="4"/>
-                 <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-         <ParameterList name="saturation">
-           <ParameterList name="BC 4">
-             <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <ParameterList name="boundary saturation">
-               <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="1.0"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="concentration">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="concentration">
-           <ParameterList name="BC 5">
-             <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <Parameter name="name" type="string" value="SH4"/>
-             <ParameterList name="boundary concentration">
-               <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="0.0"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-       </ParameterList>
+      <ParameterList name="source terms">
+        <ParameterList name="mass rate">
+          <ParameterList name="SRC 0">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-       <ParameterList name="source terms">
-         <ParameterList name="mass rate">
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+          <Parameter name="manifolds" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
+              <Parameter name="manifolds" type="bool" value="true"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="manifolds" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="manifolds" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-           <ParameterList name="SRC 0">
-             <Parameter name="regions" type="Array(string)" value="{All}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <Parameter name="name" type="string" value="SH4"/>
-             <ParameterList name="injector">
-               <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="4"/>
-                 <Parameter name="formula" type="string" value="0.0"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="extreme"/>
+      </ParameterList>
 
-           <ParameterList name="SRC 1">
-             <Parameter name="regions" type="Array(string)" value="{All}"/>
-             <Parameter name="spatial distribution method" type="string" value="none"/>
-             <Parameter name="name" type="string" value="water"/>
-             <ParameterList name="injector">
-               <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="4"/>
-                 <Parameter name="formula" type="string" value="0.0"/>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
+    </ParameterList>
 
-         </ParameterList>
-       </ParameterList>
+  </ParameterList>
 
-       <ParameterList name="operators">
-         <ParameterList name="advection operator">
-           <Parameter name="discretization primary" type="string" value="upwind"/>
-           <Parameter name="reconstruction order" type="int" value="0"/>
-           <Parameter name="manifolds" type="bool" value="true"/>
-         </ParameterList>
-         <ParameterList name="diffusion operator">
-           <ParameterList name="upwind">
-             <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-             <ParameterList name="upwind parameters">
-                <Parameter name="tolerance" type="double" value="1e-12"/>
-                <Parameter name="manifolds" type="bool" value="true"/>
-             </ParameterList>
-           </ParameterList>
-           <ParameterList name="matrix">
-             <Parameter name="discretization primary" type="string" value="fv: default"/>
-             <Parameter name="discretization secondary" type="string" value="fv: default"/>
-             <Parameter name="schema" type="Array(string)" value="{cell}"/>
-             <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-             <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-             <Parameter name="gravity" type="bool" value="false"/>
-             <Parameter name="manifolds" type="bool" value="true"/>
-           </ParameterList>
-         </ParameterList>
-         <ParameterList name="molecular diffusion operator">
-           <ParameterList name="matrix">
-             <Parameter name="discretization primary" type="string" value="fv: default"/>
-             <Parameter name="discretization secondary" type="string" value="fv: default"/>
-             <Parameter name="schema" type="Array(string)" value="{cell}"/>
-             <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-             <Parameter name="nonlinear coefficient" type="string" value="none"/>
-             <Parameter name="gravity" type="bool" value="false"/>
-             <Parameter name="manifolds" type="bool" value="true"/>
-           </ParameterList>
-         </ParameterList>
-       </ParameterList>
-       <ParameterList name="verbose object">
-         <Parameter name="verbosity level" type="string" value="extreme"/>
-       </ParameterList>
-     </ParameterList>
-     </ParameterList>  <!-- PKs, no shift -->
+  <!-- PKs, no shift -->
+  <ParameterList name="state">
+    <ParameterList name="initial conditions">
 
-     <ParameterList name="state">
-       <ParameterList name="initial conditions">
-         <ParameterList name="gravity">
-           <Parameter name="value" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-         </ParameterList>
-         <ParameterList name="atmospheric_pressure">
-           <Parameter name="value" type="double" value="101325.0"/>
-         </ParameterList>
+      <ParameterList name="gravity">
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+      </ParameterList>
 
-         <ParameterList name="pressure_liquid">
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="1.0e+6"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <ParameterList name="atmospheric_pressure">
+        <Parameter name="value" type="double" value="101325.0"/>
+      </ParameterList>
 
-         <ParameterList name="saturation_liquid">
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="1.0"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <ParameterList name="pressure_liquid">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="molar_density_liquid">
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="1.0e-100"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-         <ParameterList name="mass_density_liquid">
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="998.2"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <ParameterList name="saturation_liquid">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="permeability">
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-                 <ParameterList name="function">
-                   <Parameter name="number of dofs" type="int" value="3"/>
-                   <Parameter name="function type" type="string" value="composite function"/>
-                   <ParameterList name="dof 1 function">
-                     <ParameterList name="function-constant">
-                       <Parameter name="value" type="double" value="5.0e-20"/>
-                     </ParameterList>
-                   </ParameterList>
-                   <ParameterList name="dof 2 function">
-                     <ParameterList name="function-constant">
-                       <Parameter name="value" type="double" value="5.0e-20"/>
-                     </ParameterList>
-                   </ParameterList>
-                   <ParameterList name="dof 3 function">
-                     <ParameterList name="function-constant">
-                       <Parameter name="value" type="double" value="5.0e-20"/>
-                     </ParameterList>
-                   </ParameterList>
-                 </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-       </ParameterList>
+      <ParameterList name="molar_density_liquid">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e-100"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-       <ParameterList name="evaluators">
-         <ParameterList name="temperature">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="303"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
+      <ParameterList name="mass_density_liquid">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="998.2"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="ncp_g">
-           <Parameter name="evaluator type" type="string" value="ncp henry law"/>
-           <Parameter name="tag" type="string" value=""/>
-           <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
-           <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
-           <Parameter name="temperature key" type="string" value="temperature"/>
-         </ParameterList>
+      <ParameterList name="permeability">
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="3"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+              <ParameterList name="dof 3 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
 
-         <ParameterList name="total_water_storage">
-           <Parameter name="evaluator type" type="string" value="product"/>
-           <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                        porosity,
-                                                                        saturation_liquid }"/>
-           <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-
-         <ParameterList name="total_component_storage">
-           <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
-           <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
-           <Parameter name="porosity key" type="string" value="porosity"/>
-           <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
-           <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-
-         <!-- ADVECTION -->
-         <ParameterList name="advection_water">
-           <Parameter name="evaluator type" type="string" value="product"/>
-           <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                        rel_permeability_liquid,
-                                                                        viscosity_liquid }"/>
-           <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-         <ParameterList name="advection_liquid">
-           <Parameter name="evaluator type" type="string" value="product"/>
-           <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                        rel_permeability_liquid,
-                                                                        viscosity_liquid }"/>
-           <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-         <ParameterList name="advection_gas">
-           <Parameter name="evaluator type" type="string" value="product"/>
-           <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                        rel_permeability_gas,
-                                                                        viscosity_gas }"/>
-           <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-
-         <!-- DIFFUSION -->
-         <ParameterList name="diffusion_liquid">
-           <Parameter name="evaluator type" type="string" value="product"/>
-           <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                        porosity,
-                                                                        saturation_liquid }"/>
-           <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
-           <Parameter name="tag" type="string" value=""/>
-         </ParameterList>
-
-         <ParameterList name="porosity">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="domain">
-               <Parameter name="region" type="string" value="All"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="0.15"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-
-         <ParameterList name="viscosity_liquid">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="All">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="1.0e-3"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-
-         <ParameterList name="viscosity_gas">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="domain">
-               <Parameter name="regions" type="Array(string)" value="{All}"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="9.0e-6"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-
-         <ParameterList name="molar_density_water">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="domain">
-               <Parameter name="region" type="string" value="All"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="100000"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-         <ParameterList name="molar_density_gas">
-           <Parameter name="evaluator type" type="string" value="eos"/>
-           <Parameter name="eos basis" type="string" value="both"/>
-           <Parameter name="molar density key" type="string" value="molar_density_gas"/>
-           <Parameter name="mass density key" type="string" value="mass_density_gas"/>
-           <Parameter name="pressure key" type="string" value="pressure_gas"/>
-           <ParameterList name="EOS parameters">
-             <Parameter name="eos type" type="string" value="ideal gas"/>
-             <Parameter name="molar mass" type="double" value="2.0e-3"/>
-             <Parameter name="density" type="double" value="1.0"/>
-           </ParameterList>
-           <!--ParameterList name="verbose object">
+    </ParameterList>
+    <ParameterList name="evaluators">
+      <ParameterList name="temperature">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="303.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="ncp_g">
+        <Parameter name="evaluator type" type="string" value="ncp henry law"/>
+        <Parameter name="tag" type="string" value=""/>
+        <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
+        <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
+        <Parameter name="temperature key" type="string" value="temperature"/>
+      </ParameterList>
+      <ParameterList name="total_water_storage">
+        <Parameter name="evaluator type" type="string" value="product"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <ParameterList name="total_component_storage">
+        <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
+        <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
+        <Parameter name="porosity key" type="string" value="porosity"/>
+        <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
+        <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <!-- ADVECTION -->
+      <ParameterList name="advection_water">
+        <Parameter name="evaluator type" type="string" value="product"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <ParameterList name="advection_liquid">
+        <Parameter name="evaluator type" type="string" value="product"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <ParameterList name="advection_gas">
+        <Parameter name="evaluator type" type="string" value="product"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <!-- DIFFUSION -->
+      <ParameterList name="diffusion_liquid">
+        <Parameter name="evaluator type" type="string" value="product"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
+        <Parameter name="tag" type="string" value=""/>
+      </ParameterList>
+      <ParameterList name="porosity">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.15"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="viscosity_liquid">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="All">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0010"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="viscosity_gas">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0000090"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="molar_density_water">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="100000.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="molar_density_gas">
+        <Parameter name="evaluator type" type="string" value="eos"/>
+        <Parameter name="eos basis" type="string" value="both"/>
+        <Parameter name="molar density key" type="string" value="molar_density_gas"/>
+        <Parameter name="mass density key" type="string" value="mass_density_gas"/>
+        <Parameter name="pressure key" type="string" value="pressure_gas"/>
+        <ParameterList name="EOS parameters">
+          <Parameter name="eos type" type="string" value="ideal gas"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
+          <Parameter name="density" type="double" value="1.0"/>
+        </ParameterList>
+        <!--ParameterList name="verbose object">
              <Parameter name="verbosity level" type="string" value="extreme"/>
            </ParameterList-->
-         </ParameterList>
-
-         <ParameterList name="molecular_diff_liquid">
-           <Parameter name="evaluator type" type="string" value="independent variable"/>
-           <ParameterList name="function">
-             <ParameterList name="domain">
-               <Parameter name="region" type="string" value="All"/>
-               <Parameter name="component" type="string" value="cell"/>
-               <ParameterList name="function">
-                 <ParameterList name="function-constant">
-                   <Parameter name="value" type="double" value="3.0e-9"/>
-                 </ParameterList>
-               </ParameterList>
-             </ParameterList>
-           </ParameterList>
-         </ParameterList>
-       </ParameterList>
-
-       <ParameterList name="mesh partitions">
-         <ParameterList name="materials">
-           <Parameter name="region list" type="Array(string)" value="{All}"/>
-         </ParameterList>
-       </ParameterList>
-
-       <ParameterList name="verbose object">
-         <Parameter name="verbosity level" type="string" value="extreme"/>
-       </ParameterList>
-     </ParameterList>
-     
-     <ParameterList name="cycle driver">
-       <ParameterList name="time periods">
-         <ParameterList name="TP 0">
-           <ParameterList name="PK tree">
-             <ParameterList name="multiphase">
-               <Parameter name="PK type" type="string" value="multiphase"/>
-             </ParameterList>
-           </ParameterList>
-           <Parameter name="start period time" type="double" value="0.0"/>
-           <Parameter name="end period time" type="double" value="3.14e+13"/>
-           <Parameter name="initial timestep" type="double" value="1.57e+6"/>
-           <Parameter name="maximum timestep" type="double" value="1.57e+11"/>
-           <Parameter name="maximum cycle number" type="int" value="200"/>
-         </ParameterList>
-       </ParameterList>
-       <ParameterList name="time period control">
-         <Parameter name="start times" type="Array(double)" value="{}"/>
-         <Parameter name="initial timestep" type="Array(double)" value="{}"/>
-         <Parameter name="maximum timestep" type="Array(double)" value="{}"/>
-       </ParameterList>
-       <ParameterList name="verbose object">
-         <Parameter name="verbosity level" type="string" value="extreme"/>
-       </ParameterList>
-     </ParameterList>
-
+      </ParameterList>
+      <ParameterList name="molecular_diff_liquid">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
+          <ParameterList name="domain">
+            <Parameter name="region" type="string" value="All"/>
+            <Parameter name="component" type="string" value="cell"/>
+            <ParameterList name="function">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="3.0e-9"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="mesh partitions">
+      <ParameterList name="materials">
+        <Parameter name="region list" type="Array(string)" value="{All}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="verbose object">
+      <Parameter name="verbosity level" type="string" value="extreme"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="cycle driver">
+    <ParameterList name="time periods">
+      <ParameterList name="TP 0">
+        <ParameterList name="PK tree">
+          <ParameterList name="multiphase">
+            <Parameter name="PK type" type="string" value="multiphase"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="3.14e+13"/>
+        <Parameter name="initial timestep" type="double" value="1.57e+6"/>
+        <Parameter name="maximum timestep" type="double" value="1.57e+11"/>
+        <Parameter name="maximum cycle number" type="int" value="200"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="time period control">
+      <Parameter name="start times" type="Array(double)" value="{}"/>
+      <Parameter name="initial timestep" type="Array(double)" value="{}"/>
+      <Parameter name="maximum timestep" type="Array(double)" value="{}"/>
+    </ParameterList>
+    <ParameterList name="verbose object">
+      <Parameter name="verbosity level" type="string" value="extreme"/>
+    </ParameterList>
+  </ParameterList>
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -700,7 +660,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="ILU">
@@ -711,7 +670,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <!--
     <ParameterList name="SysTG">
       <Parameter name="preconditioning method" type="string" value="systg"/>
@@ -747,9 +705,7 @@
     </ParameterList>
     -->
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_multiphase_thermal.xml
+++ b/src/mpc/test/mpc_multiphase_thermal.xml
@@ -3,32 +3,30 @@
     <Parameter name="file name base" type="string" value="plot"/>
     <Parameter name="times start period stop" type="Array(double)" value="{0, 1.57e+11, -1}"/>
   </ParameterList-->
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Outflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 200.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{200.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="FirstCell">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{4.0,20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{4.0, 20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -41,17 +39,16 @@
       <Parameter name="region" type="string" value="FirstCell"/>
       <Parameter name="functional" type="string" value="observation data: point"/>
       <Parameter name="variable" type="string" value="temperature"/>
-      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}" />
+      <Parameter name="cycles start period stop" type="Array(int)" value="{1, 1, -1}"/>
       <!--Parameter name="times start period stop" type="Array(double)" value="{0, 1.57e+11, -1}"/-->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{50, 4, 4}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0,20.0,20.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0, 20.0, 20.0}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -62,27 +59,20 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
+    <!-- no shift -->
     <ParameterList name="multiphase">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="special pc term" type="bool" value="false"/>
-    
       <ParameterList name="physical models and assumptions">
       </ParameterList>
-    
-      <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                                 total_water_storage,
-                                                                 total_component_storage,
-                                                                 advection_water,
-                                                                 advection_liquid,
-                                                                 advection_gas,
-                                                                 diffusion_liquid }"/>
+
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
       <ParameterList name="system">
         <ParameterList name="pressure eqn">
           <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
           <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
           <ParameterList name="terms">
             <ParameterList name="advection">
               <Parameter name="coefficient" type="string" value="advection_water"/>
@@ -98,11 +88,9 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="solute eqn">
           <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
           <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
           <ParameterList name="terms">
             <ParameterList name="advection 0">
               <Parameter name="coefficient" type="string" value="advection_liquid"/>
@@ -124,11 +112,9 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="energy eqn">
           <Parameter name="primary unknown" type="string" value="temperature"/>
           <Parameter name="accumulation" type="string" value="energy"/>
-
           <ParameterList name="terms">
             <!--Parameter name="advection liquid" type="Array(string)" value="{ advection_energy_liquid, pressure_liquid }"/-->
             <!--Parameter name="advection gas" type="Array(string)" value="{ advection_energy_gas, pressure_gas }"/-->
@@ -140,10 +126,9 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="constraint eqn">
           <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-          <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
         </ParameterList>
       </ParameterList>
 
@@ -153,17 +138,15 @@
       <Parameter name="error control options" type="Array(string)" value="{residual}"/>
       <Parameter name="number aqueous components" type="int" value="1"/>
       <Parameter name="number gaseous components" type="int" value="0"/>
-
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
         <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-        <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
       </ParameterList>
 
-      <Parameter name="molar mass of water" type="double" value="1.0e-2"/>
-
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
       <Parameter name="CPR enhancement" type="bool" value="false"/>
       <ParameterList name="CPR parameters">
         <Parameter name="global solve" type="bool" value="true"/>
@@ -216,12 +199,11 @@
             <Parameter name="max timestep" type="double" value="6.0e+10"/>
             <Parameter name="min timestep" type="double" value="1.0e-20"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="Newton"/>
           <ParameterList name="Newton parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
             <Parameter name="max divergent iterations" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -230,9 +212,8 @@
             <Parameter name="make one iteration" type="bool" value="true"/>
             <ParameterList name="verbose object">
               <Parameter name="verbosity level" type="string" value="high"/>
-            </ParameterList>                        
+            </ParameterList>
           </ParameterList>
-          
           <ParameterList name="verbose object">
             <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
@@ -246,7 +227,7 @@
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e6"/>
+                <Parameter name="value" type="double" value="1.0e+6"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -285,7 +266,6 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="concentration">
           <ParameterList name="BC 5">
             <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
@@ -298,7 +278,6 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="temperature">
           <ParameterList name="BC 6">
             <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
@@ -330,7 +309,7 @@
           <ParameterList name="upwind">
             <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
             <ParameterList name="upwind parameters">
-               <Parameter name="tolerance" type="double" value="1e-12"/>
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
           <ParameterList name="matrix">
@@ -353,20 +332,27 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
-    </ParameterList>
-  </ParameterList>  <!-- PKs, no shift -->
 
+    </ParameterList>
+
+  </ParameterList>
+
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -454,8 +440,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -465,13 +451,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="303"/>
+                <Parameter name="value" type="double" value="303.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -479,16 +464,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -497,43 +478,32 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -548,7 +518,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -557,13 +526,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -572,13 +540,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -587,13 +554,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="100000"/>
+                <Parameter name="value" type="double" value="100000.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -608,7 +574,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -617,11 +582,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_fraction_gas">
         <Parameter name="evaluator type" type="string" value="molar fraction gas"/>
         <Parameter name="molar fraction key" type="string" value="molar_fraction_gas"/>
@@ -629,7 +593,6 @@
           <Parameter name="eos type" type="string" value="water vapor over water/ice"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -644,7 +607,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <!-- ENERGY -->
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
@@ -661,12 +623,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_gas">
         <Parameter name="evaluator type" type="string" value="iem water vapor"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_gas"/>
       </ParameterList>
-
       <ParameterList name="internal_energy_rock">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_rock"/>
@@ -682,7 +642,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -691,25 +650,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-     
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -736,7 +692,6 @@
     <Parameter name="initial timestep" type="Array(double)" value="{}"/>
     <Parameter name="io frequency" type="int" value="10"/>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -755,7 +710,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="ILU">
@@ -767,9 +721,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/mpc/test/mpc_pressure.xml
+++ b/src/mpc/test/mpc_pressure.xml
@@ -1,41 +1,40 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Well">
       <ParameterList name="region: point">
-        <Parameter name="coordinate" type="Array(double)" value="{0.5,0.5}"/>
+        <Parameter name="coordinate" type="Array(double)" value="{0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -43,9 +42,9 @@
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
-          <Parameter name="number of cells" type="Array(int)" value="{5, 5}"/>
-          <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
-          <Parameter name="domain high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="number of cells" type="Array(int)" value="{5, 5}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -56,18 +55,17 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
-    <Parameter name="end time" type="double" value="2"/>
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="end time" type="double" value="2.0"/>
     <ParameterList name="time intervals">
       <ParameterList name="TI 0">
         <Parameter name="physical model" type="string" value="PK tree"/>
-        <Parameter name="initial timestep" type="double" value="1.00000000000000000e+00"/>
-        <Parameter name="maximal timestep" type="double" value="1.00000000000000000e+07"/>
-        <Parameter name="start interval time" type="double" value="0.00000000000000000e+00"/>
-        <Parameter name="end interval time" type="double" value="2.00000000000000000e+00"/>
-<!--
+        <Parameter name="initial timestep" type="double" value="1.00000000000000000"/>
+        <Parameter name="maximal timestep" type="double" value="10000000.0000000000"/>
+        <Parameter name="start interval time" type="double" value="0e-17"/>
+        <Parameter name="end interval time" type="double" value="2.00000000000000000"/>
+        <!--
   <Parameter name="time integration method" type="string" value="BDF1"/>
   <ParameterList name="BDF1">
     <Parameter name="timestep controller type" type="string" value="standard"/>
@@ -99,30 +97,34 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree">
     <ParameterList name="Pressure PK">
       <Parameter name="PK type" type="string" value="Pressure PK"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.00000000000000000e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0e-17, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="water_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="water_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
+
       <ParameterList name="oil_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="oil_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -130,12 +132,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                <Parameter name="value" type="double" value="0e-17"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -143,47 +146,52 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                <Parameter name="value" type="double" value="0e-17"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="1.99759999999999989e-12"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="1.99759999999999999e-13"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.99759999999999989e-12"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.99759999999999999e-13"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList> <!-- End initial conditions -->
 
+    </ParameterList>
+    <!-- End initial conditions -->
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList> <!-- End State -->
-
+  </ParameterList>
+  <!-- End State -->
   <ParameterList name="PKs">
+
     <ParameterList name="Pressure PK">
       <Parameter name="PK type" type="string" value="Pressure PK"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  FLOW  -->
@@ -191,11 +199,9 @@
     <ParameterList name="Pressure Problem">
       <Parameter name="atmospheric pressure" type="double" value="0.0"/>
       <Parameter name="relative permeability" type="string" value="upwind with gravity"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
-
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -214,7 +220,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 1">
@@ -227,7 +232,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="source terms">
         <ParameterList name="SRC 0">
           <Parameter name="regions" type="Array(string)" value="{Well}"/>
@@ -239,18 +243,16 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="Water retention models">
         <ParameterList name="Water retention model for the whole domain">
           <Parameter name="water retention model" type="string" value="Simple"/>
           <Parameter name="region" type="string" value="All"/>
-          <Parameter name="residual saturation wet" type="double" value="0.00000000000000000e+00"/>
-          <Parameter name="residual saturation nonwet" type="double" value="0.00000000000000000e+00"/>
+          <Parameter name="residual saturation wet" type="double" value="0e-17"/>
+          <Parameter name="residual saturation nonwet" type="double" value="0e-17"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -261,7 +263,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -276,5 +277,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>

--- a/src/mpc/test/mpc_reactive_transport.xml
+++ b/src/mpc/test/mpc_reactive_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_rt"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 1, -1}"/>
@@ -8,38 +7,37 @@
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_rt"/>
     <Parameter name="file name digits" type="int" value="5"/>
-    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}" />
-  </ParameterList>  
-
+    <Parameter name="cycles start period stop" type="Array(int)" value="{0, 1, -1}"/>
+  </ParameterList>
   <ParameterList name="regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+00, 1.0e+00, 1.0e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0e+00, 1.0e+00, 1.0e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0e+00, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+00, 1.0e+00, 1.00e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.00000000000000000e-01, 1.0e+00, 1.0e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.500000000000000000, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{5.00e-01, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0e+00, 1.0e+00, 1.0e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.500, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
@@ -49,12 +47,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{100, 1, 1}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0e+00, 0.0e+00, 0.0e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.0e+00, 1.0e+00, 1.0e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -65,37 +64,38 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
+    <Parameter name="start time" type="double" value="0.0"/>
     <Parameter name="end time" type="double" value="10000000.0"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<Parameter name="physical model" type="string" value="PK tree"/>
-	<Parameter name="start period time" type="double" value="0.0e+00"/>
-	<Parameter name="end period time" type="double" value="200.0"/>
+        <Parameter name="physical model" type="string" value="PK tree"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="200.0"/>
         <ParameterList name="PK tree">
           <ParameterList name="reactive transport">
             <Parameter name="PK type" type="string" value="reactive transport"/>
             <ParameterList name="transport">
-	      <Parameter name="PK type" type="string" value="transport"/>
+              <Parameter name="PK type" type="string" value="transport"/>
             </ParameterList>
             <ParameterList name="chemistry">
-	      <Parameter name="PK type" type="string" value="chemistry amanzi"/>
+              <Parameter name="PK type" type="string" value="chemistry amanzi"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{Na+, Ca++, Mg++, Cl-}"/>
-    <Parameter name="component molar masses" type="Array(double)" value="{23.0e-3, 40.0e-3, 24.3e-3, 35.5e-3}"/>
+    <Parameter name="component molar masses" type="Array(double)" value="{0.0230, 0.0400, 0.0243, 0.0355}"/>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="reactive transport">
-      <Parameter name="PK type" type="string" value="reactive transport"/>      
-      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/> 
+      <Parameter name="PK type" type="string" value="reactive transport"/>
+      <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/>
+
     </ParameterList>
+
     <ParameterList name="chemistry">
       <Parameter name="PK type" type="string" value="chemistry pk"/>
       <Parameter name="component names" type="Array(string)" value="{Na+, Ca++, Mg++, Cl-}"/>
@@ -104,120 +104,131 @@
       <Parameter name="maximum Newton iterations" type="int" value="50"/>
       <Parameter name="log formulation" type="bool" value="true"/>
       <ParameterList name="initial conditions">
-	<ParameterList name="mineral_volume_fractions">
+
+        <ParameterList name="mineral_volume_fractions">
           <Parameter name="function" type="string" value="list was moved to state"/>
-	</ParameterList>
-	<ParameterList name="mineral_specific_surface_area">
+        </ParameterList>
+
+        <ParameterList name="mineral_specific_surface_area">
           <Parameter name="function" type="string" value="list was moved to state"/>
-	</ParameterList>
-	<ParameterList name="ion_exchange_sites">
+        </ParameterList>
+
+        <ParameterList name="ion_exchange_sites">
           <Parameter name="function" type="string" value="list was moved to state"/>
-	</ParameterList>
-	<ParameterList name="ion_exchange_ref_cation_conc">
+        </ParameterList>
+
+        <ParameterList name="ion_exchange_ref_cation_conc">
           <Parameter name="function" type="string" value="list was moved to state"/>
-	</ParameterList>
-	<ParameterList name="free_ion_species">
+        </ParameterList>
+
+        <ParameterList name="free_ion_species">
           <Parameter name="function" type="string" value="list was moved to state"/>
-	</ParameterList>
+        </ParameterList>
+
       </ParameterList>
+
       <Parameter name="minerals" type="Array(string)" value="{Halite}"/>
       <Parameter name="number of component concentrations" type="int" value="4"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transport">
       <Parameter name="PK type" type="string" value="transport pk"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <Parameter name="cfl" type="double" value="1.0e+00"/>
+      <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="advection limiter" type="string" value="Tensorial"/>
       <Parameter name="solver" type="string" value="PCG with Hypre AMG"/>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
+
+      <Parameter name="enable internal tests" type="bool" value="true"/>
       <ParameterList name="molecular diffusion">
-	<Parameter name="aqueous names" type="Array(string)" value="{}"/>
-	<Parameter name="aqueous values" type="Array(double)" value="{}"/>
+        <Parameter name="aqueous names" type="Array(string)" value="{}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{}"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Na+">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Na+">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{9.42676899999999977e-03, 9.42676899999999977e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Ca++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00942676899999999977, 0.00942676899999999977}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Ca++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{5.01423899999999955e-04, 5.01423899999999955e-04}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Mg++">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.000501423899999999955, 0.000501423899999999955}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Mg++">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{2.13606599999999983e-03, 2.13606599999999983e-03}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Cl-">
-	    <ParameterList name="West BC">
-	      <Parameter name="regions" type="Array(string)" value="{West}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.00213606599999999983, 0.00213606599999999983}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Cl-">
+            <ParameterList name="West BC">
+              <Parameter name="regions" type="Array(string)" value="{West}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="y values" type="Array(double)" value="{1.47017488000000009e-02, 1.47017488000000009e-02}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="y values" type="Array(double)" value="{0.0147017488000000009, 0.0147017488000000009}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="4"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <Parameter name="runtime diagnostics: regions" type="Array(string)" value="{}"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
-
     <ParameterList name="evaluators" type="ParameterList">
-
       <ParameterList name="porosity">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="Soil_1">
             <Parameter name="regions" type="Array(string)" value="{Soil_1}"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -226,30 +237,28 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
       <ParameterList name="mass_density_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="Entire DomainSoil_1Soil_2">
             <Parameter name="regions" type="Array(string)" value="{Entire Domain, Soil_1, Soil_2}"/>
@@ -262,19 +271,21 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0e+00, 0.0e+00, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00200000000000007e-03"/>
+        <Parameter name="value" type="double" value="0.00100200000000000007"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -295,18 +306,19 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.00000000000000000e+00"/>
+                  <Parameter name="value" type="double" value="0e-17"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.86340000000000002e-06"/>
+                  <Parameter name="value" type="double" value="0.00000186340000000000002"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -357,6 +369,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="Entire DomainSoil_1Soil_2">
@@ -364,12 +377,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325000000000000e+05"/>
+                <Parameter name="value" type="double" value="201325.000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -380,7 +394,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000005e-04"/>
+                  <Parameter name="value" type="double" value="0.000100000000000000005"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -393,13 +407,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000000000000010e-04"/>
+                  <Parameter name="value" type="double" value="0.000200000000000000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -410,7 +425,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -423,13 +438,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000e+00"/>
+                  <Parameter name="value" type="double" value="2.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -440,7 +456,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000005e-04"/>
+                  <Parameter name="value" type="double" value="0.000100000000000000005"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -453,13 +469,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000000000000010e-04"/>
+                  <Parameter name="value" type="double" value="0.000200000000000000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_sites">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -470,7 +487,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="7.50000e+02"/>
+                  <Parameter name="value" type="double" value="750.000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -483,13 +500,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.50000e+02"/>
+                  <Parameter name="value" type="double" value="250.000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="ion_exchange_ref_cation_conc">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
@@ -500,7 +518,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -513,13 +531,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000e+00"/>
+                  <Parameter name="value" type="double" value="1.00000"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="free_ion_species">
         <ParameterList name="function">
           <ParameterList name="Entire Domain">
@@ -530,22 +549,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                 <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -558,22 +577,22 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -586,28 +605,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
-	          </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <Parameter name="names" type="Array(string)" value="{total, total, total, total}"/>
         <ParameterList name="function">
@@ -619,28 +639,29 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="8.67463299999999965e-02"/>
+                  <Parameter name="value" type="double" value="0.0867463299999999965"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.82518300000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0182518300000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.11316100000000001e-02"/>
+                  <Parameter name="value" type="double" value="0.0111316100000000001"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.45513210000000004e-01"/>
+                  <Parameter name="value" type="double" value="0.145513210000000004"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -648,54 +669,53 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="flow">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
     <ParameterList name="operators">
       <ParameterList name="diffusion operator">
-	<ParameterList name="matrix">
-	  <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	  <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	  <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	  <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	  <Parameter name="gravity" type="bool" value="true"/>
-	</ParameterList>
-	<ParameterList name="preconditioner">
-	  <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	  <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	  <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	  <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	  <Parameter name="gravity" type="bool" value="true"/>
-	</ParameterList>
+        <ParameterList name="matrix">
+          <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+          <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+          <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+          <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+          <Parameter name="gravity" type="bool" value="true"/>
+        </ParameterList>
+        <ParameterList name="preconditioner">
+          <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+          <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+          <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+          <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+          <Parameter name="gravity" type="bool" value="true"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
     <ParameterList name="boundary conditions">
       <ParameterList name="mass flux">
-	<ParameterList name="BC 0">
-	  <Parameter name="regions" type="Array(string)" value="{West}"/>
-	  <Parameter name="rainfall" type="bool" value="false"/>
-	  <ParameterList name="outward mass flux">
-	    <ParameterList name="function-tabular">
-	      <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-	      <Parameter name="y values" type="Array(double)" value="{-7.91317859000000037e-06, -1.31785899999999989e+00}"/>
-	      <Parameter name="forms" type="Array(string)" value="{constant}"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="BC 0">
+          <Parameter name="regions" type="Array(string)" value="{West}"/>
+          <Parameter name="rainfall" type="bool" value="false"/>
+          <ParameterList name="outward mass flux">
+            <ParameterList name="function-tabular">
+              <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+              <Parameter name="y values" type="Array(double)" value="{-0.00000791317859000000037, -1.31785899999999989}"/>
+              <Parameter name="forms" type="Array(string)" value="{constant}"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
       <ParameterList name="pressure">
-	<ParameterList name="BC 1">
-	  <Parameter name="regions" type="Array(string)" value="{East}"/>
-	  <ParameterList name="boundary pressure">
-	    <ParameterList name="function-tabular">
-	      <Parameter name="x values" type="Array(double)" value="{0.0e+00, 3.15360000000000000e+07}"/>
-	      <Parameter name="y values" type="Array(double)" value="{2.01325000000000000e+05, 2.01325000000000000e+05}"/>
-	      <Parameter name="forms" type="Array(string)" value="{constant}"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="BC 1">
+          <Parameter name="regions" type="Array(string)" value="{East}"/>
+          <ParameterList name="boundary pressure">
+            <ParameterList name="function-tabular">
+              <Parameter name="x values" type="Array(double)" value="{0.0, 31536000.0000000000}"/>
+              <Parameter name="y values" type="Array(double)" value="{201325.000000000000, 201325.000000000000}"/>
+              <Parameter name="forms" type="Array(string)" value="{constant}"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
     <ParameterList name="transient time integrator">
@@ -703,49 +723,48 @@
       <Parameter name="linear solver" type="string" value="AztecOO"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <ParameterList name="dae constraint">
-	<Parameter name="method" type="string" value="projection"/>
-	<Parameter name="inflow krel correction" type="bool" value="true"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="method" type="string" value="projection"/>
+        <Parameter name="inflow krel correction" type="bool" value="true"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
       </ParameterList>
       <Parameter name="time integration method" type="string" value="BDF1"/>
       <ParameterList name="BDF1">
-	<Parameter name="timestep controller type" type="string" value="standard"/>
-	<ParameterList name="timestep controller standard parameters">
-	  <Parameter name="max iterations" type="int" value="15"/>
-	  <Parameter name="min iterations" type="int" value="10"/>
-	  <Parameter name="timestep increase factor" type="double" value="1.25000000000000000e+00"/>
-	  <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-	  <Parameter name="max timestep" type="double" value="6.00000000000000000e+10"/>
-	  <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
-	</ParameterList>
-	<Parameter name="solver type" type="string" value="nka"/>
-	<ParameterList name="nka parameters">
-	  <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999945e-21"/>
-	  <Parameter name="diverged tolerance" type="double" value="1.00000000000000000e+10"/>
-	  <Parameter name="max du growth factor" type="double" value="1.00000000000000000e+03"/>
-	  <Parameter name="max divergent iterations" type="int" value="3"/>
-	  <Parameter name="max nka vectors" type="int" value="10"/>
-	  <Parameter name="limit iterations" type="int" value="20"/>
-	  <Parameter name="modify correction" type="bool" value="false"/>
-	</ParameterList>
-	<Parameter name="max preconditioner lag iterations" type="int" value="4"/>
-	<Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	<Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	<Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-	<Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
+        <Parameter name="timestep controller type" type="string" value="standard"/>
+        <ParameterList name="timestep controller standard parameters">
+          <Parameter name="max iterations" type="int" value="15"/>
+          <Parameter name="min iterations" type="int" value="10"/>
+          <Parameter name="timestep increase factor" type="double" value="1.25000000000000000"/>
+          <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+          <Parameter name="max timestep" type="double" value="60000000000.0000000"/>
+          <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
+        </ParameterList>
+        <Parameter name="solver type" type="string" value="nka"/>
+        <ParameterList name="nka parameters">
+          <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999945e-21"/>
+          <Parameter name="diverged tolerance" type="double" value="10000000000.0000000"/>
+          <Parameter name="max du growth factor" type="double" value="1000.00000000000000"/>
+          <Parameter name="max divergent iterations" type="int" value="3"/>
+          <Parameter name="max nka vectors" type="int" value="10"/>
+          <Parameter name="limit iterations" type="int" value="20"/>
+          <Parameter name="modify correction" type="bool" value="false"/>
+        </ParameterList>
+        <Parameter name="max preconditioner lag iterations" type="int" value="4"/>
+        <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
       </ParameterList>
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
         <Parameter name="strong threshold" type="double" value="0.5"/>
@@ -760,16 +779,15 @@
       <Parameter name="preconditioning method" type="string" value="block ilu"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="block ilu parameters">
-        <Parameter name="fact: relax value" type="double" value="1.0e+00"/>
-        <Parameter name="fact: absolute threshold" type="double" value="0.0e+00"/>
-        <Parameter name="fact: relative threshold" type="double" value="1.0e+00"/>
+        <Parameter name="fact: relax value" type="double" value="1.0"/>
+        <Parameter name="fact: absolute threshold" type="double" value="0.0"/>
+        <Parameter name="fact: relative threshold" type="double" value="1.0"/>
         <Parameter name="fact: level-of-fill" type="int" value="0"/>
         <Parameter name="overlap" type="int" value="0"/>
         <Parameter name="schwarz: combine mode" type="string" value="Add"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -792,7 +810,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="Na+">
@@ -801,9 +818,9 @@
         <Parameter name="gram molecular weight" type="double" value="22.99"/>
       </ParameterList>
       <ParameterList name="Ca++">
-        <Parameter name="ion size parameter" type="double" value="6.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="6.00000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="4.00780000000000030e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="40.0780000000000030"/>
       </ParameterList>
       <ParameterList name="Mg++">
         <Parameter name="ion size parameter" type="double" value="8.0"/>
@@ -821,11 +838,11 @@
         <Parameter name="rate model" type="string" value="TST"/>
         <Parameter name="rate constant" type="double" value="-36.0"/>
         <Parameter name="modifiers" type="string" value=""/>
-        <Parameter name="gram molecular weight" type="double" value="5.84425E+01 "/>
+        <Parameter name="gram molecular weight" type="double" value="58.4425"/>
         <Parameter name="reaction" type="string" value="1.0 Na+   1.0 Cl-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.58550E+00"/>
-        <Parameter name="molar volume" type="double" value="2.70150E+01"/>
-        <Parameter name="specific surface area" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="1.58550"/>
+        <Parameter name="molar volume" type="double" value="27.0150"/>
+        <Parameter name="specific surface area" type="double" value="1.00000000000000000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="ion exchange sites">
@@ -837,19 +854,18 @@
     <ParameterList name="ion exchange complexes">
       <ParameterList name="Na+X">
         <Parameter name="reaction" type="string" value="1.0 Na+  1.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="1.00000000000000000"/>
       </ParameterList>
       <ParameterList name="Ca++X">
         <Parameter name="reaction" type="string" value="1.0 Ca++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="2.95300E-01"/>
+        <Parameter name="equilibrium constant" type="double" value="0.295300"/>
       </ParameterList>
       <ParameterList name="Mg++X">
         <Parameter name="reaction" type="string" value="1.0 Mg++  2.0 X-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.66600E-01"/>
+        <Parameter name="equilibrium constant" type="double" value="0.166600"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{West, East, West, East}"/>

--- a/src/mpc/test/mpc_shallow_water.xml
+++ b/src/mpc/test/mpc_shallow_water.xml
@@ -1,6 +1,5 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-  
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -22,14 +21,14 @@
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -37,37 +36,34 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
-    <Parameter name="end time" type="double" value="100"/>
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="end time" type="double" value="100.0"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="shallow water">
-	    <Parameter name="PK type" type="string" value="shallow water"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="0.2"/>
-	<Parameter name="initial timestep" type="double" value="0.01"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="shallow water">
+            <Parameter name="PK type" type="string" value="shallow water"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="0.2"/>
+        <Parameter name="initial timestep" type="double" value="0.01"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{10.0, 20.0, 30.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{0.2, 0.4, 0.6}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{5.0, 25.0, 15.0}"/>		 
+      <Parameter name="maximum timestep" type="Array(double)" value="{5.0, 25.0, 15.0}"/>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -79,12 +75,15 @@
         <Parameter name="limiter location" type="string" value="node"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
+      <ParameterList name="boundary conditions">
+      </ParameterList>
 
-      <ParameterList name="boundary conditions"/>
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -104,8 +103,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -124,7 +123,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -138,7 +138,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -168,8 +169,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="mesh name" type="string" value="surface"/>
@@ -178,7 +179,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-

--- a/src/mpc/test/mpc_thermal_darcy_dfn.xml
+++ b/src/mpc/test/mpc_thermal_darcy_dfn.xml
@@ -1,46 +1,44 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="plot_thermal"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.5,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.5, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -61,7 +59,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -87,7 +84,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -95,7 +91,7 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="ALL">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -111,7 +107,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.4641e-6"/>
+                <Parameter name="value" type="double" value="0.0000034641"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -131,7 +127,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -140,7 +135,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -174,7 +169,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -186,7 +180,6 @@
           <Parameter name="density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="viscosity"/>
         <Parameter name="viscosity key" type="string" value="viscosity_liquid"/>
@@ -196,7 +189,6 @@
           <Parameter name="density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_liquid"/>
@@ -228,23 +220,28 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-3"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -258,6 +255,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -265,23 +263,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9.7935192e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -289,7 +286,7 @@
         <Parameter name="tolerance" type="double" value="0.001"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -297,7 +294,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -320,12 +316,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow and energy">
       <Parameter name="PKs order" type="Array(string)" value="{flow, energy}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
@@ -347,9 +342,9 @@
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="15"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -366,106 +361,113 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="liquid water"/>
+            <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="0.1"/>
             <Parameter name="reference temperature" type="double" value="298.15"/>
-	  </ParameterList>
-	</ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="300.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="310.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="300.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="310.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="fracture permeability models">
         <ParameterList name="FPM for Entire Domain">
           <Parameter name="region" type="string" value="All"/>
@@ -475,68 +477,70 @@
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <ParameterList name="boundary pressure">
-      	      <ParameterList name="function-constant">
-      		<Parameter name="value" type="double" value="101325.0"/>
-      	      </ParameterList>
-      	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	</ParameterList>
-
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
+        </ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="PCG with Hypre AMG"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_thermal_richards.xml
+++ b/src/mpc/test/mpc_thermal_richards.xml
@@ -1,10 +1,8 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_thermal"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -14,48 +12,47 @@
     <Parameter name="file name base" type="string" value="plot_thermal"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 20, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Bottom Surface">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 0.0}"/>
         <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionBottom">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 4.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 40.0}"/>
         <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionMiddle">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 8.0e+01}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 4.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 80.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 40.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RegionTop">
       <ParameterList name="region: box">
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 8.0e+01}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 80.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface West">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{7.20000e+01, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{72.0000, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib-1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{7.20000e+01, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{8.0e+01, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{72.0000, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{80.0, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top Surface East">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{8.0e+01, 1.20000e+02}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{80.0, 120.000}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
@@ -76,7 +73,7 @@
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{54, 60}"/>
         <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{2.16000e+02, 1.20000e+02}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{216.000, 120.000}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -87,7 +84,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
@@ -118,7 +114,6 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
@@ -132,7 +127,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -152,7 +147,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -167,7 +161,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -225,7 +218,6 @@
         <Parameter name="evaluator type" type="string" value="iem water vapor"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_gas"/>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -234,7 +226,8 @@
           <Parameter name="eos type" type="string" value="vapor in gas"/>
           <ParameterList name="EOS parameters">
             <Parameter name="eos type" type="string" value="ideal gas"/>
-            <Parameter name="molar mass" type="double" value="28.9647e-03"/>  <!-- dry air -->
+            <Parameter name="molar mass" type="double" value="0.0289647"/>
+            <!-- dry air -->
             <Parameter name="density" type="double" value="1.0"/>
           </ParameterList>
         </ParameterList>
@@ -247,25 +240,29 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="region" type="string" value="All"/>
-            <Parameter name="components" type="Array(string)" value="{ cell, face }"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="298.0"/>
@@ -274,6 +271,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="RegionMiddle">
@@ -320,7 +318,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0706e-09"/>
+                  <Parameter name="value" type="double" value="2.0706e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -332,6 +330,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -339,14 +338,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+02}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -979.35192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -364,6 +364,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -371,7 +372,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -380,7 +380,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -400,7 +400,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -413,12 +412,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow and energy">
       <Parameter name="PKs order" type="Array(string)" value="{flow, energy}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="true"/>
       </ParameterList>
@@ -440,9 +438,9 @@
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -461,229 +459,240 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="true"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="true"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="thermal conductivity parameters">
+        <ParameterList name="thermal conductivity parameters">
           <ParameterList name="TCM_0">
-	    <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
+            <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
             <Parameter name="thermal conductivity of rock" type="double" value="0.2"/>
             <Parameter name="thermal conductivity of liquid" type="double" value="0.1"/>
             <Parameter name="thermal conductivity of gas" type="double" value="0.02"/>
-	    <Parameter name="unsaturated alpha" type="double" value="1.0"/>
-	    <Parameter name="epsilon" type="double" value="1.e-10"/>
-	    <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="unsaturated alpha" type="double" value="1.0"/>
+            <Parameter name="epsilon" type="double" value="1e-10"/>
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="298.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.1}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: amanzi"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for RegionMiddle">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.94670000000000005e-04"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionBottom">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.13600000000000012e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.02600000000000002e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionTop">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-	  <Parameter name="van Genuchten m" type="double" value="3.00599999999999978e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.06740000000000005e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
+        <ParameterList name="WRM for RegionMiddle">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000194670000000000005"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionBottom">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.213600000000000012"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00202600000000000002"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionTop">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.300599999999999978"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00206740000000000005"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.2"/>
-		<Parameter name="gravity" type="double" value="9.80665"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="0.0"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Crib-1}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.153732e+10, 6.15688776e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10e-07, -2.54022e-03, -1.10e-07}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top Surface West, Top Surface East}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10e-07, -1.10e-07}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.80665"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="0.0"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Crib-1}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.153732e+10, 6.15688776e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10e-7, -0.00254022, -1.10e-7}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top Surface West, Top Surface East}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 9.0e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10e-7, -1.10e-7}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="none"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="none"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_thermal_richards_jacobian.xml
+++ b/src/mpc/test/mpc_thermal_richards_jacobian.xml
@@ -3,17 +3,16 @@
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Bottom Surface">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crib">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.25, 1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.25, 1.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.75, 1.0}"/>
       </ParameterList>
     </ParameterList>
@@ -28,7 +27,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
@@ -42,7 +40,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -62,7 +60,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
@@ -74,7 +71,6 @@
         <Parameter name="eos basis" type="string" value="both"/>
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
       </ParameterList>
-
       <ParameterList name="mass_density_liquids">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -127,34 +123,39 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.9820e+02"/>
+        <Parameter name="value" type="double" value="998.20"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="region" type="string" value="All"/>
-            <Parameter name="components" type="Array(string)" value="{ cell, face }"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-	      <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="3"/>
-                 <Parameter name="formula" type="string" value="338 + 40 * x + 20 * y"/>
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="3"/>
+                <Parameter name="formula" type="string" value="338 + 40 * x + 20 * y"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -177,6 +178,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -184,14 +186,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="2.01325e+06"/>
+                <Parameter name="y0" type="double" value="2.01325e+6"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+04}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -97935.192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -202,13 +205,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.0e+00"/>
+                  <Parameter name="value" type="double" value="0.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -216,7 +220,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -225,7 +228,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -233,7 +236,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -256,24 +258,22 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree">
     <ParameterList name="flow and energy">
       <Parameter name="PK type" type="string" value="thermal flow"/>
       <ParameterList name="flow">
         <Parameter name="PK type" type="string" value="richards"/>
-       </ParameterList>
-       <ParameterList name="energy">
-         <Parameter name="PK type" type="string" value="one-phase energy"/>
-       </ParameterList>
+      </ParameterList>
+      <ParameterList name="energy">
+        <Parameter name="PK type" type="string" value="one-phase energy"/>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow and energy">
       <Parameter name="PKs order" type="Array(string)" value="{flow, energy}"/>
       <Parameter name="master PK index" type="int" value="0"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="vapor diffusion" type="bool" value="false"/>
       </ParameterList>
@@ -295,9 +295,9 @@
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+04"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+4"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -316,230 +316,242 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="energy evaluator">
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="true"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="true"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="2.0"/>
             <Parameter name="reference temperature" type="double" value="273.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
-	    <Parameter name="eos type" type="string" value="constant"/>
+            <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
             <Parameter name="reference temperature" type="double" value="273.15"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="relative permeability"/>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="relative permeability"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Crib}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-exprtk">
+        <ParameterList name="temperature">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Crib}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="3"/>
                 <Parameter name="formula" type="string" value="338 + 10 * x + 20 * y"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-	    <Parameter name="min timestep" type="double" value="1.0e-20"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	</ParameterList>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: amanzi"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for all">
+        <ParameterList name="WRM for all">
           <Parameter name="water retention model" type="string" value="saturated"/>
           <Parameter name="regions" type="Array(string)" value="{All}"/>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="pressure">
           <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="2.01325e+06"/>
+                <Parameter name="y0" type="double" value="2.01325e+6"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+04}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -97935.192}"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Crib}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.153732e+10, 6.15688776e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.10e-07, -2.54022e-03, -1.10e-07}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant, constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Crib}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.153732e+10, 6.15688776e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.10e-7, -0.00254022, -1.10e-7}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant, constant}"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25000e+00"/>
-	    <Parameter name="timestep reduction factor" type="double" value="8.0e-01"/>
-	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-	    <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters"/>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-	</ParameterList>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25000"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.80"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_transport.xml
+++ b/src/mpc/test/mpc_transport.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="checkpoint data">
     <Parameter name="file name base" type="string" value="chk_transport"/>
     <Parameter name="file name digits" type="int" value="5"/>
@@ -10,7 +9,6 @@
     <Parameter name="file name base" type="string" value="plot_transport"/>
     <Parameter name="cycles start period stop 0" type="Array(int)" value="{0, 100, -1}"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -23,7 +21,7 @@
     <ParameterList name="All domain">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-1.0, -1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,  1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -43,41 +41,40 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
-	<Parameter name="framework" type="string" value="MSTK"/>
+        <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
-
       <ParameterList name="read mesh file">
-	<Parameter name="file" type="string" value="test/mpc_transport_mesh.exo"/>
-	<Parameter name="format" type="string" value="Exodus II"/>
+        <Parameter name="file" type="string" value="test/mpc_transport_mesh.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
-    <Parameter name="end time" type="double" value="100"/>
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="end time" type="double" value="100.0"/>
     <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="transport">
-	    <Parameter name="PK type" type="string" value="transport"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="1.00000000000000000e+00"/>
-	<Parameter name="maximal timestep" type="double" value="1.00000000000000000e+07"/>
-	<Parameter name="start period time" type="double" value="0.00000000000000000e+00"/>
-	<Parameter name="end period time" type="double" value="1.00000000000000000e+03"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="transport">
+            <Parameter name="PK type" type="string" value="transport"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="1.00000000000000000"/>
+        <Parameter name="maximal timestep" type="double" value="10000000.0000000000"/>
+        <Parameter name="start period time" type="double" value="0e-17"/>
+        <Parameter name="end period time" type="double" value="1000.00000000000000"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -88,7 +85,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.08200000000000007e-01"/>
+                <Parameter name="value" type="double" value="0.408200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -109,17 +106,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -142,6 +142,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -149,14 +150,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="y0" type="double" value="101325.000000000000"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.79351920000000064e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.51920000000064}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -179,6 +181,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -190,18 +193,19 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.8634e-04"/>
+                  <Parameter name="value" type="double" value="0.00018634"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.8634e-04"/>
+                  <Parameter name="value" type="double" value="0.00018634"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -215,6 +219,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -222,16 +227,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="2"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="2"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
       <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
@@ -239,50 +244,54 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Tc-99">
-	    <ParameterList name="BC for bottom and left side">
-	      <Parameter name="regions" type="Array(string)" value="{Bottom side, Left side}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Tc-99">
+            <ParameterList name="BC for bottom and left side">
+              <Parameter name="regions" type="Array(string)" value="{Bottom side, Left side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Tc-98">
-	    <ParameterList name="BC for bottom">
-	      <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Tc-98">
+            <ParameterList name="BC for bottom">
+              <Parameter name="regions" type="Array(string)" value="{Left side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <ParameterList name="BC for left">
-	      <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="BC for left">
+              <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{0.5, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0.5, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_transport_initialize.xml
+++ b/src/mpc/test/mpc_transport_initialize.xml
@@ -1,6 +1,5 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -13,7 +12,7 @@
     <ParameterList name="All domain">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-1.0, -1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,  1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -33,41 +32,40 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
-	<Parameter name="framework" type="string" value="MSTK"/>
+        <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
-
       <ParameterList name="read mesh file">
-	<Parameter name="file" type="string" value="test/mpc_transport_mesh.exo"/>
-	<Parameter name="format" type="string" value="Exodus II"/>
+        <Parameter name="file" type="string" value="test/mpc_transport_mesh.exo"/>
+        <Parameter name="format" type="string" value="Exodus II"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
-    <Parameter name="end time" type="double" value="100"/>
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="end time" type="double" value="100.0"/>
     <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="transport">
-	    <Parameter name="PK type" type="string" value="transport"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="initial timestep" type="double" value="1.00000000000000000e+00"/>
-	<Parameter name="maximal timestep" type="double" value="1.00000000000000000e+07"/>
-	<Parameter name="start period time" type="double" value="0.00000000000000000e+00"/>
-	<Parameter name="end period time" type="double" value="1.00000000000000000e+03"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="transport">
+            <Parameter name="PK type" type="string" value="transport"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="initial timestep" type="double" value="1.00000000000000000"/>
+        <Parameter name="maximal timestep" type="double" value="10000000.0000000000"/>
+        <Parameter name="start period time" type="double" value="0e-17"/>
+        <Parameter name="end period time" type="double" value="1000.00000000000000"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <Parameter name="initialization filename" type="string" value="chk_transport_final.h5"/>
     <ParameterList name="evaluators">
@@ -79,7 +77,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="4.08200000000000007e-01"/>
+                <Parameter name="value" type="double" value="0.408200000000000007"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -100,17 +98,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -133,6 +134,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -140,14 +142,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325000000000000e+05"/>
+                <Parameter name="y0" type="double" value="101325.000000000000"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.79351920000000064e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.51920000000064}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -159,18 +162,19 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.8634e-04"/>
+                  <Parameter name="value" type="double" value="0.00018634"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.8634e-04"/>
+                  <Parameter name="value" type="double" value="0.00018634"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="Computational domain">
@@ -184,6 +188,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -194,16 +199,16 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <Parameter name="PK type" type="string" value="transport"/>
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="2"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="2"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <Parameter name="component names" type="Array(string)" value="{Tc-99, Tc-98}"/>
       <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
@@ -211,50 +216,54 @@
         <Parameter name="limiter" type="string" value="tensorial"/>
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="concentration">
-	  <ParameterList name="Tc-99">
-	    <ParameterList name="BC for bottom and left side">
-	      <Parameter name="regions" type="Array(string)" value="{Bottom side, Left side}"/>
+        <ParameterList name="concentration">
+          <ParameterList name="Tc-99">
+            <ParameterList name="BC for bottom and left side">
+              <Parameter name="regions" type="Array(string)" value="{Bottom side, Left side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="Tc-98">
-	    <ParameterList name="BC for bottom">
-	      <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="Tc-98">
+            <ParameterList name="BC for bottom">
+              <Parameter name="regions" type="Array(string)" value="{Left side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <ParameterList name="BC for left">
-	      <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <ParameterList name="BC for left">
+              <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-tabular">
-		  <Parameter name="forms" type="Array(string)" value="{constant}"/>
-		  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
-		  <Parameter name="y values" type="Array(double)" value="{0.5, 1.0}"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-tabular">
+                  <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 0.1}"/>
+                  <Parameter name="y values" type="Array(double)" value="{0.5, 1.0}"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/mpc/test/mpc_walkabout_2D.xml
+++ b/src/mpc/test/mpc_walkabout_2D.xml
@@ -1,17 +1,14 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="walkabout data">
     <Parameter name="file name base" type="string" value="walkabout"/>
     <Parameter name="file name digits" type="int" value="5"/>
-
     <ParameterList name="write regions">
       <Parameter name="region names" type="Array(string)" value="{All}"/>
       <Parameter name="material names" type="Array(string)" value="{MAT1}"/>
       <Parameter name="material ids" type="Array(int)" value="{1000}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -45,32 +42,30 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
+    <Parameter name="start time" type="double" value="0.0"/>
     <Parameter name="end time" type="double" value="1.0"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="flow">
-	    <Parameter name="PK type" type="string" value="darcy"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0"/>
-	<Parameter name="initial timestep" type="double" value="1.0"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="flow">
+            <Parameter name="PK type" type="string" value="darcy"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{0.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{1.0}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{1.0}"/>		 
+      <Parameter name="maximum timestep" type="Array(double)" value="{1.0}"/>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="none"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
@@ -91,7 +86,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -126,17 +121,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -163,6 +161,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -170,109 +169,113 @@
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.01325e+05"/>
+                <Parameter name="value" type="double" value="101325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
-      <ParameterList name="operators">
-      	<ParameterList name="diffusion operator">
-      	  <ParameterList name="matrix">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	  <ParameterList name="preconditioner">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-      	<ParameterList name="mass flux">
-      	  <ParameterList name="BC 0">
-      	    <Parameter name="regions" type="Array(string)" value="{Inlet}"/>
-            <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <ParameterList name="outward mass flux">
-      	      <ParameterList name="function-constant">
-      		<Parameter name="value" type="double" value="-1.0e-6"/>
-      	      </ParameterList>
-      	    </ParameterList>
-      	  </ParameterList>
-      	</ParameterList>
-      	<ParameterList name="pressure">
-      	  <ParameterList name="BC 1">
-      	    <Parameter name="regions" type="Array(string)" value="{Outlet}"/>
-            <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <ParameterList name="boundary pressure">
-      	      <ParameterList name="function-constant">
-      		<Parameter name="value" type="double" value="101325.0"/>
-      	      </ParameterList>
-      	    </ParameterList>
-      	  </ParameterList>
-         </ParameterList>
-      </ParameterList>
-      <ParameterList name="time integrator">
-	<Parameter name="start interval time" type="double" value="0.0"/>
-	<Parameter name="initial timestep" type="double" value="1.0"/>
-	<Parameter name="maximal timestep" type="double" value="1.0e+07"/>
-      	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-      	<Parameter name="linear solver" type="string" value="AztecOO"/>
-      	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      	<Parameter name="time integration method" type="string" value="BDF1"/>
-      	<ParameterList name="BDF1">
-      	  <Parameter name="timestep controller type" type="string" value="standard"/>
-      	  <ParameterList name="timestep controller standard parameters">
-      	    <Parameter name="max iterations" type="int" value="15"/>
-      	    <Parameter name="min iterations" type="int" value="10"/>
-      	    <Parameter name="timestep increase factor" type="double" value="1.5"/>
-      	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-      	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-      	    <Parameter name="min timestep" type="double" value="1e-20"/>
-      	  </ParameterList>
-      	  <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
-      	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-      	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-      	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-      	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-      	</ParameterList>
 
-      	<ParameterList name="initialization">
-      	  <Parameter name="method" type="string" value="saturated solver"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Inlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-0.0000010"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outlet}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="start interval time" type="double" value="0.0"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
+        <Parameter name="maximal timestep" type="double" value="1.0e+7"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.5"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1e-20"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="relaxation type" type="int" value="3"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
@@ -280,7 +283,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="pcg"/>

--- a/src/mpc/test/mpc_walkabout_3D.xml
+++ b/src/mpc/test/mpc_walkabout_3D.xml
@@ -1,17 +1,14 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="walkabout data">
     <Parameter name="file name base" type="string" value="walkabout"/>
     <Parameter name="file name digits" type="int" value="5"/>
-
     <ParameterList name="write regions">
       <Parameter name="region names" type="Array(string)" value="{Bottom Region, Middle Region, Top Region}"/>
       <Parameter name="material names" type="Array(string)" value="{MAT1, MAT2, MAT3}"/>
       <Parameter name="material ids" type="Array(int)" value="{1000, 2000, 3000}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="expert">
@@ -57,32 +54,30 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
-    <Parameter name="start time" type="double" value="0"/>
+    <Parameter name="start time" type="double" value="0.0"/>
     <Parameter name="end time" type="double" value="1.0"/>
     <ParameterList name="time periods">
       <ParameterList name="TP 0">
-	<ParameterList name="PK tree">
-	  <ParameterList name="flow">
-	    <Parameter name="PK type" type="string" value="darcy"/>
-	  </ParameterList>
-	</ParameterList>
-	<Parameter name="start period time" type="double" value="0.0"/>
-	<Parameter name="end period time" type="double" value="1.0"/>
-	<Parameter name="initial timestep" type="double" value="1.0"/>
+        <ParameterList name="PK tree">
+          <ParameterList name="flow">
+            <Parameter name="PK type" type="string" value="darcy"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="1.0"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="time period control">
       <Parameter name="start times" type="Array(double)" value="{0.0}"/>
       <Parameter name="initial timestep" type="Array(double)" value="{1.0}"/>
-      <Parameter name="maximum timestep" type="Array(double)" value="{1.0}"/>		 
+      <Parameter name="maximum timestep" type="Array(double)" value="{1.0}"/>
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="none"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
@@ -103,7 +98,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -156,17 +151,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -198,6 +196,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -205,14 +204,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.793e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -220,89 +220,93 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
-      <ParameterList name="operators">
-      	<ParameterList name="diffusion operator">
-      	  <ParameterList name="matrix">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	  <ParameterList name="preconditioner">
-      	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-      	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      	    <Parameter name="gravity" type="bool" value="true"/>
-      	  </ParameterList>
-      	</ParameterList>
-      </ParameterList>
-      <ParameterList name="boundary conditions">
-      	<ParameterList name="pressure">
-      	  <ParameterList name="BC 0">
-      	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-            <Parameter name="spatial distribution method" type="string" value="none"/>
-      	    <ParameterList name="boundary pressure">
-      	      <ParameterList name="function-constant">
-      		<Parameter name="value" type="double" value="101325.0"/>
-      	      </ParameterList>
-      	    </ParameterList>
-      	  </ParameterList>
-      	</ParameterList>
-      </ParameterList>
-      <ParameterList name="time integrator">
-	<Parameter name="start interval time" type="double" value="0.0"/>
-	<Parameter name="initial timestep" type="double" value="1.0"/>
-	<Parameter name="maximal timestep" type="double" value="1.0e+07"/>
-      	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-      	<Parameter name="linear solver" type="string" value="AztecOO"/>
-      	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-      	<ParameterList name="dae constraint">
-      	  <Parameter name="method" type="string" value="projection"/>
-      	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
-      	<Parameter name="time integration method" type="string" value="BDF1"/>
-      	<ParameterList name="BDF1">
-      	  <Parameter name="timestep controller type" type="string" value="standard"/>
-      	  <ParameterList name="timestep controller standard parameters">
-      	    <Parameter name="max iterations" type="int" value="15"/>
-      	    <Parameter name="min iterations" type="int" value="10"/>
-      	    <Parameter name="timestep increase factor" type="double" value="1.5"/>
-      	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-      	    <Parameter name="max timestep" type="double" value="6.0e+10"/>
-      	    <Parameter name="min timestep" type="double" value="1e-20"/>
-      	  </ParameterList>
-      	  <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
-      	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-      	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-      	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0e+00"/>
-      	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0e+00"/>
-      	</ParameterList>
 
-      	<ParameterList name="initialization">
-      	  <Parameter name="method" type="string" value="saturated solver"/>
-      	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-      	</ParameterList>
+      <ParameterList name="operators">
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="start interval time" type="double" value="0.0"/>
+        <Parameter name="initial timestep" type="double" value="1.0"/>
+        <Parameter name="maximal timestep" type="double" value="1.0e+7"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.5"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1e-20"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="20"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="relaxation type" type="int" value="3"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
@@ -310,7 +314,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="pcg"/>

--- a/src/mpc/test/observable_line_segment.xml
+++ b/src/mpc/test/observable_line_segment.xml
@@ -1,34 +1,28 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,10.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 10.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well3012">
       <ParameterList name="region: line segment">
-        <Parameter name="end coordinate" type="Array(double)" value="{2.60, 2.60, 0.0e+00}"/>
+        <Parameter name="end coordinate" type="Array(double)" value="{2.60, 2.60, 0.0}"/>
         <Parameter name="opposite end coordinate" type="Array(double)" value="{5.60, 6.60, 9.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well3013">
       <ParameterList name="region: line segment">
-        <Parameter name="end coordinate" type="Array(double)" value="{4.60, 4.60, 4.0e+00}"/>
+        <Parameter name="end coordinate" type="Array(double)" value="{4.60, 4.60, 4.0}"/>
         <Parameter name="opposite end coordinate" type="Array(double)" value="{4.10, 4.90, 5.1}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
-
   <!--  STATE  -->
   <ParameterList name="state">
-
   </ParameterList>
-
-
 </ParameterList>
-

--- a/src/operators/test/operator_advdiff.xml
+++ b/src/operators/test/operator_advdiff.xml
@@ -1,24 +1,23 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -26,14 +25,12 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: monotone for hex"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, face}"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator fv">
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="discretization primary" type="string" value="fv: default"/>
@@ -41,14 +38,12 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
       <Parameter name="gravity" type="bool" value="false"/>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="method order" type="int" value="0"/>
       <Parameter name="matrix type" type="string" value="advection"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -73,7 +68,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -89,4 +83,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_advdiff_surface.xml
+++ b/src/operators/test/operator_advdiff_surface.xml
@@ -1,24 +1,23 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -26,16 +25,14 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: monotone for hex"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="use surface flux" type="bool" value="false"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -49,7 +46,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -65,4 +61,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_advection_dg.xml
+++ b/src/operators/test/operator_advection_dg.xml
@@ -1,15 +1,12 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  OPERATORS 2D -->
   <ParameterList name="PK operator 2D">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="upwind"/>
       <Parameter name="jump operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -17,11 +14,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -29,11 +24,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
-      <Parameter name="coef" type="double" value="200"/>
+      <Parameter name="coef" type="double" value="200.0"/>
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -42,16 +35,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS 2D: primal formulation -->
   <ParameterList name="PK operator 2D: primal">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="downwind"/>
       <Parameter name="jump operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -59,11 +49,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -71,11 +59,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
-      <Parameter name="coef" type="double" value="200"/>
+      <Parameter name="coef" type="double" value="200.0"/>
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -84,16 +70,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS 2D: primal formulation, gauss points -->
   <ParameterList name="PK operator 2D: gauss points">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="downwind at gauss points"/>
       <Parameter name="jump operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -101,11 +84,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -113,11 +94,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
-      <Parameter name="coef" type="double" value="200"/>
+      <Parameter name="coef" type="double" value="200.0"/>
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -126,16 +105,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  3D -->
   <ParameterList name="PK operator 3D">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="upwind"/>
       <Parameter name="jump operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -143,11 +119,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -155,11 +129,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
-      <Parameter name="coef" type="double" value="200"/>
+      <Parameter name="coef" type="double" value="200.0"/>
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -168,7 +140,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -182,7 +153,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -196,6 +166,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/operators/test/operator_advection_dg_transient.xml
+++ b/src/operators/test/operator_advection_dg_transient.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- MAPS -->
   <ParameterList name="maps">
     <Parameter name="method" type="string" value="Lagrange serendipity"/>
@@ -8,16 +7,13 @@
     <Parameter name="projector" type="string" value="L2"/>
     <Parameter name="map name" type="string" value="VEM"/>
   </ParameterList>
-
   <!--  OPERATORS: dual formulation -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="upwind"/>
       <Parameter name="jump operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -25,11 +21,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -37,10 +31,8 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="inverse mass operator">
       <Parameter name="matrix type" type="string" value="mass inverse"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -48,10 +40,8 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -60,16 +50,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS: primal formulation -->
   <ParameterList name="PK operator: primal">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="downwind"/>
       <Parameter name="jump operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -77,11 +64,9 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -89,10 +74,8 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="inverse mass operator">
       <Parameter name="matrix type" type="string" value="mass inverse"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -100,10 +83,8 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -112,16 +93,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS: primal formulation, gauss points -->
   <ParameterList name="PK operator: gauss points">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="downwind at gauss points"/>
       <Parameter name="jump operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -129,11 +107,9 @@
         <Parameter name="dg basis" type="string" value="orthonormalized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="false"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -141,10 +117,8 @@
         <Parameter name="dg basis" type="string" value="orthonormalized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="inverse mass operator">
       <Parameter name="matrix type" type="string" value="mass inverse"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -152,10 +126,8 @@
         <Parameter name="dg basis" type="string" value="orthonormalized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -165,4 +137,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_commute.xml
+++ b/src/operators/test/operator_commute.xml
@@ -1,24 +1,23 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -26,14 +25,12 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator mfd">
       <Parameter name="discretization primary" type="string" value="mfd: monotone for hex"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, face}"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator fv">
       <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
@@ -41,7 +38,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -56,4 +52,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion.xml
+++ b/src/operators/test/operator_diffusion.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -41,7 +40,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="GMRES">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -52,7 +50,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Belos GMRES">
       <Parameter name="iterative method" type="string" value="belos: gmres"/>
       <ParameterList name="belos: gmres parameters">
@@ -63,7 +60,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos1">
       <Parameter name="direct method" type="string" value="amesos: klu"/>
       <ParameterList name="amesos: klu parameters">
@@ -71,7 +67,6 @@
         <Parameter name="amesos version" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos2: basker">
       <Parameter name="direct method" type="string" value="amesos2: basker"/>
       <ParameterList name="amesos2: basker parameters">
@@ -79,7 +74,6 @@
         <Parameter name="amesos version" type="int" value="2"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos2: superludist">
       <Parameter name="direct method" type="string" value="amesos2: superludist"/>
       <ParameterList name="amesos2: superludist parameters">
@@ -88,7 +82,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -104,16 +97,13 @@
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="identity">
       <Parameter name="preconditioning method" type="string" value="identity"/>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- NODAL (conformal) MFD schemes -->
     <ParameterList name="diffusion operator nodal">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
@@ -121,7 +111,6 @@
       <Parameter name="schema" type="Array(string)" value="{node}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{node}"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator Lagrange">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -130,7 +119,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator Lagrange serendipity">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -139,7 +127,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator 3D Lagrange">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -148,7 +135,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator 3D Lagrange serendipity">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -157,7 +143,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <!-- EDGE (nonconformal) MFD schemes -->
     <ParameterList name="diffusion operator edge">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -167,7 +152,6 @@
         <Parameter name="method order" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator Crouzeix-Raviart">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -176,7 +160,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <!-- MIXED MFD schemes -->
     <ParameterList name="diffusion operator mixed">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
@@ -184,7 +167,6 @@
       <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator divk">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -193,7 +175,6 @@
       <Parameter name="nonlinear coefficient" type="string" value="divk: cell-face"/>
       <!--Parameter name="file name" type="string" value="test/struct.exo"/-->
     </ParameterList>
-
     <ParameterList name="diffusion operator nonsymmetric">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: default"/>
@@ -201,7 +182,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="diffusion tensor" type="string" value="nonsymmetric"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator gravity mfd">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -209,7 +189,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="gravity" type="bool" value="true"/>
     </ParameterList>
-
     <!-- FV schemes -->
     <ParameterList name="diffusion operator gravity fv">
       <Parameter name="discretization primary" type="string" value="fv: default"/>
@@ -218,44 +197,38 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
       <Parameter name="gravity" type="bool" value="true"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator nlfv">
       <Parameter name="discretization primary" type="string" value="nlfv: default"/>
       <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
-
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
       <ParameterList name="upwind parameters">
         <Parameter name="tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator second-order">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-      <!-- We use the existing option, since we override local matrix calculation anyway -->   
+      <!-- We use the existing option, since we override local matrix calculation anyway -->
       <Parameter name="nonlinear coefficient" type="string" value="divk: cell-face-twin"/>
     </ParameterList>
-
     <ParameterList name="upwind second-order">
       <Parameter name="upwind method" type="string" value="upwind: second-order"/>
       <ParameterList name="upwind parameters">
         <Parameter name="tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="diffusion operator cell">
       <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
-
     <!-- DG (nonconformal) schemes -->
     <ParameterList name="diffusion operator dg">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -269,4 +242,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_consistent_face.xml
+++ b/src/operators/test/operator_diffusion_consistent_face.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -39,7 +38,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -55,17 +53,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator mixed">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-
       <ParameterList name="consistent faces">
         <ParameterList name="preconditioner">
           <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -78,27 +73,24 @@
             <Parameter name="verbosity" type="int" value="2"/>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="linear solver">
           <Parameter name="iterative method" type="string" value="gmres"/>
           <ParameterList name="gmres parameters">
             <Parameter name="maximum number of iterations" type="int" value="100"/>
             <Parameter name="error tolerance" type="double" value="1e-15"/>
-           </ParameterList>
+          </ParameterList>
           <ParameterList name="verbose object" type="ParameterList">
-            <Parameter name="verbosity level" type="string" value="extreme" />
+            <Parameter name="verbosity level" type="string" value="extreme"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
       <ParameterList name="upwind parameters">
         <Parameter name="tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="upwind second-order">
       <Parameter name="upwind method" type="string" value="upwind: second-order"/>
       <ParameterList name="upwind parameters">
@@ -107,4 +99,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_curved.xml
+++ b/src/operators/test/operator_diffusion_curved.xml
@@ -1,11 +1,10 @@
 <ParameterList name="Main">
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -23,7 +22,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -39,7 +37,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
       <ParameterList name="ml parameters">
@@ -63,20 +60,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- Curved MFD schemes -->
     <ParameterList name="diffusion operator curved">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="diffusion generalized"/>
-        <Parameter name="method order" type="int" value="-1"/>  <!-- not used /-->
+        <Parameter name="method order" type="int" value="-1"/>
+        <!-- not used /-->
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_curved_face.xml
+++ b/src/operators/test/operator_diffusion_curved_face.xml
@@ -1,5 +1,4 @@
 <ParameterList name="Main">
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Boundary">
@@ -9,8 +8,8 @@
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -28,7 +27,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -44,17 +42,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion curved face">
       <Parameter name="discretization primary" type="string" value="mfd: curved face"/>
       <Parameter name="discretization secondary" type="string" value="mfd: default"/>
-      <Parameter name="schema" type="Array(string)" value="{face,cell}"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
+      <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_dfn.xml
+++ b/src/operators/test/operator_diffusion_dfn.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -12,8 +11,8 @@
         <Parameter name="partitioner" type="string" value="zoltan_rcb"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Universe">
@@ -22,20 +21,20 @@
     </ParameterList>
     <ParameterList name="ALL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fractures">
@@ -49,22 +48,19 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="use manifold flux" type="bool" value="true"/>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="method order" type="int" value="0"/>
       <Parameter name="matrix type" type="string" value="advection"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -83,7 +79,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -102,4 +97,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_dfn_fv.xml
+++ b/src/operators/test/operator_diffusion_dfn_fv.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -12,8 +11,8 @@
         <Parameter name="partitioner" type="string" value="zoltan_rcb"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Universe">
@@ -22,20 +21,20 @@
     </ParameterList>
     <ParameterList name="ALL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fractures">
@@ -49,7 +48,6 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="fv: defaulty"/>
       <Parameter name="discretization secondary" type="string" value="fv: default"/>
@@ -59,7 +57,6 @@
       <Parameter name="manifolds" type="string" value="fractures"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -78,7 +75,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -97,4 +93,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_dfn_nlfv.xml
+++ b/src/operators/test/operator_diffusion_dfn_nlfv.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -12,8 +11,8 @@
         <Parameter name="partitioner" type="string" value="zoltan_rcb"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Universe">
@@ -22,20 +21,20 @@
     </ParameterList>
     <ParameterList name="ALL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fractures">
@@ -49,7 +48,6 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="nlfv: default"/>
       <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
@@ -59,7 +57,6 @@
       <Parameter name="manifolds" type="string" value="fractures"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -78,7 +75,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -97,4 +93,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_fractured_matrix.xml
+++ b/src/operators/test/operator_diffusion_fractured_matrix.xml
@@ -1,12 +1,11 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Middle side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -20,7 +19,6 @@
         <Parameter name="error tolerance" type="double" value="1e-14"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="GMRES">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -32,7 +30,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -46,16 +43,13 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="identity">
       <Parameter name="preconditioning method" type="string" value="identity"/>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="fracture" type="Array(string)" value="{Middle side}"/>
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
@@ -66,4 +60,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_low_order.xml
+++ b/src/operators/test/operator_diffusion_low_order.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -38,7 +37,6 @@
         <Parameter name="error tolerance" type="double" value="1e-14"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="GMRES">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -49,7 +47,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="NKA">
       <Parameter name="iterative method" type="string" value="nka"/>
       <ParameterList name="nka parameters">
@@ -60,7 +57,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Belos GMRES">
       <Parameter name="iterative method" type="string" value="belos gmres"/>
       <ParameterList name="belos gmres parameters">
@@ -71,7 +67,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos1">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -79,7 +74,6 @@
         <Parameter name="amesos version" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos2: basker">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -87,7 +81,6 @@
         <Parameter name="amesos version" type="int" value="2"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Amesos2: superludist">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -96,7 +89,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="HypreAMG">
@@ -110,21 +102,19 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="ifpack2: ILUT">
       <Parameter name="preconditioning method" type="string" value="ifpack2: ILUT"/>
       <ParameterList name="ifpack2: ILUT parameters">
-       <Parameter name="fact: ilut level-of-fill" type="double" value="10.0"/>
-       <Parameter name="fact: drop tolerance" type="double" value="0.0"/>
+        <Parameter name="fact: ilut level-of-fill" type="double" value="10.0"/>
+        <Parameter name="fact: drop tolerance" type="double" value="0.0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="ifpack2: SCHWARZ">
       <Parameter name="preconditioning method" type="string" value="ifpack2: SCHWARZ"/>
       <ParameterList name="ifpack2: SCHWARZ parameters">
         <Parameter name="schwarz: combine mode" type="string" value="add"/>
         <Parameter name="schwarz: overlap level" type="int" value="1"/>
-        <Parameter name="schwarz: use reordering" type="bool" value="false"/>-->
+        <Parameter name="schwarz: use reordering" type="bool" value="false"/>
         <Parameter name="schwarz: inner preconditioner name" type="string" value="ILUT"/>
         <ParameterList name="schwarz: inner preconditioner parameters">
           <Parameter name="fact: ilut level-of-fill" type="double" value="10.0"/>
@@ -134,22 +124,18 @@
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="identity">
       <Parameter name="preconditioning method" type="string" value="identity"/>
     </ParameterList>
-
     <ParameterList name="diagonal">
       <Parameter name="preconditioning method" type="string" value="diagonal"/>
       <ParameterList name="diagonal parameters">
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="HypreAMG"/>
-
     <!-- NODAL (conformal) MFD schemes -->
     <ParameterList name="nodal">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
@@ -158,7 +144,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{node}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
     </ParameterList>
-
     <ParameterList name="Lagrange">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -167,7 +152,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Lagrange serendipity">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -176,7 +160,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="3D Lagrange">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -185,7 +168,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="3D Lagrange serendipity">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -194,7 +176,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <!-- EDGE (nonconformal) MFD schemes -->
     <ParameterList name="edge">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -204,7 +185,6 @@
         <Parameter name="method order" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Crouzeix-Raviart">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -213,7 +193,6 @@
         <Parameter name="method order" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
-
     <!-- MIXED MFD schemes -->
     <ParameterList name="mixed">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
@@ -222,7 +201,6 @@
       <Parameter name="nonlinear coefficient" type="string" value="none"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
     </ParameterList>
-
     <ParameterList name="mixed upwind">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -230,7 +208,6 @@
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
     </ParameterList>
-    
     <ParameterList name="so">
       <Parameter name="discretization primary" type="string" value="mfd: support operator"/>
       <Parameter name="discretization secondary" type="string" value="mfd: support operator"/>
@@ -238,7 +215,6 @@
       <Parameter name="nonlinear coefficient" type="string" value="none"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
     </ParameterList>
-
     <ParameterList name="divk">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -247,7 +223,6 @@
       <Parameter name="nonlinear coefficient" type="string" value="divk: cell-face"/>
       <!--Parameter name="file name" type="string" value="test/struct.exo"/-->
     </ParameterList>
-
     <ParameterList name="nonsymmetric">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: default"/>
@@ -255,7 +230,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="diffusion tensor" type="string" value="nonsymmetric"/>
     </ParameterList>
-
     <ParameterList name="gravity mfd">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -263,37 +237,32 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="gravity" type="bool" value="true"/>
     </ParameterList>
-
     <!-- FV schemes -->
     <ParameterList name="fv">
       <Parameter name="discretization primary" type="string" value="fv: default"/>
       <Parameter name="discretization secondary" type="string" value="fv: default"/>
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-      <Parameter name="diagonal shift" type="double" value="1.e-8"/>
+      <Parameter name="diagonal shift" type="double" value="1e-8"/>
     </ParameterList>
-
     <ParameterList name="nlfv">
       <Parameter name="discretization primary" type="string" value="nlfv: default"/>
       <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
-
     <ParameterList name="nlfv with bfaces">
       <Parameter name="discretization primary" type="string" value="nlfv: default"/>
       <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,boundary_face}"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,boundary_face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, boundary_face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, boundary_face}"/>
     </ParameterList>
-    
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
       <ParameterList name="upwind parameters">
         <Parameter name="tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="second-order">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -301,21 +270,18 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="nonlinear coefficient" type="string" value="divk: cell-grad-face-twin"/>
     </ParameterList>
-
     <ParameterList name="upwind second-order">
       <Parameter name="upwind method" type="string" value="upwind: second-order"/>
       <ParameterList name="upwind parameters">
         <Parameter name="tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="cell">
       <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="schema" type="Array(string)" value="{cell}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
-
     <!-- DG (nonconformal) schemes -->
     <ParameterList name="dg">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -329,4 +295,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_schwarz.xml
+++ b/src/operators/test/operator_diffusion_schwarz.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Universe">
@@ -9,32 +8,32 @@
     </ParameterList>
     <ParameterList name="ALL">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{2.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="LEFT">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RIGHT">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="MIDDLE1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="MIDDLE2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.01,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.01, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -42,16 +41,14 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operators">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="gravity" type="bool" value="false"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="reconstruction">
     <Parameter name="polynomial order" type="int" value="0"/>
     <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
@@ -59,7 +56,6 @@
     <Parameter name="limiter location" type="string" value="node"/>
     <Parameter name="limiter cfl" type="double" value="1.0"/>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -78,7 +74,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -97,4 +92,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_diffusion_strip.xml
+++ b/src/operators/test/operator_diffusion_strip.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-4.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-4.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{4.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{4.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -39,7 +38,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -55,11 +53,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="fv: default"/>
       <Parameter name="discretization secondary" type="string" value="fv: default"/>
@@ -67,7 +63,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
       <Parameter name="gravity" type="bool" value="false"/>
     </ParameterList>
-
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
       <ParameterList name="upwind parameters">
@@ -76,4 +71,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_elasticity.xml
+++ b/src/operators/test/operator_elasticity.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
   </ParameterList>
@@ -28,7 +27,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -43,11 +41,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- NODE 2, FACE 1 scheme -->
     <ParameterList name="elasticity operator">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -58,6 +54,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/operators/test/operator_elasticity_fractured_matrix.xml
+++ b/src/operators/test/operator_elasticity_fractured_matrix.xml
@@ -1,12 +1,11 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="fracture">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -24,7 +23,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -39,11 +37,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- NODE 2, FACE 1 scheme -->
     <ParameterList name="elasticity operator">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -55,6 +51,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/operators/test/operator_elasticity_weak_symmetry.xml
+++ b/src/operators/test/operator_elasticity_weak_symmetry.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -52,7 +51,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -68,11 +66,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- NODE 2, FACE 1 scheme -->
     <ParameterList name="elasticity operator">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -83,6 +79,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/operators/test/operator_electromagnetics.xml
+++ b/src/operators/test/operator_electromagnetics.xml
@@ -1,24 +1,23 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
@@ -31,7 +30,6 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="electromagnetics operator">
       <ParameterList name="schema electric">
         <Parameter name="base" type="string" value="cell"/>
@@ -40,7 +38,6 @@
         <Parameter name="method order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="magnetic diffusion operators">
       <ParameterList name="schema electric">
         <Parameter name="base" type="string" value="cell"/>
@@ -55,7 +52,6 @@
         <Parameter name="method order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="magnetic diffusion operators vem">
       <ParameterList name="schema electric">
         <Parameter name="base" type="string" value="cell"/>
@@ -70,7 +66,6 @@
         <Parameter name="method order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="curlcurl operator">
       <Parameter name="matrix type" type="string" value="stiffness"/>
       <ParameterList name="schema">
@@ -80,7 +75,6 @@
         <Parameter name="method order" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="accumulation operator">
       <Parameter name="matrix type" type="string" value="mass"/>
       <ParameterList name="schema">
@@ -91,20 +85,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="default">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
-        <Parameter name="error tolerance" type="double" value="1e-6"/>
+        <Parameter name="error tolerance" type="double" value="0.000001"/>
         <Parameter name="maximum number of iterations" type="int" value="200"/>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="silent">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
@@ -115,7 +107,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="GMRES">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -127,7 +118,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMS">
@@ -154,4 +144,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_electromagnetics_TM.xml
+++ b/src/operators/test/operator_electromagnetics_TM.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
   </ParameterList>
@@ -8,7 +7,6 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="electromagnetics operator">
       <ParameterList name="schema electric">
         <Parameter name="base" type="string" value="cell"/>
@@ -18,7 +16,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="default">
@@ -31,7 +28,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="silent">
       <Parameter name="iterative method" type="string" value="pcg"/>
       <ParameterList name="pcg parameters">
@@ -43,7 +39,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -59,4 +54,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_laplace_beltrami.xml
+++ b/src/operators/test/operator_laplace_beltrami.xml
@@ -1,40 +1,38 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="Regions Flat">
     <ParameterList name="Middle z-surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle y-surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle x-surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Half z-surface">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.3,0.3,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.3, 0.3, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions Closed">
     <ParameterList name="Top surface">
       <ParameterList name="region: labeled set">
@@ -45,19 +43,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator Sff">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="use surface flux" type="bool" value="false"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator Scc">
       <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
@@ -66,16 +61,14 @@
       <Parameter name="nonstandard symbolic assembling" type="int" value="1"/>
       <Parameter name="use surface flux" type="bool" value="false"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="use surface flux" type="bool" value="false"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -99,7 +92,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -121,4 +113,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_marshak.xml
+++ b/src/operators/test/operator_marshak.xml
@@ -1,19 +1,18 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="simulation time" type="double" value="0.6"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{3.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{3.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -21,7 +20,6 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator nlfv">
       <Parameter name="discretization primary" type="string" value="nlfv: default"/>
       <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
@@ -29,16 +27,14 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator Sff">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="scaled constraint equation" type="bool" value="true"/>
     </ParameterList>
-    
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
       <ParameterList name="upwind parameters">
@@ -48,7 +44,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -72,7 +67,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -91,4 +85,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_marshak_logical.xml
+++ b/src/operators/test/operator_marshak_logical.xml
@@ -1,18 +1,17 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{3.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{3.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -20,13 +19,11 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator">
       <Parameter name="discretization primary" type="string" value="fv: default"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="scaled constraint equation" type="bool" value="true"/>
     </ParameterList>
-    
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
       <ParameterList name="upwind parameters">
@@ -34,7 +31,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -58,7 +54,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -77,4 +72,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_remap.xml
+++ b/src/operators/test/operator_remap.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Boundary">
@@ -18,7 +17,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-    
+
   <!-- MAPS -->
   <ParameterList name="maps">
     <Parameter name="method" type="string" value="Lagrange serendipity"/>
@@ -26,7 +25,6 @@
     <Parameter name="projector" type="string" value="H1"/>
     <Parameter name="map name" type="string" value="VEM"/>
   </ParameterList>
-
   <!-- LIMITER -->
   <ParameterList name="limiter">
     <Parameter name="limiter" type="string" value="none"/>
@@ -36,17 +34,14 @@
     <Parameter name="smoothness indicator" type="string" value="high order term"/>
     <Parameter name="limiter points" type="int" value="1"/>
   </ParameterList>
-
   <!--  OPERATORS: dual formulation -->
   <ParameterList name="PK operator">
     <Parameter name="boundary conditions" type="string" value="none"/>
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="flux operator">
       <Parameter name="matrix type" type="string" value="flux"/>
       <Parameter name="flux formula" type="string" value="downwind"/>
       <Parameter name="jump operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="face"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -54,11 +49,9 @@
         <Parameter name="dg basis" type="string" value="orthonormalized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="advection operator">
       <Parameter name="matrix type" type="string" value="advection"/>
       <Parameter name="gradient operator on test function" type="bool" value="true"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -66,10 +59,8 @@
         <Parameter name="dg basis" type="string" value="orthonormalized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="reaction operator">
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -77,10 +68,8 @@
         <Parameter name="method order" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="divergence operator">
       <Parameter name="matrix type" type="string" value="mass"/>
-
       <ParameterList name="schema">
         <Parameter name="base" type="string" value="cell"/>
         <Parameter name="method" type="string" value="dg modal"/>
@@ -90,4 +79,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_stability.xml
+++ b/src/operators/test/operator_stability.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -32,28 +31,24 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operators">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="mixed diffusion">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="preconditioner schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="preconditioner schema" type="Array(string)" value="{cell, face}"/>
     </ParameterList>
-
     <ParameterList name="mixed diffusion sff">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: default"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
     </ParameterList>
-
     <ParameterList name="mixed diffusion scc">
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
     </ParameterList>
-
     <ParameterList name="nodal diffusion">
       <Parameter name="schema" type="Array(string)" value="{node}"/>
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
@@ -61,8 +56,6 @@
       <Parameter name="preconditioner schema" type="Array(string)" value="{node}"/>
     </ParameterList>
   </ParameterList>
-
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -76,7 +69,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -86,7 +78,7 @@
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="strong threshold" type="double" value="0.5"/>
-        <Parameter name="tolerance" type="double" value="0"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <!--Parameter name="relaxation type" type="int" value="6"/-->
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
@@ -95,4 +87,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/operators/test/operator_stokes.xml
+++ b/src/operators/test/operator_stokes.xml
@@ -1,30 +1,29 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -43,7 +42,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -62,11 +60,9 @@
       <Parameter name="preconditioning method" type="string" value="diagonal"/>
     </ParameterList>
   </ParameterList>
-
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <!-- NODE 2, FACE 1 scheme -->
     <ParameterList name="elasticity operator">
       <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -76,7 +72,6 @@
         <Parameter name="method order" type="int" value="1"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="divergence operator">
       <Parameter name="matrix type" type="string" value="divergence"/>
       <ParameterList name="schema domain">
@@ -91,7 +86,6 @@
         <Parameter name="dg basis" type="string" value="regularized"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="gradient operator">
       <Parameter name="matrix type" type="string" value="divergence transpose"/>
       <Parameter name="factory" type="string" value="schema range"/>
@@ -108,6 +102,4 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
 </ParameterList>
-

--- a/src/operators/test/operator_upwind.xml
+++ b/src/operators/test/operator_upwind.xml
@@ -1,36 +1,35 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top surface">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fractures">
@@ -45,4 +44,3 @@
     <Parameter name="tolerance" type="double" value="1e-12"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/chemistry/test/chemistry_alquimia_pk.xml
+++ b/src/pks/chemistry/test/chemistry_alquimia_pk.xml
@@ -17,12 +17,11 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98, -9.9e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98,  9.9e+98,  9.9e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -36,7 +35,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -50,7 +49,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.5e-01"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -72,17 +71,20 @@
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -111,6 +113,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -118,20 +121,23 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="geochemical conditions">
         <ParameterList name="initial">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="isotherm_kd">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -142,13 +148,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e+01"/>
+                  <Parameter name="value" type="double" value="10.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="isotherm_langmuir_b">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -166,6 +173,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="isotherm_freundlich_n">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -183,6 +191,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -190,14 +199,13 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PK tree">
     <ParameterList name="chemistry">
       <Parameter name="PK type" type="string" value="chemistry alquimia"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="chemistry">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="engine" type="string" value="CrunchFlow"/>
@@ -206,19 +214,21 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="1.57784630000000000e+07"/>
-      <Parameter name="min timestep (s)" type="double" value="1.00000000000000000e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.57784630000000000e+07"/>
+      <Parameter name="max timestep (s)" type="double" value="15778463.0000000000"/>
+      <Parameter name="min timestep (s)" type="double" value="10000000000.0000000"/>
+      <Parameter name="initial timestep (s)" type="double" value="15778463.0000000000"/>
       <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
-      <Parameter name="initial conditions time" type="double" value="0.00000000000000000e+00"/>
+      <Parameter name="initial conditions time" type="double" value="0e-17"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>

--- a/src/pks/chemistry/test/chemistry_amanzi_pk.xml
+++ b/src/pks/chemistry/test/chemistry_amanzi_pk.xml
@@ -1,59 +1,58 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00e+00, 0.00e+00, 0.00e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00e+00, 1.00e+00, 1.00e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00, 0.00, 0.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00, 1.00, 1.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Upper">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00e+00, 0.00e+00, 5.00e-01}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00e+00, 1.00e+00, 1.00e+00}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00, 0.00, 0.500}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00, 1.00, 1.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.00e+00, 0.00e+00, 0.00e+00}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.00e+00, 1.00e+00, 5.00e-01}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.00, 0.00, 0.00}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.00, 1.00, 0.500}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="XLOW">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.00e+00, 5.00e-01, 5.00e-01}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.00e+00, 0.00e+00, 0.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{0.00, 0.500, 0.500}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.00, 0.00, 0.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="XHIGH">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.00e+00, 5.00e-01, 5.00e-01}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.00e+00, 0.00e+00, 0.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{1.00, 0.500, 0.500}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.00, 0.00, 0.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="YLOW">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{5.00e-01, 0.00e+00, 5.00e-01}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.00e+00, 1.00e+00, 0.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{0.500, 0.00, 0.500}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.00, 1.00, 0.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="YHIGH">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{5.00e-01, 1.00e+00, 5.00e-01}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.00e+00, -1.00e+00, 0.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{0.500, 1.00, 0.500}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.00, -1.00, 0.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="ZLOW">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{5.00e-01, 5.00e-01, 0.00e+00}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.00e+00, 0.00e+00, 1.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{0.500, 0.500, 0.00}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.00, 0.00, 1.00}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="ZHIGH">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{5.00e-01, 5.00e-01, 1.00e+00}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.00e+00, 0.00e+00, -1.00e+00}"/>
+        <Parameter name="point" type="Array(double)" value="{0.500, 0.500, 1.00}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.00, 0.00, -1.00}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -62,83 +61,81 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{1, 1, 10}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00e+00, 0.00e+00, 0.00e+00}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00e+00, 1.00e+00, 1.00e+00}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.00, 0.00, 0.00}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{1.00, 1.00, 1.00}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <Parameter name="component names" type="Array(string)" value="{Al+++, H+, HPO4--, SiO2(aq), UO2++}"/>
   </ParameterList>
-
   <ParameterList name="PK tree">
     <ParameterList name="chemistry">
       <Parameter name="PK type" type="string" value="chemistry amanzi"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
-  <ParameterList name="chemistry">
-    <Parameter name="number of component concentrations" type="int" value="5"/>
-    <Parameter name="Component Solutes" type="Array(string)" value="{Al+++, H+, HPO4--, SiO2(aq), UO2++}"/>
-    <Parameter name="minerals" type="Array(string)" value="{Kaolinite, Quartz, (UO2)3(PO4)2.4H2O}"/>
-    <Parameter name="sorption sites" type="Array(string)" value="{>FeOH, >AlOH, >SiOH}"/>
-    <ParameterList name="verbose object" type="ParameterList">
-      <Parameter name="verbosity level" type="string" value="low" />
+
+    <ParameterList name="chemistry">
+      <Parameter name="number of component concentrations" type="int" value="5"/>
+      <Parameter name="Component Solutes" type="Array(string)" value="{Al+++, H+, HPO4--, SiO2(aq), UO2++}"/>
+      <Parameter name="minerals" type="Array(string)" value="{Kaolinite, Quartz, (UO2)3(PO4)2.4H2O}"/>
+      <Parameter name="sorption sites" type="Array(string)" value="{&gt;FeOH, &gt;AlOH, &gt;SiOH}"/>
+      <ParameterList name="verbose object" type="ParameterList">
+        <Parameter name="verbosity level" type="string" value="low"/>
+      </ParameterList>
+
+      <Parameter name="activity model" type="string" value="debye-huckel"/>
+      <Parameter name="tolerance" type="double" value="1.50000000000000007e-12"/>
+      <Parameter name="maximum Newton iterations" type="int" value="150"/>
+      <Parameter name="auxiliary data" type="Array(string)" value="{pH}"/>
+      <Parameter name="log formulation" type="bool" value="true"/>
+
     </ParameterList>
 
-    <Parameter name="activity model" type="string" value="debye-huckel"/>
-    <Parameter name="tolerance" type="double" value="1.50000000000000007e-12"/>
-    <Parameter name="maximum Newton iterations" type="int" value="150"/>
-    <Parameter name="auxiliary data" type="Array(string)" value="{pH}"/>
-    <Parameter name="log formulation" type="bool" value="true"/>
-  </ParameterList>
   </ParameterList>
 
   <ParameterList name="transport">
     <Parameter name="number of component concentrations" type="int" value="5"/>
-
     <ParameterList name="Transport BCs">
       <ParameterList name="BC upper Al+++">
-        <Parameter name="Al+++" type="Array(double)" value="{1.00e+00}"/>
-        <Parameter name="times" type="Array(double)" value="{0.00e+00}"/>
+        <Parameter name="Al+++" type="Array(double)" value="{1.00}"/>
+        <Parameter name="times" type="Array(double)" value="{0.00}"/>
         <Parameter name="time functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="regions" type="Array(string)" value="{ZHIGH}"/>
       </ParameterList>
       <ParameterList name="BC upper H+">
-        <Parameter name="H+" type="Array(double)" value="{1.00e+00}"/>
-        <Parameter name="times" type="Array(double)" value="{0.00e+00}"/>
+        <Parameter name="H+" type="Array(double)" value="{1.00}"/>
+        <Parameter name="times" type="Array(double)" value="{0.00}"/>
         <Parameter name="time functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="regions" type="Array(string)" value="{ZHIGH}"/>
       </ParameterList>
       <ParameterList name="BC upper HPO4--">
-        <Parameter name="HPO4--" type="Array(double)" value="{1.00e+00}"/>
-        <Parameter name="times" type="Array(double)" value="{0.00e+00}"/>
+        <Parameter name="HPO4--" type="Array(double)" value="{1.00}"/>
+        <Parameter name="times" type="Array(double)" value="{0.00}"/>
         <Parameter name="time functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="regions" type="Array(string)" value="{ZHIGH}"/>
       </ParameterList>
       <ParameterList name="BC upper SiO2(aq)">
-        <Parameter name="SiO2(aq)" type="Array(double)" value="{1.00e+00}"/>
-        <Parameter name="times" type="Array(double)" value="{0.00e+00}"/>
+        <Parameter name="SiO2(aq)" type="Array(double)" value="{1.00}"/>
+        <Parameter name="times" type="Array(double)" value="{0.00}"/>
         <Parameter name="time functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="regions" type="Array(string)" value="{ZHIGH}"/>
       </ParameterList>
       <ParameterList name="BC upper UO2++">
-        <Parameter name="UO2++" type="Array(double)" value="{1.00e+00}"/>
-        <Parameter name="times" type="Array(double)" value="{0.00e+00}"/>
+        <Parameter name="UO2++" type="Array(double)" value="{1.00}"/>
+        <Parameter name="times" type="Array(double)" value="{0.00}"/>
         <Parameter name="time functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="regions" type="Array(string)" value="{ZHIGH}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -153,9 +150,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
@@ -168,9 +164,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
       <ParameterList name="saturation_liquid">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
@@ -183,17 +178,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-    
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.00000000000000002e-03"/>
+        <Parameter name="value" type="double" value="0.00100000000000000002"/>
       </ParameterList>
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
-     
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -246,17 +241,17 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="3.16771999999999973e-08"/>
+                  <Parameter name="value" type="double" value="3.16771999999999973e-8"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="9.99999999999999955e-07"/>
+                  <Parameter name="value" type="double" value="9.99999999999999955e-7"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 4 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.86999999999999992e-04"/>
+                  <Parameter name="value" type="double" value="0.000186999999999999992"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 5 function">
@@ -279,17 +274,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.000e-02"/>
+                  <Parameter name="value" type="double" value="0.05000"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.000e-01"/>
+                  <Parameter name="value" type="double" value="0.2000"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="7.50e-01"/>
+                  <Parameter name="value" type="double" value="0.750"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -307,17 +302,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.00000000000000010e-04"/>
+                  <Parameter name="value" type="double" value="0.000200000000000000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.00000000000000005e-04"/>
+                  <Parameter name="value" type="double" value="0.000100000000000000005"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.99999999999999989e-01"/>
+                  <Parameter name="value" type="double" value="0.299999999999999989"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -335,17 +330,17 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.36000000000000018e-03"/>
+                  <Parameter name="value" type="double" value="0.00536000000000000018"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="6.36000000000000020e-03"/>
+                  <Parameter name="value" type="double" value="0.00636000000000000020"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="4.36000000000000016e-03"/>
+                  <Parameter name="value" type="double" value="0.00436000000000000016"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -391,20 +386,20 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="Al+++">
-        <Parameter name="ion size parameter" type="double" value="9.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="9.00000000000000000"/>
         <Parameter name="charge" type="int" value="3"/>
-        <Parameter name="gram molecular weight" type="double" value="2.69815000000000005e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="26.9815000000000005"/>
       </ParameterList>
       <ParameterList name="H+">
-        <Parameter name="ion size parameter" type="double" value="9.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="9.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.01000000000000001e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.01000000000000001"/>
       </ParameterList>
       <ParameterList name="HPO4--">
         <Parameter name="ion size parameter" type="double" value="4.0"/>
@@ -412,38 +407,37 @@
         <Parameter name="gram molecular weight" type="double" value="95.9793"/>
       </ParameterList>
       <ParameterList name="SiO2(aq)">
-        <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="6.00799999999999983e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="60.0799999999999983"/>
       </ParameterList>
       <ParameterList name="UO2++">
-        <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="2.70027699999999982e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="270.027699999999982"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="aqueous equilibrium complexes">
       <ParameterList name="OH-">
-        <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-        <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
       </ParameterList>
       <ParameterList name="AlOH++">
-        <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="4.39889000000000010e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="43.9889000000000010"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Al+++"/>
-        <Parameter name="equilibrium constant" type="double" value="4.95709999999999962e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="4.95709999999999962"/>
       </ParameterList>
       <ParameterList name="Al(OH)2+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="6.09962000000000018e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="60.9962000000000018"/>
         <Parameter name="reaction" type="string" value="2.0 H2O  -2.0 H+  1.0 Al+++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.05945000000000000e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="10.5945000000000000"/>
       </ParameterList>
       <ParameterList name="AlH2PO4++">
         <Parameter name="ion size parameter" type="double" value="4.5"/>
@@ -495,11 +489,11 @@
         <Parameter name="equilibrium constant" type="double" value="12.3218"/>
       </ParameterList>
       <ParameterList name="UO2OH+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="2.87035000000000025e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="287.035000000000025"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="5.20730000000000004e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="5.20730000000000004"/>
       </ParameterList>
       <ParameterList name="UO2PO4-">
         <Parameter name="ion size parameter" type="double" value="4.0"/>
@@ -509,67 +503,67 @@
         <Parameter name="equilibrium constant" type="double" value="-2.0798"/>
       </ParameterList>
       <ParameterList name="UO2(OH)2(aq)">
-        <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="3.04042399999999986e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="304.042399999999986"/>
         <Parameter name="reaction" type="string" value="2.0 H2O  -2.0 H+  1.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.03146000000000004e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="10.3146000000000004"/>
       </ParameterList>
       <ParameterList name="UO2(OH)3-">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="3.21049699999999973e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="321.049699999999973"/>
         <Parameter name="reaction" type="string" value="3.0 H2O  -3.0 H+  1.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.92218000000000018e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="19.2218000000000018"/>
       </ParameterList>
       <ParameterList name="UO2(OH)4--">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="-2"/>
-        <Parameter name="gram molecular weight" type="double" value="3.38057099999999991e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="338.057099999999991"/>
         <Parameter name="reaction" type="string" value="4.0 H2O  -4.0 H+  1.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="3.30290999999999997e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="33.0290999999999997"/>
       </ParameterList>
       <ParameterList name="(UO2)2OH+++">
-        <Parameter name="ion size parameter" type="double" value="5.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="5.00000000000000000"/>
         <Parameter name="charge" type="int" value="3"/>
-        <Parameter name="gram molecular weight" type="double" value="5.57062699999999950e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="557.062699999999950"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  2.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="2.70719999999999983e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="2.70719999999999983"/>
       </ParameterList>
       <ParameterList name="(UO2)2(OH)2++">
-        <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="5.74070100000000025e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="574.070100000000025"/>
         <Parameter name="reaction" type="string" value="2.0 H2O  -2.0 H+  2.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="5.63459999999999983e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="5.63459999999999983"/>
       </ParameterList>
       <ParameterList name="(UO2)3(OH)4++">
-        <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="8.78112499999999955e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="878.112499999999955"/>
         <Parameter name="reaction" type="string" value="4.0 H2O  -4.0 H+  3.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.19290000000000003e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="11.9290000000000003"/>
       </ParameterList>
       <ParameterList name="(UO2)3(OH)5+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="8.95119800000000055e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="895.119800000000055"/>
         <Parameter name="reaction" type="string" value="5.0 H2O  -5.0 H+  3.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.55861999999999998e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="15.5861999999999998"/>
       </ParameterList>
       <ParameterList name="(UO2)3(OH)7-">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="9.29134500000000003e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="929.134500000000003"/>
         <Parameter name="reaction" type="string" value="7.0 H2O  -7.0 H+  3.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="3.10507999999999988e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="31.0507999999999988"/>
       </ParameterList>
       <ParameterList name="(UO2)4(OH)7+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.19916219999999998e+03"/>
+        <Parameter name="gram molecular weight" type="double" value="1199.16219999999998"/>
         <Parameter name="reaction" type="string" value="7.0 H2O  -7.0 H+  4.0 UO2++"/>
-        <Parameter name="equilibrium constant" type="double" value="2.19508000000000010e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="21.9508000000000010"/>
       </ParameterList>
       <ParameterList name="UO2(H2PO4)(H3PO4)+">
         <Parameter name="ion size parameter" type="double" value="4.0"/>
@@ -607,16 +601,15 @@
         <Parameter name="equilibrium constant" type="double" value="-8.4398"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mineral kinetics">
       <ParameterList name="Kaolinite">
         <Parameter name="rate model" type="string" value="TST"/>
         <Parameter name="rate constant" type="double" value="-8.9670000000000005"/>
         <Parameter name="modifiers" type="string" value="H+  7.77000E-01"/>
-        <Parameter name="gram molecular weight" type="double" value="2.58160000000000025e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="258.160000000000025"/>
         <Parameter name="reaction" type="string" value="5.0 H2O  -6.0 H+  2.0 Al+++  2.0 SiO2(aq)"/>
         <Parameter name="equilibrium constant" type="double" value="6.8101"/>
-        <Parameter name="molar volume" type="double" value="9.95199999999999960e+01"/>
+        <Parameter name="molar volume" type="double" value="99.5199999999999960"/>
         <Parameter name="specific surface area" type="double" value="0.0003"/>
       </ParameterList>
       <ParameterList name="Quartz">
@@ -626,7 +619,7 @@
         <Parameter name="gram molecular weight" type="double" value="60.0843"/>
         <Parameter name="reaction" type="string" value="1.0 SiO2(aq)"/>
         <Parameter name="equilibrium constant" type="double" value="-3.9993"/>
-        <Parameter name="molar volume" type="double" value="2.26879999999999988e+01"/>
+        <Parameter name="molar volume" type="double" value="22.6879999999999988"/>
         <Parameter name="specific surface area" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="(UO2)3(PO4)2.4H2O">
@@ -641,55 +634,55 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="surface complex sites">
-      <ParameterList name=">FeOH">
-        <Parameter name="density" type="double" value="6.3600E-03"/>
+      <ParameterList name="&gt;FeOH">
+        <Parameter name="density" type="double" value="0.0063600"/>
       </ParameterList>
-      <ParameterList name=">AlOH">
-        <Parameter name="density" type="double" value="6.3600E-03"/>
+      <ParameterList name="&gt;AlOH">
+        <Parameter name="density" type="double" value="0.0063600"/>
       </ParameterList>
-      <ParameterList name=">SiOH">
-        <Parameter name="density" type="double" value="6.3600E-03"/>
+      <ParameterList name="&gt;SiOH">
+        <Parameter name="density" type="double" value="0.0063600"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="surface complexes">
-      <ParameterList name=">SiOUO3H3++">
+      <ParameterList name="&gt;SiOUO3H3++">
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="reaction" type="string" value="1.0 >SiOH  1.0 H2O  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;SiOH  1.0 H2O  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="5.18"/>
       </ParameterList>
-      <ParameterList name=">SiOUO3H2+">
+      <ParameterList name="&gt;SiOUO3H2+">
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="reaction" type="string" value="1.0 >SiOH  1.0 H2O  -1.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;SiOH  1.0 H2O  -1.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="5.18"/>
       </ParameterList>
-      <ParameterList name=">SiOUO3H">
+      <ParameterList name="&gt;SiOUO3H">
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="reaction" type="string" value="1.0 >SiOH  1.0 H2O  -2.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;SiOH  1.0 H2O  -2.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="5.18"/>
       </ParameterList>
-      <ParameterList name=">SiOUO3-">
+      <ParameterList name="&gt;SiOUO3-">
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="reaction" type="string" value="1.0 >SiOH  1.0 H2O  -3.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;SiOH  1.0 H2O  -3.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="12.35"/>
       </ParameterList>
-      <ParameterList name=">SiOUO2(OH)2-">
+      <ParameterList name="&gt;SiOUO2(OH)2-">
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="reaction" type="string" value="1.0 >SiOH  2.0 H2O  -3.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;SiOH  2.0 H2O  -3.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="12.35"/>
       </ParameterList>
-      <ParameterList name=">FeOHUO3">
+      <ParameterList name="&gt;FeOHUO3">
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="reaction" type="string" value="1.0 >FeOH  1.0 H2O  -2.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;FeOH  1.0 H2O  -2.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="3.05"/>
       </ParameterList>
-      <ParameterList name=">FeOHUO2++">
+      <ParameterList name="&gt;FeOHUO2++">
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="reaction" type="string" value="1.0 >FeOH  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;FeOH  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="-6.63"/>
       </ParameterList>
-      <ParameterList name=">AlOUO2+">
+      <ParameterList name="&gt;AlOUO2+">
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="reaction" type="string" value="1.0 >AlOH  -1.0 H+  1.0 UO2++"/>
+        <Parameter name="reaction" type="string" value="1.0 &gt;AlOH  -1.0 H+  1.0 UO2++"/>
         <Parameter name="equilibrium constant" type="double" value="-3.13"/>
       </ParameterList>
     </ParameterList>

--- a/src/pks/chemistry/test/chemistry_benchmarks_1d_b.xml
+++ b/src/pks/chemistry/test/chemistry_benchmarks_1d_b.xml
@@ -24,6 +24,7 @@
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
@@ -47,6 +48,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
+
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
@@ -63,7 +65,6 @@
         </ParameterList>
         <Parameter name="evaluator type" type="string" value="independent variable"/>
       </ParameterList>
-
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -71,7 +72,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+                <Parameter name="value" type="double" value="998.200000000000045"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -85,7 +86,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.50000000000000000e-01"/>
+                <Parameter name="value" type="double" value="0.250000000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -99,7 +100,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.e+00"/>
+                <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -108,18 +109,23 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942e+00}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.80664999999999942}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.982e+02"/>
+        <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -148,6 +154,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -155,17 +162,19 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="geochemical conditions">
         <ParameterList name="initial">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="total_component_concentration">
         <Parameter name="names" type="Array(string)" value="{free, gas@CO2, mineral@Calcite}"/>
         <ParameterList name="function">
@@ -187,16 +196,18 @@
               </ParameterList>
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5.0e-4"/>
+                  <Parameter name="value" type="double" value="0.00050"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="mineral_volume_fractions">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -207,13 +218,14 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-05"/>
+                  <Parameter name="value" type="double" value="0.000010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_specific_surface_area">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -231,6 +243,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mineral_rate_constant">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -248,6 +261,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="saturation_liquid">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -261,6 +275,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -270,7 +285,7 @@
   </ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="calcite"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.e+00, 3.15569260000000000e+07, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 31556926.0000000000, -1.0}"/>
   </ParameterList>
   <ParameterList name="cycle driver">
     <ParameterList name="time periods">
@@ -280,9 +295,9 @@
             <Parameter name="PK type" type="string" value="darcy"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.e+00"/>
-        <Parameter name="end period time" type="double" value="0.e+00"/>
-        <Parameter name="initial timestep" type="double" value="1.57680000000000000e+05"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="0.0"/>
+        <Parameter name="initial timestep" type="double" value="157680.000000000000"/>
         <Parameter name="maximum timestep" type="double" value="9.99999999999999967e+98"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
       </ParameterList>
@@ -304,11 +319,11 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.e+00"/>
-        <Parameter name="end period time" type="double" value="1.57784630000000000e+08"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
+        <Parameter name="end period time" type="double" value="157784630.000000000"/>
         <Parameter name="maximum cycle number" type="int" value="-1"/>
-        <Parameter name="initial timestep" type="double" value="1.57680000000000000e+05"/>
-        <Parameter name="maximum timestep" type="double" value="6.00000000000000000e+10"/>
+        <Parameter name="initial timestep" type="double" value="157680.000000000000"/>
+        <Parameter name="maximum timestep" type="double" value="60000000000.0000000"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{H+, HCO3-, Ca++}"/>
@@ -324,11 +339,13 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="flow steady">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -358,6 +375,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -373,17 +391,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.25e+00"/>
-            <Parameter name="timestep reduction factor" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.800000000000000044"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999980e-13"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -399,13 +417,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="mass flux">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{West}"/>
             <ParameterList name="outward mass flux">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="-7.91317859000000037e-06"/>
+                <Parameter name="value" type="double" value="-0.00000791317859000000037"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -418,7 +437,7 @@
             <Parameter name="regions" type="Array(string)" value="{East}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -426,22 +445,29 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="flow and reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{flow, reactive transport}"/>
       <Parameter name="master PK index" type="int" value="0"/>
+
     </ParameterList>
+
     <ParameterList name="reactive transport">
       <Parameter name="PKs order" type="Array(string)" value="{chemistry, transport}"/>
+
     </ParameterList>
+
     <ParameterList name="transport">
       <Parameter name="domain name" type="string" value="domain"/>
       <Parameter name="spatial discretization order" type="int" value="2"/>
       <Parameter name="temporal discretization order" type="int" value="2"/>
-      <Parameter name="cfl" type="double" value="1.e+00"/>
+      <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="flow mode" type="string" value="transient"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
@@ -453,11 +479,13 @@
         <Parameter name="limiter extension for transport" type="bool" value="true"/>
         <Parameter name="limiter stencil" type="string" value="face to cells"/>
       </ParameterList>
+
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{H+, HCO3-, Ca++}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="molar masses" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -476,6 +504,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="constraints">
           <ParameterList name="West BC">
@@ -484,21 +513,25 @@
             <Parameter name="use area fractions" type="bool" value="false"/>
             <Parameter name="names" type="Array(string)" value="{pH, total, charge}"/>
             <ParameterList name="boundary constraints">
-              <Parameter name="constant values" type="Array(double)" value="{5.0, 1.0e-3, 1.0e-6}"/>
+              <Parameter name="constant values" type="Array(double)" value="{5.0, 0.0010, 0.0000010}"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <Parameter name="number of aqueous components" type="int" value="3"/>
       <Parameter name="number of gaseous components" type="int" value="0"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="chemistry">
       <Parameter isUsed="true" name="domain name" type="string" value="domain"/>
       <Parameter name="chemistry model" type="string" value="Amanzi"/>
@@ -507,27 +540,30 @@
       <!--Parameter name="activity model" type="string" value="unit"/-->
       <Parameter name="maximum Newton iterations" type="int" value="50"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="2.20e+05"/>
+      <Parameter name="max timestep (s)" type="double" value="2.20e+5"/>
       <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="2.2e+05"/>
+      <Parameter name="initial timestep (s)" type="double" value="2.2e+5"/>
       <Parameter name="timestep cut threshold" type="int" value="10"/>
-      <Parameter name="timestep cut factor" type="double" value="2.e+00"/>
+      <Parameter name="timestep cut factor" type="double" value="2.0"/>
       <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
       <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="auxiliary data" type="Array(string)" value="{pH}"/>
-      <Parameter name="initial conditions time" type="double" value="0.e+00"/>
+      <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <Parameter name="log formulation" type="bool" value="true"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
     <ParameterList name="flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="absolute permeability">
         <Parameter name="coordinate system" type="string" value="cartesian"/>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="diffusion operator">
           <ParameterList name="matrix">
@@ -557,6 +593,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
         <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
         <Parameter name="linear solver" type="string" value="AztecOO"/>
@@ -575,14 +612,14 @@
             <Parameter name="timestep increase factor" type="double" value="1.25"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
             <Parameter name="max timestep" type="double" value="4.3234e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999980e-13"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -598,13 +635,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="mass flux">
           <ParameterList name="BC 0">
             <Parameter name="regions" type="Array(string)" value="{West}"/>
             <ParameterList name="outward mass flux">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="-7.91317859000000037e-06"/>
+                <Parameter name="value" type="double" value="-0.00000791317859000000037"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -617,7 +655,7 @@
             <Parameter name="regions" type="Array(string)" value="{East}"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.01325e+05"/>
+                <Parameter name="value" type="double" value="201325.0"/>
               </ParameterList>
             </ParameterList>
             <Parameter name="spatial distribution method" type="string" value="none"/>
@@ -625,11 +663,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
+
   <ParameterList name="solvers">
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -692,12 +734,12 @@
         <Parameter name="prec type" type="string" value="MGV"/>
         <Parameter name="cycle applications" type="int" value="2"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled-MIS"/>
-        <Parameter name="aggregation: damping factor" type="double" value="1.3333299999999999e+00"/>
-        <Parameter name="aggregation: threshold" type="double" value="0.e+00"/>
+        <Parameter name="aggregation: damping factor" type="double" value="1.3333299999999999"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="eigen-analysis: iterations" type="int" value="10"/>
         <Parameter name="smoother: sweeps" type="int" value="3"/>
-        <Parameter name="smoother: damping factor" type="double" value="1.e+00"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: type" type="string" value="Jacobi"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -707,10 +749,10 @@
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -730,67 +772,66 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="thermodynamic database">
     <ParameterList name="primary species">
       <ParameterList name="H+">
-        <Parameter name="ion size parameter" type="double" value="9.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="9.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.00790000000000002e+00"/>
+        <Parameter name="gram molecular weight" type="double" value="1.00790000000000002"/>
       </ParameterList>
       <ParameterList name="HCO3-">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="6.10170999999999992e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="61.0170999999999992"/>
       </ParameterList>
       <ParameterList name="Ca++">
-        <Parameter name="ion size parameter" type="double" value="6.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="6.00000000000000000"/>
         <Parameter name="charge" type="int" value="2"/>
-        <Parameter name="gram molecular weight" type="double" value="4.00780000000000030e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="40.0780000000000030"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="aqueous equilibrium complexes">
       <ParameterList name="OH-">
-        <Parameter name="ion size parameter" type="double" value="3.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.50000000000000000"/>
         <Parameter name="charge" type="int" value="-1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.70073000000000008e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="17.0073000000000008"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+"/>
-        <Parameter name="equilibrium constant" type="double" value="1.39951000000000008e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="13.9951000000000008"/>
       </ParameterList>
       <ParameterList name="CO3--">
-        <Parameter name="ion size parameter" type="double" value="4.50000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.50000000000000000"/>
         <Parameter name="charge" type="int" value="-2"/>
-        <Parameter name="gram molecular weight" type="double" value="6.00091999999999999e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="60.0091999999999999"/>
         <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-"/>
-        <Parameter name="equilibrium constant" type="double" value="1.03287999999999993e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="10.3287999999999993"/>
       </ParameterList>
       <ParameterList name="CO2(aq)">
-        <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="4.40097999999999985e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="44.0097999999999985"/>
         <Parameter name="reaction" type="string" value="-1.0 H2O  1.0 H+  1.0 HCO3-"/>
-        <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="-6.34469999999999956"/>
       </ParameterList>
       <ParameterList name="CaOH+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="5.70852999999999966e+01"/>
+        <Parameter name="gram molecular weight" type="double" value="57.0852999999999966"/>
         <Parameter name="reaction" type="string" value="1.0 H2O  -1.0 H+  1.0 Ca++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.28499999999999996e+01"/>
+        <Parameter name="equilibrium constant" type="double" value="12.8499999999999996"/>
       </ParameterList>
       <ParameterList name="CaHCO3+">
-        <Parameter name="ion size parameter" type="double" value="4.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="4.00000000000000000"/>
         <Parameter name="charge" type="int" value="1"/>
-        <Parameter name="gram molecular weight" type="double" value="1.01095100000000002e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="101.095100000000002"/>
         <Parameter name="reaction" type="string" value="1.0 HCO3-  1.0 Ca++"/>
-        <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="-1.04669999999999996"/>
       </ParameterList>
       <ParameterList name="CaCO3(aq)">
-        <Parameter name="ion size parameter" type="double" value="3.00000000000000000e+00"/>
+        <Parameter name="ion size parameter" type="double" value="3.00000000000000000"/>
         <Parameter name="charge" type="int" value="0"/>
-        <Parameter name="gram molecular weight" type="double" value="1.00087199999999996e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="100.087199999999996"/>
         <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
-        <Parameter name="equilibrium constant" type="double" value="7.00169999999999959e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="7.00169999999999959"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="mineral kinetics">
@@ -798,15 +839,14 @@
         <Parameter name="rate model" type="string" value="TST"/>
         <Parameter name="rate constant" type="double" value="-9.0"/>
         <Parameter name="modifiers" type="string" value=""/>
-        <Parameter name="gram molecular weight" type="double" value="1.00087199999999996e+02"/>
+        <Parameter name="gram molecular weight" type="double" value="100.087199999999996"/>
         <Parameter name="reaction" type="string" value="-1.0 H+  1.0 HCO3-  1.0 Ca++"/>
-        <Parameter name="equilibrium constant" type="double" value="1.84870000000000001e+00"/>
-        <Parameter name="molar volume" type="double" value="3.69339999999999975e+01"/>
-        <Parameter name="specific surface area" type="double" value="1.00000000000000000e+00"/>
+        <Parameter name="equilibrium constant" type="double" value="1.84870000000000001"/>
+        <Parameter name="molar volume" type="double" value="36.9339999999999975"/>
+        <Parameter name="specific surface area" type="double" value="1.00000000000000000"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="analysis">
     <ParameterList name="domain">
       <Parameter name="used boundary condition regions" type="Array(string)" value="{West, East, West, East, West, East}"/>

--- a/src/pks/energy/test/energy_convergence.xml
+++ b/src/pks/energy/test/energy_convergence.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="3"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -16,8 +14,8 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -28,57 +26,58 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  1.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
         <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-       <Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="energy evaluator">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
-	<Parameter name="liquid molar mass" type="double" value="0.018015"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
+        <Parameter name="liquid molar mass" type="double" value="0.018015"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
-	<Parameter name="liquid molar mass" type="double" value="0.018015"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="false"/>
+        <Parameter name="liquid molar mass" type="double" value="0.018015"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+        <ParameterList name="All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
@@ -88,92 +87,91 @@
             <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="2.0"/>
             <Parameter name="reference temperature" type="double" value="1.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="advection operator">
           <Parameter name="schema" type="Array(string)" value="{cell}"/>
           <Parameter name="method order" type="int" value="0"/>
           <Parameter name="matrix type" type="string" value="advection"/>
           <Parameter name="single domain" type="Array(string)" value="{domain}"/>
-        </ParameterList>          
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-5"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="none"/>
-	    </ParameterList>
-	  </ParameterList>
-
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="2"/>
-                 <Parameter name="formula" type="string" value="1.0 / tan((x - t) / 2)"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="2"/>
+                <Parameter name="formula" type="string" value="1.0 / tan((x - t) / 2)"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -193,7 +191,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -206,12 +203,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
-   <ParameterList name="verbose object">
-     <Parameter name="verbosity level" type="string" value="none"/>
+    <ParameterList name="verbose object">
+      <Parameter name="verbosity level" type="string" value="none"/>
     </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="particle_density">
@@ -222,7 +218,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -250,7 +246,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+03"/>
+                <Parameter name="value" type="double" value="1000.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -338,20 +334,24 @@
         <Parameter name="evaluator type" type="string" value="independent variable constant"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -410,7 +410,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/energy/test/energy_convergence_src.xml
+++ b/src/pks/energy/test/energy_convergence_src.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="3"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -16,13 +14,11 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
+  </ParameterList>
 
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>
-
-  
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -33,55 +29,56 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  1.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
         <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-       <Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="energy evaluator">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="ALL">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="ALL">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.0"/>
@@ -91,15 +88,15 @@
             <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="4.0"/>
             <Parameter name="reference temperature" type="double" value="1.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="conductivity">
+        <Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="conductivity">
             <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
             <Parameter name="upwind frequency" type="string" value="every timestep"/>
             <ParameterList name="upwind parameters">
@@ -109,93 +106,89 @@
               <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
             </ParameterList>
           </ParameterList>
-          
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="advection operator">
           <Parameter name="schema" type="Array(string)" value="{cell}"/>
           <Parameter name="method order" type="int" value="0"/>
           <Parameter name="matrix type" type="string" value="advection"/>
           <Parameter name="single domain" type="Array(string)" value="{domain}"/>
-        </ParameterList>          
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-7"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="high"/>
-	    </ParameterList>
-	  </ParameterList>
-
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1e-7"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
+        <ParameterList name="temperature">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
               <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="2"/>
                 <Parameter name="formula" type="string" value="x^2"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="energy flux">
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward energy flux">
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="energy flux">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward energy flux">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="-12.0"/>
-              </ParameterList>                            
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -205,7 +198,7 @@
         <ParameterList name="_SRC 0">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="source">            
+          <ParameterList name="source">
             <ParameterList name="function-exprtk">
               <Parameter name="number of arguments" type="int" value="2"/>
               <Parameter name="formula" type="string" value="-8.0 + 2 * x"/>
@@ -213,7 +206,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -233,7 +228,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -246,7 +240,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
@@ -259,7 +252,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -287,7 +280,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.00000000000000000e+03"/>
+                <Parameter name="value" type="double" value="1000.00000000000000"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -375,20 +368,24 @@
         <Parameter name="evaluator type" type="string" value="independent variable constant"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -398,10 +395,11 @@
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
-            </ParameterList>              
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="molar_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -425,7 +423,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/energy/test/energy_jacobian.xml
+++ b/src/pks/energy/test/energy_jacobian.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="3"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -16,26 +14,26 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  1.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
         <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -45,125 +43,124 @@
       <Parameter name="PK type" type="string" value="one phase"/>
     </ParameterList>
   </ParameterList>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-       <Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="energy evaluator">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="true"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="true"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="2.0"/>
-	    <Parameter name="reference temperature" type="double" value="273.15"/>
+            <Parameter name="reference temperature" type="double" value="273.15"/>
           </ParameterList>
           <ParameterList name="liquid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
-	    <Parameter name="reference temperature" type="double" value="273.15"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="reference temperature" type="double" value="273.15"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="advection operator">
           <Parameter name="schema" type="Array(string)" value="{cell}"/>
           <Parameter name="method order" type="int" value="0"/>
           <Parameter name="matrix type" type="string" value="advection"/>
           <Parameter name="single domain" type="Array(string)" value="{domain}"/>
-        </ParameterList>          
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-5"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="none"/>
-	    </ParameterList>
-	  </ParameterList>
-
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="3"/>
-                 <Parameter name="formula" type="string" value="315 + 10 * x + 20 * y"/>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="3"/>
+                <Parameter name="formula" type="string" value="315 + 10 * x + 20 * y"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -183,7 +180,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -196,7 +192,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
@@ -209,13 +204,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="molar density key" type="string" value="molar_density_liquid"/>
@@ -227,7 +221,6 @@
         <Parameter name="eos basis" type="string" value="both"/>
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
       </ParameterList>
-
       <!-- setting it to one, removes rock conductivity from the test -->
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -290,7 +283,6 @@
       <ParameterList name="molar_flow_rate">
         <Parameter name="evaluator type" type="string" value="independent variable constant"/>
       </ParameterList>
-
       <ParameterList name="pressure">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -298,7 +290,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-	      <ParameterList name="function-exprtk">
+              <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="3"/>
                 <Parameter name="formula" type="string" value="201325.0 - 51000 * x * y"/>
               </ParameterList>
@@ -307,29 +299,33 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="*"/>
             <ParameterList name="function">
-	      <ParameterList name="function-exprtk">
-                 <Parameter name="number of arguments" type="int" value="3"/>
-                 <Parameter name="formula" type="string" value="315 + 10 * x + 20 * y"/>
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="3"/>
+                <Parameter name="formula" type="string" value="315 + 10 * x + 20 * y"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -346,7 +342,7 @@
               <Parameter name="number of dofs" type="int" value="2"/>
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
-	        <ParameterList name="function-exprtk">
+                <ParameterList name="function-exprtk">
                   <Parameter name="number of arguments" type="int" value="3"/>
                   <Parameter name="formula" type="string" value="100 + 10 * x - 8 * y"/>
                 </ParameterList>
@@ -360,10 +356,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/energy/test/energy_matrix_2D.xml
+++ b/src/pks/energy/test/energy_matrix_2D.xml
@@ -1,131 +1,135 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- ENERGY -->
   <ParameterList name="PKs">
+
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="energy evaluator">
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="extreme"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="extreme"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="enthalpy evaluator">
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="extreme"/>
-	</ParameterList>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="extreme"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="thermal conductivity parameters">
-	  <ParameterList name="TCM_0">
-	    <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-	    <Parameter name="thermal conductivity of rock" type="double" value="0.2"/>
-	    <Parameter name="thermal conductivity of liquid" type="double" value="0.1"/>
-	    <Parameter name="thermal conductivity of gas" type="double" value="0.02"/>
-	    <Parameter name="unsaturated alpha" type="double" value="1.0"/>
-	    <Parameter name="epsilon" type="double" value="1.e-10"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="thermal conductivity parameters">
+          <ParameterList name="TCM_0">
+            <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
+            <Parameter name="thermal conductivity of rock" type="double" value="0.2"/>
+            <Parameter name="thermal conductivity of liquid" type="double" value="0.1"/>
+            <Parameter name="thermal conductivity of gas" type="double" value="0.02"/>
+            <Parameter name="unsaturated alpha" type="double" value="1.0"/>
+            <Parameter name="epsilon" type="double" value="1e-10"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="advection operator">
-	  <Parameter name="discretization primary" type="string" value="upwind"/>
-	  <!--Parameter name="reconstruction order" type="int" value="0"/-->
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <!--Parameter name="reconstruction order" type="int" value="0"/-->
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="energy flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward energy flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="273.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="energy flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward energy flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="273.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- STATE -->
@@ -148,7 +152,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -166,7 +169,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="pressure">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -184,7 +186,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -192,8 +193,9 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -202,7 +204,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_liquid"/>
@@ -219,7 +220,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_rock">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_rock"/>
@@ -236,7 +236,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_gas">
         <Parameter name="evaluator type" type="string" value="iem water vapor"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_gas"/>
@@ -244,7 +243,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -252,14 +250,13 @@
         <Parameter name="mass density key" type="string" value="mass_density_liquid"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="liquid water 0-30C"/>
-          <Parameter name="molar mass" type="double" value="18.0153e-03"/>
+          <Parameter name="molar mass" type="double" value="0.0180153"/>
           <Parameter name="density" type="double" value="997.0"/>
         </ParameterList>
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -268,7 +265,7 @@
           <Parameter name="eos type" type="string" value="vapor in gas"/>
           <ParameterList name="EOS parameters">
             <Parameter name="eos type" type="string" value="ideal gas"/>
-            <Parameter name="molar mass" type="double" value="28.9647e-03"/>
+            <Parameter name="molar mass" type="double" value="0.0289647"/>
             <Parameter name="density" type="double" value="1.0"/>
           </ParameterList>
         </ParameterList>
@@ -276,7 +273,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_fraction_gas">
         <Parameter name="evaluator type" type="string" value="molar fraction gas"/>
         <Parameter name="molar fraction key" type="string" value="molar_fraction_gas"/>
@@ -287,7 +283,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_flow_rate">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -303,11 +298,12 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -343,9 +339,9 @@
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
@@ -370,20 +366,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
-   <ParameterList name="Hypre AMG">
+    <ParameterList name="Hypre AMG">
       <Parameter name="discretization method" type="string" value="optimized mfd"/>
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="verbosity" type="int" value="3"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/energy/test/energy_newton_picard.xml
+++ b/src/pks/energy/test/energy_newton_picard.xml
@@ -1,18 +1,17 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{3.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{3.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -20,34 +19,30 @@
   <!--  OPERATORS  -->
   <ParameterList name="PK operator">
     <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
     <ParameterList name="diffusion operator NKA">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="Newton correction" type="string" value="none"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator Newton-Picard">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
     </ParameterList>
-
     <ParameterList name="diffusion operator JFNK">
       <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
       <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-      <Parameter name="schema" type="Array(string)" value="{cell,face}"/>
+      <Parameter name="schema" type="Array(string)" value="{cell, face}"/>
       <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
       <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
       <Parameter name="Newton correction" type="string" value="none"/>
     </ParameterList>
-
     <ParameterList name="upwind">
       <Parameter name="upwind method" type="string" value="standard"/>
       <ParameterList name="upwind parameters">
@@ -55,13 +50,12 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Newton-Picard">
     <Parameter name="solver type" type="string" value="Newton"/>
     <ParameterList name="Newton parameters">
       <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
       <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-      <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+      <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
       <Parameter name="max divergent iterations" type="int" value="3"/>
       <Parameter name="max nka vectors" type="int" value="10"/>
       <Parameter name="limit iterations" type="int" value="20"/>
@@ -71,13 +65,12 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="NKA">
     <Parameter name="solver type" type="string" value="nka"/>
     <ParameterList name="nka parameters">
       <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
       <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-      <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+      <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
       <Parameter name="max divergent iterations" type="int" value="3"/>
       <Parameter name="max nka vectors" type="int" value="10"/>
       <Parameter name="limit iterations" type="int" value="20"/>
@@ -87,7 +80,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="JFNK">
     <Parameter name="solver type" type="string" value="JFNK"/>
     <ParameterList name="JFNK parameters">
@@ -96,7 +88,7 @@
         <Parameter name="solver type" type="string" value="Newton"/>
         <ParameterList name="Newton parameters">
           <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+          <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
           <Parameter name="max divergent iterations" type="int" value="3"/>
           <Parameter name="max nka vectors" type="int" value="10"/>
           <Parameter name="limit iterations" type="int" value="20"/>
@@ -106,7 +98,7 @@
         </ParameterList>
       </ParameterList>
       <ParameterList name="JF matrix parameters">
-        <Parameter name="finite difference epsilon" type="double" value="1.0e-08"/>
+        <Parameter name="finite difference epsilon" type="double" value="1.0e-8"/>
         <Parameter name="method for epsilon" type="string" value="Knoll-Keyes"/>
       </ParameterList>
       <ParameterList name="linear operator">
@@ -118,15 +110,14 @@
         </ParameterList>
       </ParameterList>
       <Parameter name="limit iterations" type="int" value="20"/>
-      <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+      <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
       <Parameter name="max divergent iterations" type="int" value="3"/>
-      <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+      <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="AztecOO CG">
@@ -150,7 +141,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -163,10 +153,9 @@
         <Parameter name="relaxation type down" type="int" value="13"/>
         <Parameter name="relaxation type up" type="int" value="14"/>
         <Parameter name="coarsen type" type="int" value="0"/>
-        <Parameter name="tolerance" type="double" value="0"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/energy/test/energy_one_phase.xml
+++ b/src/pks/energy/test/energy_one_phase.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="3"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -16,26 +14,26 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  1.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
         <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -45,32 +43,32 @@
       <Parameter name="PK type" type="string" value="one phase"/>
     </ParameterList>
   </ParameterList>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="energy">
       <ParameterList name="verbose object">
-       <Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="energy evaluator">
-	<Parameter name="vapor diffusion" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="vapor diffusion" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="enthalpy evaluator">
-	<Parameter name="include work term" type="bool" value="false"/>
-	<ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
-	</ParameterList>
+        <Parameter name="include work term" type="bool" value="false"/>
+        <ParameterList name="verbose object">
+          <Parameter name="verbosity level" type="string" value="high"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="thermal conductivity evaluator">
-	<ParameterList name="All">
-	  <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
+        <ParameterList name="All">
+          <Parameter name="thermal conductivity type" type="string" value="one-phase polynomial"/>
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
           <ParameterList name="solid phase">
             <Parameter name="eos type" type="string" value="constant"/>
             <Parameter name="reference conductivity" type="double" value="0.2"/>
@@ -80,90 +78,89 @@
             <Parameter name="eos type" type="string" value="liquid water"/>
             <Parameter name="reference conductivity" type="double" value="2.0"/>
             <Parameter name="reference temperature" type="double" value="1.0"/>
-	    <Parameter name="polynomial expansion" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
-	  </ParameterList>
-	</ParameterList>
+            <Parameter name="polynomial expansion" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="include enthalpy in preconditioner" type="bool" value="true"/>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="advection operator">
           <Parameter name="schema" type="Array(string)" value="{cell}"/>
           <Parameter name="method order" type="int" value="0"/>
           <Parameter name="matrix type" type="string" value="advection"/>
           <Parameter name="single domain" type="Array(string)" value="{domain}"/>
-        </ParameterList>          
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{temperature}"/>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-5"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="none"/>
-	    </ParameterList>
-	  </ParameterList>
-
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{temperature}"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="temperature">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary temperature">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.5"/>
+        <ParameterList name="temperature">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary temperature">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.5"/>
               </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -183,7 +180,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -196,7 +192,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
@@ -209,7 +204,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2500."/>
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -325,20 +320,24 @@
         <Parameter name="evaluator type" type="string" value="independent variable constant"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -400,10 +399,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_1well_peaceman_3D.xml
+++ b/src/pks/flow/test/flow_darcy_1well_peaceman_3D.xml
@@ -1,41 +1,40 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="extreme"/>
+        <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: two-point flux approximation"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: two-point flux approximation"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
@@ -49,7 +48,7 @@
               <Parameter name="well radius" type="double" value="0.1"/>
               <ParameterList name="bhp">
                 <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="10.0"/>
+                  <Parameter name="value" type="double" value="10.0"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -79,22 +78,22 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Right side, Left side, Back side, Front side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <!--ParameterList name="static head"> 
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Right side, Left side, Back side, Front side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <!--ParameterList name="static head"> 
 	      <ParameterList name="function-static-head">
 		<Parameter name="p0" type="double" value="0.0"/>
 		<Parameter name="density" type="double" value="1.0"/>
@@ -107,71 +106,67 @@
 		</ParameterList>
 	      </ParameterList> 
 	    </ParameterList-->
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-additive">
-		
-		<ParameterList name="function1">
-		  <ParameterList name="function-linear">
-		    <Parameter name="y0" type="double" value="10.0"/>
-		    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0,  0.0, -1.0}"/>
-		    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, -2.5}"/>
-		  </ParameterList>
-		</ParameterList>
-
-		<ParameterList name="function2">
-		  <ParameterList name="function-multiplicative">
-
-		    <ParameterList name="function1">
-		      <ParameterList name="function-constant">
-			<Parameter name="value" type="double" value="-0.318309886183791"/>
-			<!--Parameter name="value" type="double" value="-1.59154943091895"/-->
-			<!--Parameter name="value" type="double" value="-6.36619772367581"/-->
-			<!--Parameter name="value" type="double" value="-7.957747155"/-->
-		      </ParameterList>
-		    </ParameterList>
-		    
-		    <ParameterList name="function2">
-		      <ParameterList name="function-additive">
-
-			<ParameterList name="function1">
-			  <ParameterList name="function-composition">
-			    <ParameterList name="function1">
-			      <ParameterList name="function-standard-math">
-				<Parameter name="operator" type="string" value="log"/>
-			      </ParameterList>
-			    </ParameterList>
-			    <ParameterList name="function2">
-			      <ParameterList name="function-distance">
-				<Parameter name="x0" type="Array(double)" value="{0., 0., 0.}"/>
-				<Parameter name="metric" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
-			      </ParameterList>
-			    </ParameterList>
-			  </ParameterList>
-			</ParameterList>
-			
-			<ParameterList name="function2">
-			  <ParameterList name="function-constant">
-			    <Parameter name="value" type="double" value="2.302585093"/>
-			  </ParameterList>
-			</ParameterList>
-		      </ParameterList>
-		    </ParameterList>
-		  </ParameterList>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-additive">
+                <ParameterList name="function1">
+                  <ParameterList name="function-linear">
+                    <Parameter name="y0" type="double" value="10.0"/>
+                    <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, 0.0, -1.0}"/>
+                    <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0, -2.5}"/>
+                  </ParameterList>
+                </ParameterList>
+                <ParameterList name="function2">
+                  <ParameterList name="function-multiplicative">
+                    <ParameterList name="function1">
+                      <ParameterList name="function-constant">
+                        <Parameter name="value" type="double" value="-0.318309886183791"/>
+                        <!--Parameter name="value" type="double" value="-1.59154943091895"/-->
+                        <!--Parameter name="value" type="double" value="-6.36619772367581"/-->
+                        <!--Parameter name="value" type="double" value="-7.957747155"/-->
+                      </ParameterList>
+                    </ParameterList>
+                    <ParameterList name="function2">
+                      <ParameterList name="function-additive">
+                        <ParameterList name="function1">
+                          <ParameterList name="function-composition">
+                            <ParameterList name="function1">
+                              <ParameterList name="function-standard-math">
+                                <Parameter name="operator" type="string" value="log"/>
+                              </ParameterList>
+                            </ParameterList>
+                            <ParameterList name="function2">
+                              <ParameterList name="function-distance">
+                                <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+                                <Parameter name="metric" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
+                              </ParameterList>
+                            </ParameterList>
+                          </ParameterList>
+                        </ParameterList>
+                        <ParameterList name="function2">
+                          <ParameterList name="function-constant">
+                            <Parameter name="value" type="double" value="2.302585093"/>
+                          </ParameterList>
+                        </ParameterList>
+                      </ParameterList>
+                    </ParameterList>
+                  </ParameterList>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -208,23 +203,26 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -235,17 +233,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: two-point flux approximation"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -253,57 +250,55 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-55,-55.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{55, 55.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-55.0, -55.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{55.0, 55.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WellCenter">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -1,-1,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1, 1, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-1.0, -1.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-55.0,-55.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-55.0, -55.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{55.0,55.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{55.0, 55.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-55.0,-55.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-55.0, -55.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{55.0,55.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{55.0, 55.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-0.,-0.,-2.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{ 0.0, 0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-0.0, -0.0, -2.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_dual2D.xml
+++ b/src/pks/flow/test/flow_darcy_dual2D.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- MESH -->
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
@@ -12,114 +11,116 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
+  </ParameterList>
 
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="medium"/>
+        <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="linear solver" type="string" value="AztecOO CG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="1.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="linear solver" type="string" value="AztecOO CG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="1.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -127,7 +128,7 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -135,7 +136,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -150,7 +150,7 @@
           </ParameterList>
         </ParameterList>
         <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="extreme" />
+          <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="saturation_liquid">
@@ -168,37 +168,39 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
-   <!-- SOLVERS -->
-   <ParameterList name="solvers">
-     <ParameterList name="AztecOO CG">
-       <Parameter name="iterative method" type="string" value="gmres"/>
-       <ParameterList name="gmres parameters">
-         <Parameter name="error tolerance" type="double" value="1e-12"/>
-         <Parameter name="maximum number of iterations" type="int" value="400"/>
-       </ParameterList>
-     </ParameterList>
-   </ParameterList>
-
+  <!-- SOLVERS -->
+  <ParameterList name="solvers">
+    <ParameterList name="AztecOO CG">
+      <Parameter name="iterative method" type="string" value="gmres"/>
+      <ParameterList name="gmres parameters">
+        <Parameter name="error tolerance" type="double" value="1e-12"/>
+        <Parameter name="maximum number of iterations" type="int" value="400"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -207,7 +209,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -216,7 +218,7 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
@@ -224,4 +226,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_fractures.xml
+++ b/src/pks/flow/test/flow_darcy_fractures.xml
@@ -1,40 +1,41 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <Parameter name="domain name" type="string" value="domain"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -48,30 +49,29 @@
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
@@ -91,14 +91,16 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -120,7 +122,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="compliance">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -135,7 +136,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -153,7 +153,6 @@
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -169,33 +168,36 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -0.001}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -203,7 +205,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -214,9 +215,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_fractures_source.xml
+++ b/src/pks/flow/test/flow_darcy_fractures_source.xml
@@ -1,28 +1,29 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <Parameter name="domain name" type="string" value="fracture"/>
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -31,35 +32,34 @@
         <ParameterList name="FPM for Entire Domain">
           <Parameter name="region" type="string" value="All"/>
           <Parameter name="model" type="string" value="constant"/>
-          <Parameter name="value" type="double" value="1e-6"/>
+          <Parameter name="value" type="double" value="0.000001"/>
           <Parameter name="aperture" type="double" value="0.01"/>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
@@ -74,20 +74,22 @@
             <Parameter name="use volume fractions" type="bool" value="false"/>
             <ParameterList name="well">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="8.0e-2"/>
+                <Parameter name="value" type="double" value="0.080"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="fracture-specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -113,7 +115,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-compliance">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -128,7 +129,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -143,7 +143,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="fracture-saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -159,17 +158,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
       </ParameterList>
@@ -187,9 +189,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -206,7 +208,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -219,4 +220,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_misc.xml
+++ b/src/pks/flow/test/flow_darcy_misc.xml
@@ -1,6 +1,5 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- MESH -->
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
@@ -12,114 +11,116 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,1.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 1.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="medium"/>
+        <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="1.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="1.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left, Right, Front, Back}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-		<Parameter name="x values" type="Array(double)" value="{0, 7.884e+06}"/>
-		<Parameter name="y values" type="Array(double)" value="{0.0, 0.0}"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <!-- Will be populated by the code -->
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left, Right, Front, Back}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+                <Parameter name="x values" type="Array(double)" value="{0.0, 7.884e+6}"/>
+                <Parameter name="y values" type="Array(double)" value="{0.0, 0.0}"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="static head">
+        </ParameterList>
+        <ParameterList name="pressure">
+          <!-- Will be populated by the code -->
+        </ParameterList>
+        <ParameterList name="static head">
           <!-- Will be populated by the code -->
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -132,7 +133,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -141,7 +141,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -150,20 +150,19 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -192,29 +191,33 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="1."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="2.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.3"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -2.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
@@ -225,8 +228,9 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -239,22 +243,24 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="1."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
+
       <ParameterList name="specific_yield">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -295,8 +301,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="face"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -305,10 +311,4 @@
 
     </ParameterList>
   </ParameterList>
-
-
 </ParameterList>
-
-
-
-

--- a/src/pks/flow/test/flow_darcy_source.xml
+++ b/src/pks/flow/test/flow_darcy_source.xml
@@ -1,47 +1,46 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.1"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="0.6"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.1"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="0.6"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="fields">
-	  <ParameterList name="SRC 0">
+          <ParameterList name="SRC 0">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="spatial distribution method" type="string" value="field"/>
             <ParameterList name="field">
@@ -54,27 +53,29 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -128,26 +129,29 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -1.0e-20}"/>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -158,17 +162,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -176,39 +179,37 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-10,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10,5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_transient_2D.xml
+++ b/src/pks/flow/test/flow_darcy_transient_2D.xml
@@ -1,113 +1,111 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-2.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -2.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="linear solver" type="string" value="GMRES with ML"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="max timestep" type="double" value="1e+9"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="linear solver" type="string" value="GMRES with ML"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="max timestep" type="double" value="1e+9"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
@@ -125,7 +123,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -133,7 +133,7 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -141,7 +141,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -171,20 +170,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -198,9 +201,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES with ML">
@@ -211,7 +214,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -220,7 +222,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -229,12 +231,11 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
       </ParameterList>
     </ParameterList>
-        <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
+    <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_transient_3D.xml
+++ b/src/pks/flow/test/flow_darcy_transient_3D.xml
@@ -1,120 +1,118 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,2.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 2.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,2.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 2.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,2.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 2.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  0.0,0.0,-1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 1.0,0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,2.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 2.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 1.0,0.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,2.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 2.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.5,0.0,-2.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, -2.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.5,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="linear solver" type="string" value="AztecOO CG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="1.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="linear solver" type="string" value="AztecOO CG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="1.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-            <ParameterList name="BC 2">
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
             <Parameter name="regions" type="Array(string)" value="{Bottom side, Right side Bottom}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
@@ -125,7 +123,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -133,7 +133,7 @@
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -171,6 +171,7 @@
       </ParameterList>
     </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -184,6 +185,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -211,32 +213,35 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
-   <!-- SOLVERS -->
-   <ParameterList name="solvers">
-     <ParameterList name="AztecOO CG">
-       <Parameter name="iterative method" type="string" value="gmres"/>
-       <ParameterList name="gmres parameters">
-         <Parameter name="maximum number of iterations" type="int" value="400"/>
-         <Parameter name="error tolerance" type="double" value="1e-12"/>
-       </ParameterList>
-     </ParameterList>
-   </ParameterList>
-
+  <!-- SOLVERS -->
+  <ParameterList name="solvers">
+    <ParameterList name="AztecOO CG">
+      <Parameter name="iterative method" type="string" value="gmres"/>
+      <ParameterList name="gmres parameters">
+        <Parameter name="maximum number of iterations" type="int" value="400"/>
+        <Parameter name="error tolerance" type="double" value="1e-12"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -245,7 +250,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -254,12 +259,11 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
       </ParameterList>
     </ParameterList>
-        <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
+    <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_well.xml
+++ b/src/pks/flow/test/flow_darcy_well.xml
@@ -1,47 +1,46 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.1"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="0.6"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.1"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="0.6"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="wells">
-	  <ParameterList name="SRC 0">
+          <ParameterList name="SRC 0">
             <Parameter name="regions" type="Array(string)" value="{WellLeft}"/>
             <Parameter name="spatial distribution method" type="string" value="volume"/>
             <ParameterList name="well">
@@ -64,46 +63,48 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="static head">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="0.0"/>
-		<Parameter name="density" type="double" value="1.0"/>
-		<Parameter name="gravity" type="double" value="1.0"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="0.0"/>
+                <Parameter name="density" type="double" value="1.0"/>
+                <Parameter name="gravity" type="double" value="1.0"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -140,23 +141,26 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -167,17 +171,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -185,18 +188,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-10,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10,5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WellLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -3.8,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-3.8, -5.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{-3.6, 0.0}"/>
       </ParameterList>
     </ParameterList>
@@ -221,28 +223,27 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_well_3D.xml
+++ b/src/pks/flow/test/flow_darcy_well_3D.xml
@@ -1,41 +1,40 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="1.0"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="1.0"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
@@ -63,49 +62,49 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="static head">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="0.0"/>
-		<Parameter name="density" type="double" value="1.0"/>
-		<Parameter name="gravity" type="double" value="1.0"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="relative to top" type="bool" value="false"/>
-	    <Parameter name="relative to bottom" type="bool" value="true"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="0.0"/>
-		<Parameter name="density" type="double" value="1.0"/>
-		<Parameter name="gravity" type="double" value="1.0"/>
-		<Parameter name="space dimension" type="int" value="3"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="6.0"/>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="0.0"/>
+                <Parameter name="density" type="double" value="1.0"/>
+                <Parameter name="gravity" type="double" value="1.0"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="relative to top" type="bool" value="false"/>
+            <Parameter name="relative to bottom" type="bool" value="true"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="0.0"/>
+                <Parameter name="density" type="double" value="1.0"/>
+                <Parameter name="gravity" type="double" value="1.0"/>
+                <Parameter name="space dimension" type="int" value="3"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="6.0"/>
                   </ParameterList>
                 </ParameterList>
               </ParameterList>
@@ -113,15 +112,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -158,23 +159,26 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -185,17 +189,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -203,18 +206,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-10,-1.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10, 1.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0, -1.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WellLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -3.8,-0.1,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-3.8, -0.1, -5.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{-3.6, 0.1, 0.0}"/>
       </ParameterList>
     </ParameterList>
@@ -228,35 +230,32 @@
       <ParameterList name="region: box volume fractions">
         <Parameter name="corner coordinate" type="Array(double)" value="{3.7, -0.1, -5.0}"/>
         <Parameter name="opposite corner coordinate" type="Array(double)" value="{5.7, 0.1, 0.0}"/>
-        <Parameter name="normals" type="Array(double)" value="{2.0,  0.0, 4.95, 
-                                                               0.0,  1.0, 0.0,
-                                                              -4.95, 0.0, 2.0}"/> 
+        <Parameter name="normals" type="Array(double)" value="{2.0, 0.0, 4.95, 0.0, 1.0, 0.0, -4.95, 0.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-1.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -1.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{10.0,-1.0,-5.0}"/>
+        <Parameter name="point" type="Array(double)" value="{10.0, -1.0, -5.0}"/>
         <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{ 0.0, 0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0,-1.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_well_adaptive.xml
+++ b/src/pks/flow/test/flow_darcy_well_adaptive.xml
@@ -1,44 +1,43 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="adaptive"/>
-	  <ParameterList name="timestep controller adaptive parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="10.0"/>
-	    <Parameter name="reference value" type="double" value="1.0"/>
-	    <Parameter name="relative tolerance" type="double" value="0.1"/>
-	    <Parameter name="absolute tolerance" type="double" value="0.1"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="adaptive"/>
+          <ParameterList name="timestep controller adaptive parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="10.0"/>
+            <Parameter name="reference value" type="double" value="1.0"/>
+            <Parameter name="relative tolerance" type="double" value="0.1"/>
+            <Parameter name="absolute tolerance" type="double" value="0.1"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
@@ -66,46 +65,48 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="static head">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="0.0"/>
-		<Parameter name="density" type="double" value="1.0"/>
-		<Parameter name="gravity" type="double" value="1.0"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="0.0"/>
+                <Parameter name="density" type="double" value="1.0"/>
+                <Parameter name="gravity" type="double" value="1.0"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -142,23 +143,26 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -169,17 +173,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -187,18 +190,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-10,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10,5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WellLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -3.8,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-3.8, -5.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{-3.6, 0.0}"/>
       </ParameterList>
     </ParameterList>
@@ -223,28 +225,27 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_darcy_well_fromfile.xml
+++ b/src/pks/flow/test/flow_darcy_well_fromfile.xml
@@ -1,41 +1,40 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.1"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="max timestep" type="double" value="0.6"/>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.1"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="max timestep" type="double" value="0.6"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="source terms">
@@ -63,46 +62,48 @@
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="static head">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="0.0"/>
-		<Parameter name="density" type="double" value="1.0"/>
-		<Parameter name="gravity" type="double" value="1.0"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="1.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side, Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="0.0"/>
+                <Parameter name="density" type="double" value="1.0"/>
+                <Parameter name="gravity" type="double" value="1.0"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="1.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
-    
+
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="specific_storage">
         <Parameter name="evaluator type" type="string" value="specific storage"/>
-	<ParameterList name="specific storage parameters">
+        <ParameterList name="specific storage parameters">
           <ParameterList name="Material 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="model" type="string" value="constant"/>
@@ -139,27 +140,31 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <Parameter name="restart file" type="string" value="test/perm.h5"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -170,17 +175,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -188,18 +192,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-10,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10,5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="WellLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ -3.8,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-3.8, -5.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{-3.6, 0.0}"/>
       </ParameterList>
     </ParameterList>
@@ -224,28 +227,27 @@
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{-10.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{-10.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_multiscale.xml
+++ b/src/pks/flow/test/flow_multiscale.xml
@@ -3,12 +3,11 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98,  9.9e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom Surface">
@@ -113,30 +112,35 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -144,12 +148,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -197,7 +202,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0706e-09"/>
+                  <Parameter name="value" type="double" value="2.0706e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -209,6 +214,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -216,14 +222,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -237,6 +244,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -252,230 +260,234 @@
             <Parameter name="PK type" type="string" value="richards"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.0e+00"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="6.172666560e+10"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+04"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: amanzi"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="9.99e-5"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="0.0000999"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for RegionMiddle">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.294e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionBottom">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.026e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionTop">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-	  <Parameter name="van Genuchten m" type="double" value="3.006e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.0674e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
+        <ParameterList name="WRM for RegionMiddle">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2294"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionBottom">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.002026"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionTop">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.3006"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.0020674"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="multiscale models">
-	<ParameterList name="MSM for RegionMiddle">
-	  <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-	  <Parameter name="multiscale model" type="string" value="dual porosity"/>
-	  <ParameterList name="dual porosity parameters">
-	    <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
-	    <Parameter name="tolerance" type="double" value="1.0e-9"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.294e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="5.9467e-04"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.08199999999999996e-01"/>
-	</ParameterList>
-	<ParameterList name="MSM for RegionBottom">
-	  <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-	  <Parameter name="multiscale model" type="string" value="dual porosity"/>
-	  <ParameterList name="dual porosity parameters">
-	    <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
-	    <Parameter name="tolerance" type="double" value="1.0e-9"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.026e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.20599999999999991e-01"/>
-	</ParameterList>
-	<ParameterList name="MSM for RegionTop">
-	  <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-	  <Parameter name="multiscale model" type="string" value="dual porosity"/>
-	  <ParameterList name="dual porosity parameters">
-	    <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
-	    <Parameter name="tolerance" type="double" value="1.0e-9"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="3.006e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.0674e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.34000000000000014e-01"/>
-	</ParameterList>
+        <ParameterList name="MSM for RegionMiddle">
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="multiscale model" type="string" value="dual porosity"/>
+          <ParameterList name="dual porosity parameters">
+            <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
+            <Parameter name="tolerance" type="double" value="1.0e-9"/>
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2294"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00059467"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.208199999999999996"/>
+        </ParameterList>
+        <ParameterList name="MSM for RegionBottom">
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="multiscale model" type="string" value="dual porosity"/>
+          <ParameterList name="dual porosity parameters">
+            <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
+            <Parameter name="tolerance" type="double" value="1.0e-9"/>
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.002026"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.220599999999999991"/>
+        </ParameterList>
+        <ParameterList name="MSM for RegionTop">
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="multiscale model" type="string" value="dual porosity"/>
+          <ParameterList name="dual porosity parameters">
+            <Parameter name="mass transfer coefficient" type="double" value="1.0e-9"/>
+            <Parameter name="tolerance" type="double" value="1.0e-9"/>
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.3006"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.0020674"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.234000000000000014"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
-	<Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
+        <Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="preconditioner enhancement" type="string" value="none"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-	    <Parameter name="min timestep" type="double" value="9.99e-20"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="preconditioner enhancement" type="string" value="none"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.32340e+17"/>
+            <Parameter name="min timestep" type="double" value="9.99e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="9.982e+2"/>
-		<Parameter name="gravity" type="double" value="9.80665"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="0.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="relative to top" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.17e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.105e-07, -1.105e-07}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.80665"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="0.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="relative to top" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.17e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.105e-7, -1.105e-7}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -500,15 +512,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>

--- a/src/pks/flow/test/flow_multiscale_gdpm.xml
+++ b/src/pks/flow/test/flow_multiscale_gdpm.xml
@@ -3,12 +3,11 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
         <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98,  9.9e+98}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom Surface">
@@ -113,30 +112,35 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.002e-03"/>
+                <Parameter name="value" type="double" value="0.001002"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.80665}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.002e-03"/>
+        <Parameter name="value" type="double" value="0.001002"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325e+05"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -144,12 +148,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.982e+02"/>
+                <Parameter name="value" type="double" value="998.2"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="permeability">
         <Parameter name="write checkpoint" type="bool" value="false"/>
         <ParameterList name="function">
@@ -197,7 +202,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="2.0706e-09"/>
+                  <Parameter name="value" type="double" value="2.0706e-9"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -209,6 +214,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -216,14 +222,15 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-linear">
-                <Parameter name="y0" type="double" value="1.01325e+05"/>
+                <Parameter name="y0" type="double" value="101325.0"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
-                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9.7935192e+03}"/>
+                <Parameter name="gradient" type="Array(double)" value="{0.0, 0.0, -9793.5192}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -237,6 +244,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
@@ -252,238 +260,241 @@
             <Parameter name="PK type" type="string" value="richards"/>
           </ParameterList>
         </ParameterList>
-        <Parameter name="start period time" type="double" value="0.0e+00"/>
+        <Parameter name="start period time" type="double" value="0.0"/>
         <Parameter name="end period time" type="double" value="6.172666560e+10"/>
-        <Parameter name="initial timestep" type="double" value="1.0e+04"/>
+        <Parameter name="initial timestep" type="double" value="1.0e+4"/>
       </ParameterList>
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{}"/>
   </ParameterList>
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: amanzi"/>
-	<Parameter name="upwind frequency" type="string" value="every timestep"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="9.99e-5"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: amanzi"/>
+        <Parameter name="upwind frequency" type="string" value="every timestep"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="0.0000999"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for RegionMiddle">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.294e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="5.0e-01"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.9467e-04"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionBottom">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.026e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="0.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for RegionTop">
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-	  <Parameter name="van Genuchten m" type="double" value="3.006e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.0674e-03"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
+        <ParameterList name="WRM for RegionMiddle">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2294"/>
+          <Parameter name="van Genuchten l" type="double" value="0.50"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00019467"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionBottom">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.002026"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for RegionTop">
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="van Genuchten m" type="double" value="0.3006"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.0020674"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="multiscale models">
-	<ParameterList name="MSM for RegionMiddle">
-	  <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
-	  <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
-	  <ParameterList name="generalized dual porosity parameters">
+        <ParameterList name="MSM for RegionMiddle">
+          <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
+          <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
+          <ParameterList name="generalized dual porosity parameters">
             <Parameter name="number of matrix nodes" type="int" value="4"/>
-            <Parameter name="matrix depth" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.99900000000000011e-01"/>
+            <Parameter name="matrix depth" type="double" value="0.800000000000000044"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.999900000000000011"/>
             <Parameter name="absolute permeability" type="double" value="9.99999999999999979e-17"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.294e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="5.9467e-05"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.08199999999999996e-01"/>
-	</ParameterList>
-	<ParameterList name="MSM for RegionBottom">
-	  <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
-	  <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
-	  <ParameterList name="generalized dual porosity parameters">
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2294"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000059467"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.208199999999999996"/>
+        </ParameterList>
+        <ParameterList name="MSM for RegionBottom">
+          <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
+          <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
+          <ParameterList name="generalized dual porosity parameters">
             <Parameter name="number of matrix nodes" type="int" value="4"/>
-            <Parameter name="matrix depth" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.99900000000000011e-01"/>
+            <Parameter name="matrix depth" type="double" value="0.800000000000000044"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.999900000000000011"/>
             <Parameter name="absolute permeability" type="double" value="9.99999999999999979e-17"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="2.136e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.026e-05"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.20599999999999991e-01"/>
-	</ParameterList>
-	<ParameterList name="MSM for RegionTop">
-	  <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
-	  <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
-	  <ParameterList name="generalized dual porosity parameters">
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.2136"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00002026"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.220599999999999991"/>
+        </ParameterList>
+        <ParameterList name="MSM for RegionTop">
+          <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
+          <Parameter name="multiscale model" type="string" value="generalized dual porosity"/>
+          <ParameterList name="generalized dual porosity parameters">
             <Parameter name="number of matrix nodes" type="int" value="4"/>
-            <Parameter name="matrix depth" type="double" value="8.00000000000000044e-01"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.99900000000000011e-01"/>
+            <Parameter name="matrix depth" type="double" value="0.800000000000000044"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.999900000000000011"/>
             <Parameter name="absolute permeability" type="double" value="9.99999999999999979e-17"/>
-	  </ParameterList>
-
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten m" type="double" value="3.006e-01"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="2.0674e-05"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	  <Parameter name="regularization interval" type="double" value="100.0"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="2.34000000000000014e-01"/>
-	</ParameterList>
+          </ParameterList>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.3006"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000020674"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="regularization interval" type="double" value="100.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.234000000000000014"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
-	<Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
+        <Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
       </ParameterList>
+
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	  <ParameterList name="vapor matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	    <Parameter name="exclude primary terms" type="bool" value="false"/>
-	    <Parameter name="scaled constraint equation" type="bool" value="false"/>
-	    <Parameter name="Newton correction" type="string" value="none"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+          <ParameterList name="vapor matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+            <Parameter name="exclude primary terms" type="bool" value="false"/>
+            <Parameter name="scaled constraint equation" type="bool" value="false"/>
+            <Parameter name="Newton correction" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="time integrator">
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="preconditioner enhancement" type="string" value="none"/>
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="inflow krel correction" type="bool" value="true"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="min iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="4.32340e+17"/>
-	    <Parameter name="min timestep" type="double" value="9.99e-20"/>
-            <Parameter name="initial timestep" type="double" value="1.0e+04"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1.0e-07"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <ParameterList name="verbose object">
-	    <Parameter name="verbosity level" type="string" value="high"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="preconditioner enhancement" type="string" value="none"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="inflow krel correction" type="bool" value="true"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="4.32340e+17"/>
+            <Parameter name="min timestep" type="double" value="9.99e-20"/>
+            <Parameter name="initial timestep" type="double" value="1.0e+4"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="5"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
-	<ParameterList name="static head">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="9.982e+2"/>
-		<Parameter name="gravity" type="double" value="9.80665"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="0.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="relative to top" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-tabular">
-		<Parameter name="x values" type="Array(double)" value="{0.0, 6.17e+10}"/>
-		<Parameter name="y values" type="Array(double)" value="{-1.105e-07, -1.105e-07}"/>
-		<Parameter name="forms" type="Array(string)" value="{constant}"/>
-	      </ParameterList>
-	    </ParameterList>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Bottom Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.2"/>
+                <Parameter name="gravity" type="double" value="9.80665"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="0.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="relative to top" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top Surface}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-tabular">
+                <Parameter name="x values" type="Array(double)" value="{0.0, 6.17e+10}"/>
+                <Parameter name="y values" type="Array(double)" value="{-1.105e-7, -1.105e-7}"/>
+                <Parameter name="forms" type="Array(string)" value="{constant}"/>
+              </ParameterList>
+            </ParameterList>
+            <Parameter name="rainfall" type="bool" value="false"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="solvers">
@@ -508,15 +519,14 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.0e+00"/>
+        <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>

--- a/src/pks/flow/test/flow_richards_2D.xml
+++ b/src/pks/flow/test/flow_richards_2D.xml
@@ -1,193 +1,190 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-2.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -2.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
         <Parameter name="linear solver" type="string" value="none"/>
         <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
         <ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AmanziPCG"/>
-	  <Parameter name="clipping saturation value" type="double" value="0.6"/>
-	</ParameterList>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
-
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="max timestep" type="double" value="100.0"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="12"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="medium"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AmanziPCG"/>
+          <Parameter name="clipping saturation value" type="double" value="0.6"/>
+        </ParameterList>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="max timestep" type="double" value="100.0"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="12"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="medium"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
         <ParameterList name="verbose object">
-	  <Parameter name="verbosity level" type="string" value="high"/>
+          <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.1"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.1"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1">
+          <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.1"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2">
+          <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.1"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side, Right side Bottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side, Right side Bottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -243,27 +240,31 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
@@ -281,6 +282,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -294,12 +296,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
@@ -324,7 +326,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -333,7 +334,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -342,7 +343,7 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
@@ -350,4 +351,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_boundary_solver.xml
+++ b/src/pks/flow/test/flow_richards_boundary_solver.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
@@ -9,11 +8,10 @@
         <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Material 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate"  type="Array(double)" value="{-0.5, -0.5,-0.25}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,  0.5, 0.25}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-0.5, -0.5, -0.25}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.25}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
@@ -32,6 +30,7 @@
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
         <Parameter name="upwind method" type="string" value="upwind: gravity"/>
@@ -68,22 +67,18 @@
         <Parameter name="linear solver" type="string" value="none"/>
         <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
         <ParameterList name="initialization">
           <Parameter name="method" type="string" value="saturated solver"/>
           <Parameter name="linear solver" type="string" value="AmanziPCG"/>
-            <!--Parameter name="clipping saturation value" type="double" value="0.6"/--> 
+          <!--Parameter name="clipping saturation value" type="double" value="0.6"/-->
         </ParameterList>
-
         <ParameterList name="dae constraint">
           <Parameter name="method" type="string" value="projection"/>
           <Parameter name="linear solver" type="string" value="AztecOO"/>
         </ParameterList>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="5"/>
@@ -93,17 +88,16 @@
             <Parameter name="max timestep" type="double" value="100.0"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
             <Parameter name="diverged tolerance" type="double" value="1e+10"/>
             <Parameter name="limit iterations" type="int" value="12"/>
             <Parameter name="max du growth factor" type="double" value="1e+5"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <ParameterList name="verbose object">
-            <Parameter name="verbosity level" type="string" value="medium"/>
+              <Parameter name="verbosity level" type="string" value="medium"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -113,11 +107,11 @@
         <ParameterList name="WRM for Material 1">
           <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
           <Parameter name="water retention model" type="string" value="van Genuchten"/>
-          <Parameter name="van Genuchten m" type="double" value="2.29399999999999993e-01"/>
-          <Parameter name="van Genuchten l" type="double" value="5.00000000000000000e-01"/>
-          <Parameter name="van Genuchten alpha" type="double" value="1.94670000000000005e-04"/>
+          <Parameter name="van Genuchten m" type="double" value="0.229399999999999993"/>
+          <Parameter name="van Genuchten l" type="double" value="0.500000000000000000"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000194670000000000005"/>
           <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-          <Parameter name="regularization interval" type="double" value="150.00000000000000000e+00"/>
+          <Parameter name="regularization interval" type="double" value="150.00000000000000000"/>
           <Parameter name="relative permeability model" type="string" value="Mualem"/>
           <ParameterList name="output">
             <Parameter name="file" type="string" value="RegionMiddle.txt"/>
@@ -132,9 +126,9 @@
             <Parameter name="regions" type="Array(string)" value="{Top side}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-1e-5"/>
-            </ParameterList>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-0.00001"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -143,14 +137,16 @@
             <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
             <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="101325."/>
-            </ParameterList>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="101325.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -206,30 +202,35 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="pressure">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -257,9 +258,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
@@ -284,7 +285,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -293,7 +293,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -302,7 +302,7 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
@@ -310,4 +310,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_convergence.xml
+++ b/src/pks/flow/test/flow_richards_convergence.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
   </ParameterList>
@@ -9,183 +8,182 @@
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, -5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.5,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.5, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,-10.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, -10.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="other: arithmetic average"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="other: arithmetic average"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-
-      <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	    <Parameter name="initial timestep" type="double" value="1.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-5"/>
-	    <Parameter name="diverged tolerance" type="double" value="10000.0"/>
-	    <Parameter name="max du growth factor" type="double" value="100.0"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="7"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="low"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-      </ParameterList>
-
-      <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-      </ParameterList>
-
-      <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side, Front side, Back side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+            <Parameter name="initial timestep" type="double" value="1.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="10000.0"/>
+            <Parameter name="max du growth factor" type="double" value="100.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="7"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="low"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for Material 1 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side, Front side, Back side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -208,7 +206,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -225,17 +222,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
-     <ParameterList name="porosity">
+      <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.2"/>
               </ParameterList>
             </ParameterList>
@@ -285,20 +282,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -2.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="1e-10"/>
       </ParameterList>
@@ -307,10 +308,11 @@
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
-            <Parameter name="components" type="Array(string)" value="{cell,face}"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -323,8 +325,9 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="face"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -337,14 +340,15 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="1."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
+
       <ParameterList name="specific_yield">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -352,21 +356,21 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0."/>
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
-       <ParameterList name="specific_storage">
+
+      <ParameterList name="specific_storage">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0."/>
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -381,28 +385,23 @@
             <ParameterList name="function">
               <Parameter name="function type" type="string" value="composite function"/>
               <Parameter name="number of dofs" type="int" value="3"/>
-
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="0.5"/>
                 </ParameterList>
               </ParameterList>
-
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="0.5"/>
                 </ParameterList>
               </ParameterList>
-
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="0.5"/>
                 </ParameterList>
               </ParameterList>
-
             </ParameterList>
           </ParameterList>
-
           <ParameterList name="Region 2">
             <Parameter name="region" type="string" value="Material 2 Region"/>
             <Parameter name="component" type="string" value="cell"/>
@@ -446,4 +445,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_convergence_nlfv.xml
+++ b/src/pks/flow/test/flow_richards_convergence_nlfv.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
   </ParameterList>
@@ -9,178 +8,178 @@
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, -5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.5,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.5, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,-10.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, -10.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="other: arithmetic average"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="other: arithmetic average"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <!--Parameter name="Newton correction" type="string" value="approximate Jacobian"/-->
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <!--Parameter name="Newton correction" type="string" value="approximate Jacobian"/-->
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="15"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+5"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-6"/>
-	    <Parameter name="diverged tolerance" type="double" value="10000.0"/>
-	    <Parameter name="max du growth factor" type="double" value="100.0"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="7"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="low"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+5"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000001"/>
+            <Parameter name="diverged tolerance" type="double" value="10000.0"/>
+            <Parameter name="max du growth factor" type="double" value="100.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="7"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="low"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side, Front side, Back side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side, Front side, Back side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -192,7 +191,6 @@
         <Parameter name="error tolerance" type="double" value="1e-14"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="AztecOO">
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
       <Parameter name="iterative method" type="string" value="gmres"/>
@@ -205,7 +203,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -222,20 +219,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="low"/>
     </ParameterList>
     <ParameterList name="evaluators">
-     <ParameterList name="porosity">
+      <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.2"/>
               </ParameterList>
             </ParameterList>
@@ -285,20 +282,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -2.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="1e-10"/>
       </ParameterList>
@@ -309,8 +310,9 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="components" type="Array(string)" value="{cell}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -323,8 +325,9 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="face"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="0."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -337,14 +340,15 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="1."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
+
       <ParameterList name="specific_yield">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -352,21 +356,21 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0."/>
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
-       <ParameterList name="specific_storage">
+
+      <ParameterList name="specific_storage">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="0."/>
+                <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -398,7 +402,6 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-
           <ParameterList name="Region 2">
             <Parameter name="region" type="string" value="Material 2 Region"/>
             <Parameter name="component" type="string" value="cell"/>
@@ -438,7 +441,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_fractures.xml
+++ b/src/pks/flow/test/flow_richards_fractures.xml
@@ -1,49 +1,48 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.5,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.5, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <Parameter name="domain name" type="string" value="domain"/>
-
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
@@ -51,54 +50,52 @@
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0e-4"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.1"/>
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.00010"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.1"/>
         </ParameterList>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -125,7 +122,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -194,24 +193,27 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
-        <Parameter name="value" type="double" value="1.0e-3"/>
+        <Parameter name="value" type="double" value="0.0010"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
@@ -258,6 +260,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -271,19 +274,19 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -291,7 +294,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -303,4 +305,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_fractures_saturated.xml
+++ b/src/pks/flow/test/flow_richards_fractures_saturated.xml
@@ -1,47 +1,46 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.5,0.5,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.5, 0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <Parameter name="domain name" type="string" value="domain"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
 
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
@@ -49,9 +48,9 @@
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  <Parameter name="water retention model" type="string" value="saturated"/>
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="saturated"/>
         </ParameterList>
       </ParameterList>
 
@@ -64,44 +63,42 @@
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="nonlinear coefficient" type="string" value="standard: cell"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="linear solver" type="string" value="PCG"/>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -119,7 +116,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -195,17 +194,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -0.001}"/>
       </ParameterList>
@@ -223,6 +225,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -236,19 +239,19 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <Parameter name="discretization method" type="string" value="mfd: optimized for sparsity"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -256,7 +259,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -268,4 +270,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_porosity.xml
+++ b/src/pks/flow/test/flow_richards_porosity.xml
@@ -1,201 +1,195 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-2.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -2.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,-1.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, -1.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-2.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -2.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="porosity model" type="string" value="compressible"/>
+        <Parameter name="porosity model" type="string" value="compressible"/>
       </ParameterList>
 
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AmanziPCG"/>
-	  <Parameter name="clipping saturation value" type="double" value="0.6"/>
-	</ParameterList>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
-
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="5"/>
-	    <Parameter name="max iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="max timestep" type="double" value="100.0"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="12"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="medium"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AmanziPCG"/>
+          <Parameter name="clipping saturation value" type="double" value="0.6"/>
+        </ParameterList>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="5"/>
+            <Parameter name="max iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="max timestep" type="double" value="100.0"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="12"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="medium"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="van Genuchten l" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.1"/>
-	  <Parameter name="relative permeability model" type="string" value="Mualem"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.1"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1">
+          <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.1"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2">
+          <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.1"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="porosity models">
-	<ParameterList name="POM for Material 1">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
-	  <Parameter name="porosity model" type="string" value="constant"/>
-	  <Parameter name="value" type="double" value="0.2"/>
-	</ParameterList>
-
-	<ParameterList name="POM for Material 2">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
-	  <Parameter name="porosity model" type="string" value="compressible"/>
-	  <Parameter name="undeformed soil porosity" type="double" value="0.2"/>
-	  <Parameter name="reference pressure" type="double" value="-10.0"/>
-	  <Parameter name="pore compressibility" type="double" value="1e-2"/>
-	</ParameterList>
+        <ParameterList name="POM for Material 1">
+          <Parameter name="regions" type="Array(string)" value="{Material 1}"/>
+          <Parameter name="porosity model" type="string" value="constant"/>
+          <Parameter name="value" type="double" value="0.2"/>
+        </ParameterList>
+        <ParameterList name="POM for Material 2">
+          <Parameter name="regions" type="Array(string)" value="{Material 2}"/>
+          <Parameter name="porosity model" type="string" value="compressible"/>
+          <Parameter name="undeformed soil porosity" type="double" value="0.2"/>
+          <Parameter name="reference pressure" type="double" value="-10.0"/>
+          <Parameter name="pore compressibility" type="double" value="0.01"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side, Right side Bottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side Top}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side, Right side Bottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
             <ParameterList name="boundary pressure">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
@@ -204,7 +198,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -235,7 +231,7 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="10"/>
+                <Parameter name="value" type="double" value="10.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -249,30 +245,35 @@
             <Parameter name="components" type="Array(string)" value="{cell, boundary_face}"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="10.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.8}"/>
       </ParameterList>
+
       <ParameterList name="temperature">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -286,9 +287,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
@@ -315,7 +316,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -324,7 +324,7 @@
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
         <Parameter name="aggregation: nodes per aggregate" type="int" value="3"/>
-        <Parameter name="aggregation: threshold" type="double" value="0"/>
+        <Parameter name="aggregation: threshold" type="double" value="0.0"/>
         <Parameter name="aggregation: type" type="string" value="Uncoupled"/>
         <Parameter name="coarse: max size" type="int" value="128"/>
         <Parameter name="coarse: type" type="string" value="Amesos-KLU"/>
@@ -333,7 +333,7 @@
         <Parameter name="eigen-analysis: type" type="string" value="cg"/>
         <Parameter name="max levels" type="int" value="40"/>
         <Parameter name="prec type" type="string" value="MGW"/>
-        <Parameter name="smoother: damping factor" type="double" value="1"/>
+        <Parameter name="smoother: damping factor" type="double" value="1.0"/>
         <Parameter name="smoother: pre or post" type="string" value="both"/>
         <Parameter name="smoother: sweeps" type="int" value="2"/>
         <Parameter name="smoother: type" type="string" value="Gauss-Seidel"/>
@@ -341,4 +341,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_random.xml
+++ b/src/pks/flow/test/flow_richards_random.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="2"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -16,166 +14,165 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-10.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -10.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face,cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="approximate Jacobian"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure,residual}"/>
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-3"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="none"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -198,7 +195,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -210,7 +206,6 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
       <ParameterList name="ml parameters">
@@ -234,7 +229,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE -->
   <ParameterList name="state">
     <ParameterList name="verbose object">
@@ -248,7 +242,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.2"/>
               </ParameterList>
             </ParameterList>
@@ -312,17 +307,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -2.0}"/>
       </ParameterList>
@@ -337,7 +335,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -351,7 +350,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -365,7 +364,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -379,7 +378,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -455,7 +454,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_random_fv.xml
+++ b/src/pks/flow/test/flow_richards_random_fv.xml
@@ -1,11 +1,9 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="2"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -16,163 +14,161 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-10.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -10.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="none"/>
+        <Parameter name="verbosity level" type="string" value="none"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="fv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="fv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="fv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="fv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <!--Parameter name="Newton correction" type="string" value="exact jacobian"/-->
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <!--Parameter name="Newton correction" type="string" value="exact jacobian"/-->
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure,residual}"/>
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="picard"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	  <ParameterList name="picard parameters">
-	    <Parameter name="convergence tolerance" type="double" value="1e-8"/>
-	    <Parameter name="maximum number of iterations" type="int" value="20"/>
-	  </ParameterList>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-3"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="low"/>
-	    </ParameterList>
-	  </ParameterList>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="picard"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+          <ParameterList name="picard parameters">
+            <Parameter name="convergence tolerance" type="double" value="1e-8"/>
+            <Parameter name="maximum number of iterations" type="int" value="20"/>
+          </ParameterList>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="low"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left side,Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left side, Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
           <ParameterList name="BC 2">
@@ -186,7 +182,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -202,7 +200,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -215,7 +212,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
@@ -230,7 +226,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.2"/>
               </ParameterList>
             </ParameterList>
@@ -280,20 +277,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="1e-10"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -2.0}"/>
       </ParameterList>
@@ -304,7 +305,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -318,7 +320,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -332,7 +334,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -346,7 +348,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -422,7 +424,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_random_nlfv.xml
+++ b/src/pks/flow/test/flow_richards_random_nlfv.xml
@@ -1,11 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
   <Parameter name="number of meshes" type="int" value="3"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -16,96 +14,96 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 1 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-10.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,-5.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -10.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, -5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Material 2 Region">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,-5.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, -5.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,-10.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, -10.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<!--Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <!--Parameter name="upwind method" type="string" value="upwind: gravity"/>
 	<Parameter name="upwind method" type="string" value="upwind: darcy velocity"/-->
-	<Parameter name="upwind method" type="string" value="other: arithmetic average"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="other: arithmetic average"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="low"/>
+        <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <!-- <Parameter name="Newton correction" type="string" value="approximate Jacobian"/> -->
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <!-- <Parameter name="Newton correction" type="string" value="approximate Jacobian"/> -->
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="AztecOO"/>
-	<Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure,residual}"/>
-
-	<!--ParameterList name="initialization">
+        <Parameter name="linear solver" type="string" value="AztecOO"/>
+        <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure, residual}"/>
+        <!--ParameterList name="initialization">
 	  <Parameter name="method" type="string" value="picard"/>
 	  <Parameter name="linear solver" type="string" value="AztecOO"/>
 	  <ParameterList name="picard parameters">
@@ -113,72 +111,72 @@
 	    <Parameter name="maximum number of iterations" type="int" value="20"/>
 	  </ParameterList>
 	</ParameterList-->
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="8"/>
-	    <Parameter name="max iterations" type="int" value="10"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-	    <Parameter name="max timestep" type="double" value="1.0e+4"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-6"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="modify correction" type="bool" value="false"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="low"/>
-	    </ParameterList>
-	  </ParameterList>
-	  <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	</ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="8"/>
+            <Parameter name="max iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.2"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="1.0e+4"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="modify correction" type="bool" value="false"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="low"/>
+            </ParameterList>
+          </ParameterList>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for Material 1 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
-	<ParameterList name="WRM for Material 2 Region">
-	  <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
-	  <Parameter name="water retention model" type="string" value="fake"/>
-	</ParameterList>
+        <ParameterList name="WRM for Material 1 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 1 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
+        <ParameterList name="WRM for Material 2 Region">
+          <Parameter name="regions" type="Array(string)" value="{Material 2 Region}"/>
+          <Parameter name="water retention model" type="string" value="fake"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -201,7 +199,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -214,7 +211,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- STATE -->
   <ParameterList name="state">
     <ParameterList name="verbose object">
@@ -278,20 +274,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="0"/>
+        <Parameter name="value" type="double" value="0.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -2.0}"/>
       </ParameterList>
@@ -302,7 +302,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -316,7 +317,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -330,7 +331,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -344,7 +345,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -420,7 +421,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_seepage_tpfa.xml
+++ b/src/pks/flow/test/flow_richards_seepage_tpfa.xml
@@ -1,210 +1,208 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,50.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 50.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,40.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 40.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,40.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,50.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 40.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 50.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right Bottom">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{100.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{100.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right Middle">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{100.0,20.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,40.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{100.0, 20.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 40.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right Top">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{100.0,40.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,50.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{100.0, 40.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 50.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,50.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 50.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="upwind: gravity"/>
-	<Parameter name="upwind frequency" type="string" value="every nonlinear iteration"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="upwind: gravity"/>
+        <Parameter name="upwind frequency" type="string" value="every nonlinear iteration"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="fv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="fv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="fv: default"/>
-	    <Parameter name="discretization secondary" type="string" value="fv: default"/>
-	    <Parameter name="schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	    <Parameter name="Newton correction" type="string" value="true Jacobian"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+            <Parameter name="Newton correction" type="string" value="true Jacobian"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="linear operator"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<!--Parameter name="preconditioner enhancement" type="string" value="linear operator"/-->
-
-	<ParameterList name="initialization">
-	  <Parameter name="method" type="string" value="saturated solver"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	  <Parameter name="clipping saturation value" type="double" value="0.6"/>
-	</ParameterList>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="max iterations" type="int" value="35"/>
-	    <Parameter name="min iterations" type="int" value="7"/>
-	    <Parameter name="timestep increase factor" type="double" value="1.25"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="max timestep" type="double" value="6.0e+09"/>
-	    <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
-	  </ParameterList>
-	  <Parameter name="solver type" type="string" value="Newton"/>
-	  <ParameterList name="Newton parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="9.99999999999999955e-05"/>
-	    <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-	    <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	  </ParameterList>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-	  <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-	  <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-	</ParameterList>
+        <Parameter name="linear solver" type="string" value="linear operator"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <!--Parameter name="preconditioner enhancement" type="string" value="linear operator"/-->
+        <ParameterList name="initialization">
+          <Parameter name="method" type="string" value="saturated solver"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+          <Parameter name="clipping saturation value" type="double" value="0.6"/>
+        </ParameterList>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="35"/>
+            <Parameter name="min iterations" type="int" value="7"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="max timestep" type="double" value="6.0e+9"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999945e-21"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000999999999999999955"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="0.000735"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.31138"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.074"/>
-	</ParameterList>
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="0.000735"/>
+          <Parameter name="van Genuchten m" type="double" value="0.31138"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.074"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Left Top, Right Top, Bottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Top}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="-2.1076e-07"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="static head">
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Left Bottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.0"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="40.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 3">
-	    <Parameter name="regions" type="Array(string)" value="{Right Bottom}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="static head">
-	      <ParameterList name="function-static-head">
-		<Parameter name="p0" type="double" value="101325.0"/>
-		<Parameter name="density" type="double" value="998.0"/>
-		<Parameter name="gravity" type="double" value="9.81"/>
-		<Parameter name="space dimension" type="int" value="2"/>
-		<ParameterList name="water table elevation">
-		  <ParameterList name="function-constant">
-		    <Parameter name="value" type="double" value="20.0"/>
-		  </ParameterList>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="seepage face">
-	  <ParameterList name="BC 4">
-	    <Parameter name="regions" type="Array(string)" value="{Right Middle}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <Parameter name="rainfall" type="bool" value="false"/>
-	    <Parameter name="submodel" type="string" value="PFloTran"/>
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Left Top, Right Top, Bottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Top}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-2.1076e-7"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="static head">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Left Bottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.0"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="40.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Right Bottom}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="static head">
+              <ParameterList name="function-static-head">
+                <Parameter name="p0" type="double" value="101325.0"/>
+                <Parameter name="density" type="double" value="998.0"/>
+                <Parameter name="gravity" type="double" value="9.81"/>
+                <Parameter name="space dimension" type="int" value="2"/>
+                <ParameterList name="water table elevation">
+                  <ParameterList name="function-constant">
+                    <Parameter name="value" type="double" value="20.0"/>
+                  </ParameterList>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="seepage face">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Right Middle}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="rainfall" type="bool" value="false"/>
+            <Parameter name="submodel" type="string" value="PFloTran"/>
             <ParameterList name="outward mass flux">
               <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
@@ -213,7 +211,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -244,12 +244,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
       <Parameter name="preconditioning method" type="string" value="ml"/>
-
       <ParameterList name="ml parameters">
         <Parameter name="ML output" type="int" value="0"/>
         <Parameter name="aggregation: damping factor" type="double" value="1.33"/>
@@ -271,7 +269,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -331,20 +328,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="1.0"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
@@ -376,7 +377,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/flow/test/flow_richards_tensor.xml
+++ b/src/pks/flow/test/flow_richards_tensor.xml
@@ -1,6 +1,5 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
   </ParameterList>
@@ -9,187 +8,183 @@
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,1.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 1.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.5,0.5,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.5, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!--  FLOW  -->
   <ParameterList name="PKs">
+
     <ParameterList name="flow">
       <ParameterList name="relative permeability">
-	<Parameter name="upwind method" type="string" value="other: arithmetic average"/>
-	<ParameterList name="upwind parameters">
-	  <Parameter name="tolerance" type="double" value="1e-12"/>
-	</ParameterList>
+        <Parameter name="upwind method" type="string" value="other: arithmetic average"/>
+        <ParameterList name="upwind parameters">
+          <Parameter name="tolerance" type="double" value="1e-12"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="verbose object">
-	<Parameter name="verbosity level" type="string" value="high"/>
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
       <ParameterList name="operators">
-	<ParameterList name="diffusion operator">
-	  <ParameterList name="matrix">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	  <ParameterList name="preconditioner">
-	    <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
-	    <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
-	    <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
-	    <Parameter name="gravity" type="bool" value="true"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="discretization secondary" type="string" value="mfd: optimized for sparsity"/>
+            <Parameter name="schema" type="Array(string)" value="{face, cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{face}"/>
+            <Parameter name="gravity" type="bool" value="true"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-	<Parameter name="linear solver" type="string" value="none"/>
-	<Parameter name="preconditioner" type="string" value="Trilinos ML"/>
-	<Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
-	<ParameterList name="dae constraint">
-	  <Parameter name="method" type="string" value="projection"/>
-	  <Parameter name="linear solver" type="string" value="AztecOO"/>
-	</ParameterList>
-
-	<Parameter name="time integration method" type="string" value="BDF1"/>
-	<ParameterList name="BDF1">
-	  <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	  <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
-	  <Parameter name="timestep increase factor" type="double" value="1.2"/>
-
-	  <Parameter name="timestep controller type" type="string" value="standard"/>
-	  <ParameterList name="timestep controller standard parameters">
-	    <Parameter name="min iterations" type="int" value="2"/>
-	    <Parameter name="max iterations" type="int" value="5"/>
-	    <Parameter name="timestep increase factor" type="double" value="2.0"/>
-	    <Parameter name="timestep reduction factor" type="double" value="0.5"/>
-	    <Parameter name="max timestep" type="double" value="100.0"/>
-	    <Parameter name="min timestep" type="double" value="0.0"/>
-	  </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="12"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
+        <Parameter name="linear solver" type="string" value="none"/>
+        <Parameter name="preconditioner" type="string" value="Trilinos ML"/>
+        <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
+        <ParameterList name="dae constraint">
+          <Parameter name="method" type="string" value="projection"/>
+          <Parameter name="linear solver" type="string" value="AztecOO"/>
+        </ParameterList>
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+          <Parameter name="max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="timestep increase factor" type="double" value="1.2"/>
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="min iterations" type="int" value="2"/>
+            <Parameter name="max iterations" type="int" value="5"/>
+            <Parameter name="timestep increase factor" type="double" value="2.0"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.5"/>
+            <Parameter name="max timestep" type="double" value="100.0"/>
+            <Parameter name="min timestep" type="double" value="0.0"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="12"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="monitor" type="string" value="monitor l2 residual"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="high"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="water retention models">
-	<ParameterList name="WRM for All">
-	  <Parameter name="regions" type="Array(string)" value="{All}"/>
-	  <Parameter name="water retention model" type="string" value="van Genuchten"/>
-	  <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
-	  <Parameter name="van Genuchten m" type="double" value="0.5"/>
-	  <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-	</ParameterList>
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten alpha" type="double" value="1.0"/>
+          <Parameter name="van Genuchten m" type="double" value="0.5"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="boundary conditions">
-	<ParameterList name="mass flux">
-	  <ParameterList name="BC 0">
-	    <Parameter name="regions" type="Array(string)" value="{Top side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 1">
-	    <Parameter name="regions" type="Array(string)" value="{Left side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="-1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 2">
-	    <Parameter name="regions" type="Array(string)" value="{Right side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 3">
-	    <Parameter name="regions" type="Array(string)" value="{Front side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="-1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	  <ParameterList name="BC 4">
-	    <Parameter name="regions" type="Array(string)" value="{Back side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="outward mass flux">
-	      <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="1.0"/>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-
-	<ParameterList name="pressure">
-	  <ParameterList name="BC 5">
-	    <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
-	    <Parameter name="spatial distribution method" type="string" value="none"/>
-	    <ParameterList name="boundary pressure">
+        <ParameterList name="mass flux">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{Top side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Left side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Right side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Front side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Back side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="pressure">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Bottom side}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
               <ParameterList name="function-linear">
                 <Parameter name="y0" type="double" value="0.0"/>
                 <Parameter name="gradient" type="Array(double)" value="{0.0, -0.15, -0.15, -0.15}"/>
@@ -199,7 +194,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- SOLVERS -->
@@ -211,7 +208,6 @@
         <Parameter name="error tolerance" type="double" value="1e-14"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="AztecOO">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -220,7 +216,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Trilinos ML">
@@ -246,7 +241,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--  STATE: this super input desk will be used to cut-off smaller 
   input deks for other flow tests -->
   <ParameterList name="state">
@@ -308,20 +302,24 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="2.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.3"/>
       </ParameterList>
+
       <ParameterList name="gravity">
-        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1.e-9}"/>
+        <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -1e-9}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="-10.0"/>
       </ParameterList>
@@ -339,19 +337,16 @@
                   <Parameter name="value" type="double" value="1.0"/>
                 </ParameterList>
               </ParameterList>
-
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="1.0"/>
                 </ParameterList>
               </ParameterList>
-
               <ParameterList name="dof 3 function">
                 <ParameterList name="function-constant">
                   <Parameter name="value" type="double" value="1.0"/>
                 </ParameterList>
               </ParameterList>
-
             </ParameterList>
           </ParameterList>
         </ParameterList>
@@ -361,9 +356,10 @@
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="All"/>
-            <Parameter name="components" type="Array(string)" value="{cell,face}"/>
+            <Parameter name="components" type="Array(string)" value="{cell, face}"/>
             <ParameterList name="function">
-              <ParameterList name="function-linear"> <!-- time component -->
+              <ParameterList name="function-linear">
+                <!-- time component -->
                 <Parameter name="gradient" type="Array(double)" value="{0.15, -0.13, -0.145}"/>
                 <Parameter name="x0" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
                 <Parameter name="y0" type="double" value="1.0"/>
@@ -379,7 +375,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -393,7 +389,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -442,7 +438,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_clamped_beam.xml
+++ b/src/pks/mechanics/test/mechanics_clamped_beam.xml
@@ -1,22 +1,20 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,    0.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  0.0, 0.0, 0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
@@ -24,9 +22,10 @@
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics elasticity">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="true"/>
+        <Parameter name="use gravity" type="bool" value="true"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -46,12 +45,10 @@
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -62,7 +59,6 @@
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1e-8"/>
@@ -121,7 +117,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -134,7 +132,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
@@ -142,17 +140,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
@@ -202,6 +203,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -215,9 +217,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -232,7 +234,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -249,4 +250,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_cook.xml
+++ b/src/pks/mechanics/test/mechanics_cook.xml
@@ -1,38 +1,37 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.048,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.048, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics elasticity">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="false"/>
+        <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -52,12 +51,10 @@
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -67,7 +64,6 @@
             <Parameter name="max timestep" type="double" value="1e+8"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1e-10"/>
@@ -130,7 +126,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -143,25 +141,28 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
@@ -211,6 +212,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -224,9 +226,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -238,7 +240,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -256,4 +257,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_cook_small_strain.xml
+++ b/src/pks/mechanics/test/mechanics_cook_small_strain.xml
@@ -1,38 +1,37 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.048,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.048, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics small strain">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="false"/>
+        <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -52,7 +51,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Hardin Drnevich"/>
-          <Parameter name="reference shear strain" type="double" value="8.0e-1"/>
+          <Parameter name="reference shear strain" type="double" value="0.80"/>
           <Parameter name="maximum shear stress" type="double" value="70.0"/>
         </ParameterList>
       </ParameterList>
@@ -61,12 +60,10 @@
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -76,7 +73,6 @@
             <Parameter name="max timestep" type="double" value="1e+8"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
@@ -139,7 +135,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -152,14 +150,13 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="bulk_modulus">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -175,17 +172,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
@@ -235,6 +235,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -248,9 +249,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -262,7 +263,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -280,4 +280,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_elasticity_2D.xml
+++ b/src/pks/mechanics/test/mechanics_elasticity_2D.xml
@@ -1,50 +1,49 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics elasticity">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="true"/>
+        <Parameter name="use gravity" type="bool" value="true"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -64,12 +63,10 @@
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -79,7 +76,6 @@
             <Parameter name="max timestep" type="double" value="1e+8"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1e-10"/>
@@ -144,7 +140,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -157,25 +155,28 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
@@ -225,6 +226,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -238,9 +240,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -252,7 +254,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -271,4 +272,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_fractured_matrix.xml
+++ b/src/pks/mechanics/test/mechanics_fractured_matrix.xml
@@ -1,47 +1,45 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{  0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 1.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture_x">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.5,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.5, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture_y">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture_z">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture">
@@ -54,9 +52,10 @@
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics matrix fracture">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="false"/>
+        <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -68,7 +67,7 @@
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="BernardiRaugel"/>
             <Parameter name="method order" type="int" value="1"/>
-	    <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
+            <Parameter name="fracture" type="Array(string)" value="{fracture}"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -77,7 +76,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Hardin Drnevich"/>
-          <Parameter name="reference shear strain" type="double" value="8.0e-1"/>
+          <Parameter name="reference shear strain" type="double" value="0.80"/>
           <Parameter name="maximum shear stress" type="double" value="70.0"/>
         </ParameterList>
       </ParameterList>
@@ -86,12 +85,10 @@
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -101,7 +98,6 @@
             <Parameter name="max timestep" type="double" value="1e+8"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
@@ -149,7 +145,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -162,8 +160,8 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -177,7 +175,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -205,24 +203,27 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.4286e-06"/>
+                <Parameter name="value" type="double" value="0.0000014286"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
@@ -272,6 +273,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -299,6 +301,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-ref_aperture">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -312,6 +315,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="fracture-pressure">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -325,12 +329,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="medium"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -342,7 +346,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -360,4 +363,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_hydrostatic_stress.xml
+++ b/src/pks/mechanics/test/mechanics_hydrostatic_stress.xml
@@ -1,34 +1,32 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0,    0.0,   0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="LeftColumn">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  0.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{ 2.0, 1.0, 25.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{2.0, 1.0, 25.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightColumn">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{  2.0, 0.0,  0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{ 4.0, 1.0, 25.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{2.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{4.0, 1.0, 25.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{ 0.0, 0.0,  0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
@@ -36,9 +34,10 @@
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics elasticity">
       <ParameterList name="physical models and assumptions">
-	<Parameter name="use gravity" type="bool" value="true"/>
+        <Parameter name="use gravity" type="bool" value="true"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
@@ -58,12 +57,10 @@
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
         <Parameter name="error control options" type="Array(string)" value="{displacement}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
           <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -74,7 +71,6 @@
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
             <Parameter name="nonlinear tolerance" type="double" value="1e-8"/>
@@ -123,7 +119,9 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -136,7 +134,7 @@
             <Parameter name="region" type="string" value="LeftColumn"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="1000.0"/>
               </ParameterList>
             </ParameterList>
@@ -145,7 +143,7 @@
             <Parameter name="region" type="string" value="RightColumn"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="2000.0"/>
               </ParameterList>
             </ParameterList>
@@ -153,17 +151,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.001"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -10.0}"/>
       </ParameterList>
@@ -204,6 +205,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -217,9 +219,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -234,7 +236,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -251,4 +252,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/mechanics/test/mechanics_symmetry.xml
+++ b/src/pks/mechanics/test/mechanics_symmetry.xml
@@ -1,42 +1,42 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{100.0,100.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{2.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{2.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{2.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="mechanics elasticity">
       <Parameter name="domain name" type="string" value=""/>
       <ParameterList name="time integrator">
@@ -49,17 +49,17 @@
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="max iterations" type="int" value="15"/>
             <Parameter name="min iterations" type="int" value="10"/>
-            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996e+00"/>
+            <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
             <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="max timestep" type="double" value="4.32340000000000000e+17"/>
-            <Parameter name="min timestep" type="double" value="9.99999999999999955e-07"/>
+            <Parameter name="max timestep" type="double" value="432340000000000000.0"/>
+            <Parameter name="min timestep" type="double" value="9.99999999999999955e-7"/>
           </ParameterList>
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1.0e-08"/>
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
             <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
             <Parameter name="diverged l2 tolerance" type="double" value="1.0e+10"/>
-            <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
             <Parameter name="max divergent iterations" type="int" value="3"/>
             <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
@@ -75,6 +75,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="operators">
         <ParameterList name="elasticity operator">
           <Parameter name="matrix type" type="string" value="stiffness"/>
@@ -85,11 +86,13 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="physical models and assumptions">
         <Parameter name="use gravity" type="bool" value="false"/>
         <Parameter name="biot scheme: undrained split" type="bool" value="false"/>
         <Parameter name="biot scheme: fixed stress split" type="bool" value="false"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="traction">
           <ParameterList name="BC 0">
@@ -143,7 +146,7 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-03"/>
+                  <Parameter name="value" type="double" value="0.0010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -161,17 +164,20 @@
               </ParameterList>
               <ParameterList name="dof 2 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="-1.0e-03"/>
+                  <Parameter name="value" type="double" value="-0.0010"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -184,7 +190,7 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> 
+              <ParameterList name="function-constant">
                 <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
@@ -192,17 +198,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
@@ -243,6 +252,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="poisson_ratio">
         <ParameterList name="function">
           <ParameterList name="ALL">
@@ -256,9 +266,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG">
@@ -272,7 +282,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="GMRES with Hypre AMG">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -281,7 +290,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -300,5 +308,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-

--- a/src/pks/multiphase/test/multiphase_jacobian1a.xml
+++ b/src/pks/multiphase/test/multiphase_jacobian1a.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,269 +41,257 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               mole_fraction_liquid,
-                                                               mole_fraction_vapor }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, mole_fraction_liquid, mole_fraction_vapor}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="mole_fraction_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="Euclid"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.3"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.01"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-10"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="40"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="mole_fraction_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="Euclid"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.3"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.01"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-10"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <Parameter name="phase" type="string" value="liquid"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-9"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1000.0"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="40"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <Parameter name="phase" type="string" value="liquid"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-09"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -415,6 +402,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="volumetric_flow_rate_gas">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -426,7 +414,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1.0e-06"/>
+                  <Parameter name="value" type="double" value="0.0000010"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -438,8 +426,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -455,14 +443,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp mole fraction gas"/>
         <Parameter name="tag" type="string" value=""/>
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -473,7 +459,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -484,64 +469,44 @@
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     mole_fraction_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, mole_fraction_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     mole_fraction_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, mole_fraction_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     molar_density_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, molar_density_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     molar_density_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, molar_density_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_liquid">
         <Parameter name="evaluator type" type="string" value="mole fraction liquid"/>
         <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
@@ -551,17 +516,14 @@
       </ParameterList>
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -576,7 +538,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -585,13 +546,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -600,13 +560,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -621,7 +580,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -629,11 +587,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -648,7 +605,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -657,25 +613,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -701,7 +654,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Block ILU">
@@ -726,7 +678,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -735,7 +687,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -749,7 +702,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_jaffre.xml
+++ b/src/pks/multiphase/test/multiphase_jaffre.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e13, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e+13, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,136 +41,123 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-0.2"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="-0.2"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
 
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="1.0e-2"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.001"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-       
-        <!-- 
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <!-- 
         <ParameterList name="nka parameters">
           <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
           <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
@@ -183,166 +169,167 @@
           <Parameter name="monitor" type="string" value="monitor update"/>
         </ParameterList>
         -->
-
-        <!--
+          <!--
         <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
         <Parameter name="extrapolate initial guess" type="bool" value="false"/>
         <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
         <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
         <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         -->
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="concentration">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="source terms">
+        <ParameterList name="mass rate">
+          <ParameterList name="SRC 0">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+  </ParameterList>
 
-      <ParameterList name="concentration">
-        <ParameterList name="BC 5">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="boundary concentration">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="source terms">
-      <ParameterList name="mass rate">
-
-        <ParameterList name="SRC 0">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-        <ParameterList name="SRC 1">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
-
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -388,6 +375,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -407,25 +395,25 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -435,13 +423,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="303"/>
+                <Parameter name="value" type="double" value="303.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -449,16 +436,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -467,43 +450,32 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -518,7 +490,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -527,13 +498,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -542,13 +512,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -557,7 +526,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="100000"/>
+                <Parameter name="value" type="double" value="100000.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -571,14 +540,13 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
         <!--ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList-->
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -594,18 +562,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -623,7 +588,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-   <!--
+    <!--
     <ParameterList name="AMESOS">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -633,12 +598,8 @@
     </ParameterList>
     -->
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
- 
   <ParameterList name="preconditioners">
-  
-     
     <ParameterList name="ILU">
       <Parameter name="preconditioning method" type="string" value="ILU"/>
       <ParameterList name="ILU parameters">
@@ -646,7 +607,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-  
     <!--   
     <ParameterList name="SysTG">
       <Parameter name="preconditioning method" type="string" value="systg"/>
@@ -666,7 +626,6 @@
       </ParameterList>
     </ParameterList>
    -->
-    
     <!--
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
@@ -682,9 +641,7 @@
       </ParameterList>
     </ParameterList>
     -->
-  
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_jaffre_fractures.xml
+++ b/src/pks/multiphase/test/multiphase_jaffre_fractures.xml
@@ -1,33 +1,32 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,12.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 12.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,12.0,12.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 12.0, 12.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Outflow">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 200.0, 0.0, 0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,12.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{200.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 12.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{   0.0, 0.0,6.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,12.0,6.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 6.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 12.0, 6.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -36,8 +35,8 @@
     <ParameterList name="unstructured">
       <ParameterList name="generate mesh">
         <Parameter name="number of cells" type="Array(int)" value="{200, 3, 3}"/>
-        <Parameter name="domain low coordinate" type="Array(double)" value="{   0.0, 0.0, 0.0}"/>
-        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0,12.0,12.0}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{200.0, 12.0, 12.0}"/>
       </ParameterList>
       <ParameterList name="expert">
         <Parameter name="framework" type="string" value="MSTK"/>
@@ -48,260 +47,253 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="3"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="domain name" type="string" value="domain"/>
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-0.1111111111111111"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="-0.1111111111111111"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0e-10}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{0.0e-9}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.001"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-8.831177067478435e-11"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="10"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
+              <Parameter name="manifolds" type="bool" value="false"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-8.831177067478435e-11"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-             <Parameter name="manifolds" type="bool" value="false"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -347,6 +339,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -366,25 +359,25 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -400,7 +393,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -408,16 +400,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -426,42 +414,31 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- advection -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -476,7 +453,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -485,13 +461,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -500,13 +475,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -521,7 +495,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -530,14 +503,13 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
         <!--ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList-->
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -553,18 +525,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -590,7 +559,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="ILU">
@@ -608,7 +576,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -617,7 +585,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -631,7 +600,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_jaffre_gas.xml
+++ b/src/pks/multiphase/test/multiphase_jaffre_gas.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e13, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e+13, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,137 +41,123 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               saturation_liquid }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, saturation_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-0.2"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="-0.2"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_gas"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
 
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_gas"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="1.0e-2"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.001"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-       
-        <!-- 
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <!-- 
         <ParameterList name="nka parameters">
           <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
           <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
@@ -184,166 +169,167 @@
           <Parameter name="monitor" type="string" value="monitor update"/>
         </ParameterList>
         -->
-
-        <!--
+          <!--
         <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
         <Parameter name="extrapolate initial guess" type="bool" value="false"/>
         <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
         <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
         <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         -->
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="concentration">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="source terms">
+        <ParameterList name="mass rate">
+          <ParameterList name="SRC 0">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+  </ParameterList>
 
-      <ParameterList name="concentration">
-        <ParameterList name="BC 5">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="boundary concentration">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="source terms">
-      <ParameterList name="mass rate">
-
-        <ParameterList name="SRC 0">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-        <ParameterList name="SRC 1">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
-
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -389,6 +375,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -408,25 +395,25 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -436,18 +423,16 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="303"/>
+                <Parameter name="value" type="double" value="303.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_gas"/>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -455,16 +440,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -473,43 +454,32 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -524,7 +494,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -533,13 +502,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -548,13 +516,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -563,7 +530,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="100000"/>
+                <Parameter name="value" type="double" value="100000.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -577,14 +544,13 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
         <!--ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList-->
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -600,18 +566,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -629,7 +592,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-   <!--
+    <!--
     <ParameterList name="AMESOS">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -639,12 +602,8 @@
     </ParameterList>
     -->
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
- 
   <ParameterList name="preconditioners">
-  
-     
     <ParameterList name="ILU">
       <Parameter name="preconditioning method" type="string" value="ILU"/>
       <ParameterList name="ILU parameters">
@@ -652,7 +611,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-  
     <!--   
     <ParameterList name="SysTG">
       <Parameter name="preconditioning method" type="string" value="systg"/>
@@ -672,7 +630,6 @@
       </ParameterList>
     </ParameterList>
    -->
-    
     <!--
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
@@ -688,9 +645,7 @@
       </ParameterList>
     </ParameterList>
     -->
-  
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_jaffre_nlfv.xml
+++ b/src/pks/multiphase/test/multiphase_jaffre_nlfv.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e13, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 3.1536e+13, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,139 +41,126 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-0.2"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="-0.2"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
 
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-6}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="1.0e-2"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.001"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-          <ParameterList name="verbose object">
-            <Parameter name="verbosity level" type="string" value="none"/>
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
           </ParameterList>
-        </ParameterList>
-       
-        <!-- 
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="none"/>
+            </ParameterList>
+          </ParameterList>
+          <!-- 
         <ParameterList name="nka parameters">
           <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
           <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
@@ -186,145 +172,146 @@
           <Parameter name="monitor" type="string" value="monitor update"/>
         </ParameterList>
         -->
-
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="concentration">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="source terms">
+        <ParameterList name="mass rate">
+          <ParameterList name="SRC 0">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="nlfv: default"/>
+            <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="((1 - sgn(t - 1.57e+13))/2)*(-8.8300e-11)"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
+  </ParameterList>
 
-      <ParameterList name="concentration">
-        <ParameterList name="BC 5">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="boundary concentration">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="source terms">
-      <ParameterList name="mass rate">
-
-        <ParameterList name="SRC 0">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-        <ParameterList name="SRC 1">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
-
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-          <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="nlfv: default"/>
-          <Parameter name="discretization secondary" type="string" value="nlfv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
-
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -370,6 +357,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -389,25 +377,25 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -417,13 +405,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="303"/>
+                <Parameter name="value" type="double" value="303.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -431,16 +418,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -449,43 +432,32 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -500,7 +472,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -509,13 +480,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -524,13 +494,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -539,7 +508,7 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="100000"/>
+                <Parameter name="value" type="double" value="100000.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -553,14 +522,13 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
         <!--ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList-->
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -576,18 +544,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -606,12 +571,8 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
- 
   <ParameterList name="preconditioners">
-  
-     
     <ParameterList name="ILU">
       <Parameter name="preconditioning method" type="string" value="ILU"/>
       <ParameterList name="ILU parameters">
@@ -619,7 +580,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-  
     <!--   
     <ParameterList name="SysTG">
       <Parameter name="preconditioning method" type="string" value="systg"/>
@@ -639,7 +599,6 @@
       </ParameterList>
     </ParameterList>
    -->
-    
     <!--
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
@@ -655,9 +614,7 @@
       </ParameterList>
     </ParameterList>
     -->
-  
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_model1a.xml
+++ b/src/pks/multiphase/test/multiphase_model1a.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,269 +41,257 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               mole_fraction_liquid,
-                                                               mole_fraction_vapor }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, mole_fraction_liquid, mole_fraction_vapor}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="mole_fraction_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.3"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.01"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-10"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="40"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="mole_fraction_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.3"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.01"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-10"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <Parameter name="phase" type="string" value="liquid"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-9"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1000.0"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="40"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <Parameter name="phase" type="string" value="liquid"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-09"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -391,8 +378,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -408,14 +395,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp mole fraction gas"/>
         <Parameter name="tag" type="string" value=""/>
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -426,7 +411,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -437,64 +421,44 @@
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     mole_fraction_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, mole_fraction_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     mole_fraction_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, mole_fraction_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     molar_density_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, molar_density_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     molar_density_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, molar_density_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_liquid">
         <Parameter name="evaluator type" type="string" value="mole fraction liquid"/>
         <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
@@ -504,17 +468,14 @@
       </ParameterList>
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -529,7 +490,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -538,13 +498,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -553,13 +512,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -574,7 +532,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -582,11 +539,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -601,7 +557,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -610,25 +565,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -654,7 +606,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Block ILU">
@@ -677,7 +628,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -686,7 +637,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -700,7 +652,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_model1b.xml
+++ b/src/pks/multiphase/test/multiphase_model1b.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,280 +41,268 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               mole_fraction_liquid,
-                                                               mole_fraction_vapor }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, mole_fraction_liquid, mole_fraction_vapor}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="mole_fraction_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4, Na+}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9, 3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030, 0.000030}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020, 0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10, 1.39e-10}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.005"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-10"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="true"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="mole_fraction_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4,Na+}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9, 3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5, 3.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3, 2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10, 1.39e-10}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.005"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-10"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-10"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="Na+"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-10"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-
-        <Parameter name="solver type" type="string" value="nka"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="10"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="true"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 5">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
-        </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-10"/>
-            </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="Na+"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-10"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 5">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -407,8 +394,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -424,14 +411,12 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp mole fraction gas"/>
         <Parameter name="tag" type="string" value=""/>
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -442,7 +427,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -453,65 +437,44 @@
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     mole_fraction_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, mole_fraction_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     mole_fraction_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, mole_fraction_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     molar_density_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, molar_density_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     molar_density_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, molar_density_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_liquid">
         <Parameter name="evaluator type" type="string" value="mole fraction liquid"/>
         <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
@@ -521,17 +484,14 @@
       </ParameterList>
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -546,7 +506,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -555,13 +514,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -570,13 +528,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -591,7 +548,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -599,11 +555,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -618,7 +573,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -627,25 +581,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -671,7 +622,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Block ILU">
@@ -694,7 +644,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -703,7 +653,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -717,7 +668,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_model1c.xml
+++ b/src/pks/multiphase/test/multiphase_model1c.xml
@@ -1,16 +1,14 @@
-
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -43,305 +41,292 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               mole_fraction_liquid,
-                                                               mole_fraction_vapor }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, mole_fraction_liquid, mole_fraction_vapor}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="energy eqn">
+          <Parameter name="primary unknown" type="string" value="temperature"/>
+          <Parameter name="accumulation" type="string" value="energy"/>
+          <ParameterList name="terms">
+            <!--Parameter name="advection 1" type="Array(string)" value="{ advection_energy_liquid, pressure_liquid }"/-->
+            <!--Parameter name="advection 2" type="Array(string)" value="{ advection_energy_gas, pressure_gas }"/-->
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="thermal_conductivity"/>
+              <Parameter name="argument" type="string" value="temperature"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="mole_fraction_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.3"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.01"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="thermal conductivity evaluator">
+        <ParameterList name="thermal conductivity parameters">
+          <ParameterList name="TCM_0">
+            <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
+            <Parameter name="thermal conductivity of rock" type="double" value="0.2"/>
+            <Parameter name="thermal conductivity of liquid" type="double" value="0.1"/>
+            <Parameter name="thermal conductivity of gas" type="double" value="0.02"/>
+            <Parameter name="unsaturated alpha" type="double" value="1.0"/>
+            <Parameter name="epsilon" type="double" value="1e-10"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="energy eqn">
-        <Parameter name="primary unknown" type="string" value="temperature"/>
-        <Parameter name="accumulation" type="string" value="energy"/>
+      <ParameterList name="energy evaluator">
+        <Parameter name="tag" type="string" value=""/>
+        <Parameter name="liquid molar mass" type="double" value="0.018015"/>
+      </ParameterList>
 
-        <ParameterList name="terms">
-          <!--Parameter name="advection 1" type="Array(string)" value="{ advection_energy_liquid, pressure_liquid }"/-->
-          <!--Parameter name="advection 2" type="Array(string)" value="{ advection_energy_gas, pressure_gas }"/-->
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="thermal_conductivity"/>
-            <Parameter name="argument" type="string" value="temperature"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-10"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="25"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="25"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="mole_fraction_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="mole_fraction_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="mole_fraction_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.39e-10}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.3"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.01"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="thermal conductivity evaluator">
-      <ParameterList name="thermal conductivity parameters">
-	<ParameterList name="TCM_0">
-          <Parameter name="thermal conductivity type" type="string" value="two-phase Peters-Lidard"/>
-          <Parameter name="thermal conductivity of rock" type="double" value="0.2"/>
-          <Parameter name="thermal conductivity of liquid" type="double" value="0.1"/>
-          <Parameter name="thermal conductivity of gas" type="double" value="0.02"/>
-          <Parameter name="unsaturated alpha" type="double" value="1.0"/>
-          <Parameter name="epsilon" type="double" value="1.e-10"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-9"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="energy evaluator">
-      <Parameter name="tag" type="string" value=""/>
-      <Parameter name="liquid molar mass" type="double" value="0.018015"/>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-10"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="25"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1000.0"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="25"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-09"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_molar_mass">
         <Parameter name="value" type="double" value="0.018015"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -428,8 +413,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp mole fraction gas"/>
@@ -437,7 +422,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -448,7 +432,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -459,69 +442,48 @@
         <Parameter name="mole fraction gas key" type="string" value="mole_fraction_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     mole_fraction_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, mole_fraction_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     mole_fraction_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, mole_fraction_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     molar_density_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, molar_density_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     molar_density_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, molar_density_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_liquid">
         <Parameter name="evaluator type" type="string" value="mole fraction liquid"/>
         <Parameter name="pressure gas key" type="string" value="pressure_gas"/>
@@ -531,12 +493,10 @@
       </ParameterList>
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -551,7 +511,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -560,13 +519,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -575,13 +533,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -596,7 +553,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="molar"/>
@@ -604,7 +560,7 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
@@ -622,7 +578,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -637,7 +592,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -646,13 +600,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_liquid">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_liquid"/>
@@ -668,12 +621,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="internal_energy_gas">
         <Parameter name="evaluator type" type="string" value="iem water vapor"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_gas"/>
       </ParameterList>
-
       <ParameterList name="internal_energy_rock">
         <Parameter name="evaluator type" type="string" value="iem"/>
         <Parameter name="internal energy key" type="string" value="internal_energy_rock"/>
@@ -689,7 +640,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_fraction_gas">
         <Parameter name="evaluator type" type="string" value="molar fraction gas"/>
         <Parameter name="molar fraction key" type="string" value="molar_fraction_gas"/>
@@ -697,7 +647,6 @@
           <Parameter name="eos type" type="string" value="water vapor over water/ice"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="particle_density">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -705,26 +654,24 @@
             <Parameter name="region" type="string" value="All"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-                <Parameter name="value" type="double" value="2500."/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="2500.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -750,7 +697,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Block ILU">
@@ -774,7 +720,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -783,7 +729,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -797,7 +744,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_model2a.xml
+++ b/src/pks/multiphase/test/multiphase_model2a.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{200.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{200.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,268 +41,256 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               total_component_concentration_liquid,
-                                                               mole_fraction_vapor }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, total_component_concentration_liquid, mole_fraction_vapor}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
+              <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_vapor"/>
-            <Parameter name="argument" type="string" value="mole_fraction_vapor"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="total_component_concentration_gas"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="total_component_concentration_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="total_component_concentration_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
+        </ParameterList>
+      </ParameterList>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000030}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.019}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="NCP function" type="string" value="min"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.3"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.01"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-10"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1000.0"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="40"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="total_component_concentration_gas"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="total_component_concentration_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="total_component_concentration_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{3.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{3.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.9e-2}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="NCP function" type="string" value="min"/>
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.3"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.01"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-10"/>
+        <ParameterList name="mass flux total">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.0"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-4.4155885e-9"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1000.0"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="40"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e6"/>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 4">
+            <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="0.0"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-4.4155885e-9"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 4">
-          <Parameter name="regions" type="Array(string)" value="{Outflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
-            </ParameterList>
-          </ParameterList>
-        </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -390,8 +377,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -407,7 +394,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp molar densities"/>
         <Parameter name="tag" type="string" value=""/>
@@ -415,7 +401,6 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tcc gas key" type="string" value="total_component_concentration_gas"/>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -426,7 +411,6 @@
         <Parameter name="mole fraction vapor key" type="string" value="mole_fraction_vapor"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -435,77 +419,59 @@
         <Parameter name="molar density gas key" type="string" value="total_component_concentration_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ total_component_concentration_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{total_component_concentration_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ total_component_concentration_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{total_component_concentration_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_concentration_liquid">
         <Parameter name="evaluator type" type="string" value="tcc liquid"/>
         <Parameter name="tcc gas key" type="string" value="total_component_concentration_gas"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -520,7 +486,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -529,13 +494,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -544,13 +508,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -565,7 +528,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -574,11 +536,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-3"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -593,7 +554,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -602,25 +562,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="3.0e-5"/>
+                <Parameter name="value" type="double" value="0.000030"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -646,7 +603,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Block ILU">
@@ -670,7 +626,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -679,7 +635,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -693,7 +650,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_smiles.xml
+++ b/src/pks/multiphase/test/multiphase_smiles.xml
@@ -1,15 +1,14 @@
 <ParameterList>
   <ParameterList name="visualization data">
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
-    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e11, -1.0}"/>
+    <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.5768e+11, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Inflow">
@@ -42,254 +41,245 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid,
-                                                               diffusion_gas,
-                                                               diffusion_vapor,
-                                                               saturation_gas,
-                                                               total_component_concentration_gas }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <!--Parameter name="diffusion liquid" type="Array(string)" value="{ diffusion_vapor, mole_fraction_vapor }"/-->
-        </ParameterList>
-      </ParameterList>
-
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="total_component_concentration_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion 0">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="total_component_concentration_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="diffusion 1">
-            <Parameter name="coefficient" type="string" value="diffusion_gas"/>
-            <Parameter name="argument" type="string" value="total_component_concentration_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid, diffusion_gas, diffusion_vapor, saturation_gas, total_component_concentration_gas}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <!--Parameter name="diffusion liquid" type="Array(string)" value="{ diffusion_vapor, mole_fraction_vapor }"/-->
           </ParameterList>
         </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="1"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{Tritium}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{1.0e-5}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{3.016e-3}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{1.76e-5}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="18.0e-3"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="Corey"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.0"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="capillary pressure" type="double" value="1.0e-6"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="nka"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-5"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-        <ParameterList name="nka parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="3"/>
-          <Parameter name="max nka vectors" type="int" value="10"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-        </ParameterList>
-        <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-        <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-        <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
-        <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
-        <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
-    
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Outflow, Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e5"/>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="total_component_concentration_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion 0">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="total_component_concentration_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion 1">
+              <Parameter name="coefficient" type="string" value="diffusion_gas"/>
+              <Parameter name="argument" type="string" value="total_component_concentration_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="concentration">
-        <ParameterList name="BC 2l">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="Tritium"/>
-          <Parameter name="phase" type="string" value="liquid"/>
-          <ParameterList name="boundary concentration">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e-5"/>
+
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="1"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{Tritium}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.000010}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.003016}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.0000176}"/>
+      </ParameterList>
+
+      <Parameter name="molar mass of water" type="double" value="0.0180"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="Corey"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.0"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="capillary pressure" type="double" value="0.0000010"/>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.000010"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-7"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+          </ParameterList>
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
+          <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
+          <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
+          <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
+        </ParameterList>
+      </ParameterList>
+
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Outflow, Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+5"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
-        <ParameterList name="BC 2g">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="Tritium"/>
-          <Parameter name="phase" type="string" value="gas"/>
-          <ParameterList name="boundary concentration">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.760e-10"/>
+        <ParameterList name="concentration">
+          <ParameterList name="BC 2l">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="Tritium"/>
+            <Parameter name="phase" type="string" value="liquid"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="0.000010"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="BC 2g">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="Tritium"/>
+            <Parameter name="phase" type="string" value="gas"/>
+            <ParameterList name="boundary concentration">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.760e-10"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="mass flux total-off">
+          <ParameterList name="BC 3">
+            <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="Tritium"/>
+            <ParameterList name="outward mass flux">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="-1.0e-10"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="mass flux total-off">
-        <ParameterList name="BC 3">
-          <Parameter name="regions" type="Array(string)" value="{Inflow}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="Tritium"/>
-          <ParameterList name="outward mass flux">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="-1.0e-10"/>
+
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
+          </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
     </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="high"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
+  </ParameterList>
 
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -318,7 +308,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="0.0e-20"/>
+                  <Parameter name="value" type="double" value="0e-21"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -362,8 +352,8 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -379,7 +369,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -394,7 +383,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <!-- STORAGE -->
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="storage water"/>
@@ -413,79 +401,59 @@
         <Parameter name="total component concentration gas key" type="string" value="total_component_concentration_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ total_component_concentration_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{total_component_concentration_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ total_component_concentration_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{total_component_concentration_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="diffusion_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     molecular_diff_gas,
-                                                                     porosity,
-                                                                     saturation_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, molecular_diff_gas, porosity, saturation_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_concentration_gas">
         <Parameter name="evaluator type" type="string" value="tcc gas"/>
         <Parameter name="tcc liquid key" type="string" value="total_component_concentration_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="saturation_gas">
         <Parameter name="evaluator type" type="string" value="saturation"/>
         <Parameter name="saturation complement key" type="string" value="saturation_liquid"/>
       </ParameterList>
-
       <ParameterList name="mole_fraction_vapor">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ pressure_gas,
-                                                                     pressure_vapor }"/>
-        <Parameter name="powers" type="Array(int)" value="{ -1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{pressure_gas, pressure_vapor}"/>
+        <Parameter name="powers" type="Array(int)" value="{-1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -500,7 +468,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -515,7 +482,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -524,13 +490,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-3"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -539,13 +504,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-6"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -560,7 +524,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -569,11 +532,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="3.016e-3"/>
+          <Parameter name="molar mass" type="double" value="0.003016"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -596,25 +558,22 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-5"/>
+                <Parameter name="value" type="double" value="0.000010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="high"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -640,7 +599,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="ILU">
@@ -658,7 +616,7 @@
         <Parameter name="max coarse levels" type="int" value="3"/>
         <Parameter name="number of wells" type="int" value="0"/>
         <Parameter name="coarse solver type" type="int" value="0"/>
-        <Parameter name="aff solver type" type="Array(int)" value="{0,2,2}"/>
+        <Parameter name="aff solver type" type="Array(int)" value="{0, 2, 2}"/>
         <Parameter name="relaxation method" type="int" value="99"/>
         <Parameter name="max number of iterations" type="int" value="1"/>
         <Parameter name="relaxation type" type="int" value="3"/>
@@ -667,7 +625,8 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Hypre AMG">  <!-- parent list -->
+    <ParameterList name="Hypre AMG">
+      <!-- parent list -->
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
         <Parameter name="tolerance" type="double" value="0.0"/>
@@ -681,7 +640,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>

--- a/src/pks/multiphase/test/multiphase_source.xml
+++ b/src/pks/multiphase/test/multiphase_source.xml
@@ -3,13 +3,12 @@
     <Parameter name="file name base" type="string" value="phase-transition-1d"/>
     <Parameter name="times start period stop 0" type="Array(double)" value="{0.0, 1.0, -1.0}"/>
   </ParameterList>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
@@ -18,26 +17,26 @@
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Lower left">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{20.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{20.0,20.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{20.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{8.0,4.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{12.0,12.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{8.0, 4.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{12.0, 12.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -58,136 +57,123 @@
   <ParameterList name="domain">
     <Parameter isUsed="true" name="spatial dimension" type="int" value="2"/>
   </ParameterList>
+  <ParameterList name="PKs">
 
-  <ParameterList name="PKs"> <!-- no shift -->
-  <ParameterList name="multiphase">
-    <Parameter name="evaluators" type="Array(string)" value="{ ncp_g,
-                                                               total_water_storage,
-                                                               total_component_storage,
-                                                               advection_water,
-                                                               advection_liquid,
-                                                               advection_gas,
-                                                               diffusion_liquid }"/>
-    <ParameterList name="system">
-      <ParameterList name="pressure eqn">
-        <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_water_storage"/>
-
-        <ParameterList name="terms">
-          <ParameterList name="advection">
-            <Parameter name="coefficient" type="string" value="advection_water"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+    <!-- no shift -->
+    <ParameterList name="multiphase">
+      <Parameter name="evaluators" type="Array(string)" value="{ncp_g, total_water_storage, total_component_storage, advection_water, advection_liquid, advection_gas, diffusion_liquid}"/>
+      <ParameterList name="system">
+        <ParameterList name="pressure eqn">
+          <Parameter name="primary unknown" type="string" value="pressure_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_water_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection">
+              <Parameter name="coefficient" type="string" value="advection_water"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="-1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="-1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="solute eqn">
+          <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
+          <Parameter name="accumulation" type="string" value="total_component_storage"/>
+          <ParameterList name="terms">
+            <ParameterList name="advection 0">
+              <Parameter name="coefficient" type="string" value="advection_liquid"/>
+              <Parameter name="argument" type="string" value="pressure_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
+            <ParameterList name="advection 1">
+              <Parameter name="coefficient" type="string" value="advection_gas"/>
+              <Parameter name="argument" type="string" value="pressure_gas"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="1"/>
+            </ParameterList>
+            <ParameterList name="diffusion">
+              <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
+              <Parameter name="argument" type="string" value="molar_density_liquid"/>
+              <Parameter name="scaling factor" type="double" value="1.0"/>
+              <Parameter name="phase" type="int" value="0"/>
+            </ParameterList>
           </ParameterList>
+        </ParameterList>
+        <ParameterList name="constraint eqn">
+          <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
+          <Parameter name="ncp evaluators" type="Array(string)" value="{ncp_f, ncp_g}"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="solute eqn">
-        <Parameter name="primary unknown" type="string" value="molar_density_liquid"/>
-        <Parameter name="accumulation" type="string" value="total_component_storage"/>
+      <Parameter name="Jacobian type" type="string" value="analytic"/>
+      <Parameter name="linear solver" type="string" value="GMRES"/>
+      <Parameter name="preconditioner" type="string" value="ILU"/>
+      <Parameter name="error control options" type="Array(string)" value="{residual}"/>
+      <Parameter name="number aqueous components" type="int" value="1"/>
+      <Parameter name="number gaseous components" type="int" value="0"/>
+      <ParameterList name="molecular diffusion">
+        <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0020}"/>
+        <Parameter name="Henry dimensionless constants" type="Array(double)" value="{0.00000765}"/>
+      </ParameterList>
 
-        <ParameterList name="terms">
-          <ParameterList name="advection 0">
-            <Parameter name="coefficient" type="string" value="advection_liquid"/>
-            <Parameter name="argument" type="string" value="pressure_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
-          <ParameterList name="advection 1">
-            <Parameter name="coefficient" type="string" value="advection_gas"/>
-            <Parameter name="argument" type="string" value="pressure_gas"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="1"/>
-          </ParameterList>
-          <ParameterList name="diffusion">
-            <Parameter name="coefficient" type="string" value="diffusion_liquid"/>
-            <Parameter name="argument" type="string" value="molar_density_liquid"/>
-            <Parameter name="scaling factor" type="double" value="1.0"/>
-            <Parameter name="phase" type="int" value="0"/>
-          </ParameterList>
+      <Parameter name="molar mass of water" type="double" value="0.010"/>
+      <Parameter name="CPR enhancement" type="bool" value="false"/>
+      <ParameterList name="CPR parameters">
+        <Parameter name="global solve" type="bool" value="true"/>
+        <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
+        <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
+      </ParameterList>
+
+      <ParameterList name="water retention models">
+        <ParameterList name="WRM for All">
+          <Parameter name="regions" type="Array(string)" value="{All}"/>
+          <Parameter name="water retention model" type="string" value="van Genuchten"/>
+          <Parameter name="van Genuchten m" type="double" value="0.32886"/>
+          <Parameter name="van Genuchten n" type="double" value="1.49"/>
+          <Parameter name="van Genuchten l" type="double" value="0.5"/>
+          <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
+          <Parameter name="residual saturation liquid" type="double" value="0.4"/>
+          <Parameter name="residual saturation gas" type="double" value="0.0"/>
+          <Parameter name="relative permeability model" type="string" value="Mualem"/>
+          <Parameter name="regularization interval kr" type="double" value="0.005"/>
+          <Parameter name="regularization interval pc" type="double" value="0.001"/>
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="constraint eqn">
-        <Parameter name="primary unknown" type="string" value="saturation_liquid"/>
-        <Parameter name="ncp evaluators" type="Array(string)" value="{ ncp_f, ncp_g }"/>
-      </ParameterList>
-    </ParameterList>
-
-    <Parameter name="Jacobian type" type="string" value="analytic"/>
-    <Parameter name="linear solver" type="string" value="GMRES"/>
-    <Parameter name="preconditioner" type="string" value="ILU"/>
-    <Parameter name="error control options" type="Array(string)" value="{residual}"/>
-    <Parameter name="number aqueous components" type="int" value="1"/>
-    <Parameter name="number gaseous components" type="int" value="0"/>
-
-    <ParameterList name="molecular diffusion">
-      <Parameter name="aqueous names" type="Array(string)" value="{SH4}"/>
-      <Parameter name="aqueous values" type="Array(double)" value="{0.0}"/>
-      <Parameter name="gaseous values" type="Array(double)" value="{0.0}"/>
-      <Parameter name="molar masses" type="Array(double)" value="{2.0e-03}"/>
-      <Parameter name="Henry dimensionless constants" type="Array(double)" value="{7.65e-06}"/>
-    </ParameterList>
-
-    <Parameter name="molar mass of water" type="double" value="1.0e-02"/>
-
-    <Parameter name="CPR enhancement" type="bool" value="false"/>
-    <ParameterList name="CPR parameters">
-      <Parameter name="global solve" type="bool" value="true"/>
-      <Parameter name="correction blocks" type="Array(int)" value="{0}"/>
-      <Parameter name="preconditioner" type="Array(string)" value="{Hypre AMG}"/>
-    </ParameterList>
-
-    <ParameterList name="water retention models">
-      <ParameterList name="WRM for All">
-        <Parameter name="regions" type="Array(string)" value="{All}"/>
-        <Parameter name="water retention model" type="string" value="van Genuchten"/>
-        <Parameter name="van Genuchten m" type="double" value="0.32886"/>
-        <Parameter name="van Genuchten n" type="double" value="1.49"/>
-        <Parameter name="van Genuchten l" type="double" value="0.5"/>
-        <Parameter name="van Genuchten alpha" type="double" value="5.0e-7"/>
-        <Parameter name="residual saturation liquid" type="double" value="0.4"/>
-        <Parameter name="residual saturation gas" type="double" value="0.0"/>
-        <Parameter name="relative permeability model" type="string" value="Mualem"/>
-        <Parameter name="regularization interval kr" type="double" value="0.005"/>
-        <Parameter name="regularization interval pc" type="double" value="0.001"/>
-      </ParameterList>
-    </ParameterList>
-
-    <ParameterList name="time integrator">
-      <Parameter name="time integration method" type="string" value="BDF1"/>
-      <ParameterList name="BDF1">
-        <Parameter name="timestep controller type" type="string" value="standard"/>
-        <ParameterList name="timestep controller standard parameters">
-          <Parameter name="max iterations" type="int" value="15"/>
-          <Parameter name="min iterations" type="int" value="10"/>
-          <Parameter name="timestep increase factor" type="double" value="1.25"/>
-          <Parameter name="timestep reduction factor" type="double" value="0.8"/>
-          <Parameter name="max timestep" type="double" value="6.0e+10"/>
-          <Parameter name="min timestep" type="double" value="1.0e-20"/>
-        </ParameterList>
-
-        <Parameter name="solver type" type="string" value="Newton"/>
-        <ParameterList name="Newton parameters">
-          <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
-          <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
-          <Parameter name="max du growth factor" type="double" value="1.0e+03"/>
-          <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
-          <Parameter name="max divergent iterations" type="int" value="10"/>
-          <Parameter name="limit iterations" type="int" value="20"/>
-          <Parameter name="modify correction" type="bool" value="true"/>
-          <Parameter name="monitor" type="string" value="monitor update"/>
-          <Parameter name="make one iteration" type="bool" value="true"/>
-        </ParameterList>
-       
-        <!-- 
+      <ParameterList name="time integrator">
+        <Parameter name="time integration method" type="string" value="BDF1"/>
+        <ParameterList name="BDF1">
+          <Parameter name="timestep controller type" type="string" value="standard"/>
+          <ParameterList name="timestep controller standard parameters">
+            <Parameter name="max iterations" type="int" value="15"/>
+            <Parameter name="min iterations" type="int" value="10"/>
+            <Parameter name="timestep increase factor" type="double" value="1.25"/>
+            <Parameter name="timestep reduction factor" type="double" value="0.8"/>
+            <Parameter name="max timestep" type="double" value="6.0e+10"/>
+            <Parameter name="min timestep" type="double" value="1.0e-20"/>
+          </ParameterList>
+          <Parameter name="solver type" type="string" value="Newton"/>
+          <ParameterList name="Newton parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="1.0e-8"/>
+            <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
+            <Parameter name="max du growth factor" type="double" value="1.0e+3"/>
+            <Parameter name="max error growth factor" type="double" value="1.0e+10"/>
+            <Parameter name="max divergent iterations" type="int" value="10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="modify correction" type="bool" value="true"/>
+            <Parameter name="monitor" type="string" value="monitor update"/>
+            <Parameter name="make one iteration" type="bool" value="true"/>
+          </ParameterList>
+          <!-- 
         <ParameterList name="nka parameters">
           <Parameter name="nonlinear tolerance" type="double" value="1.0e-6"/>
           <Parameter name="diverged tolerance" type="double" value="1.0e+10"/>
@@ -199,132 +185,134 @@
           <Parameter name="monitor" type="string" value="monitor update"/>
         </ParameterList>
         -->
-
-        <!--
+          <!--
         <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
         <Parameter name="extrapolate initial guess" type="bool" value="false"/>
         <Parameter name="nonlinear iteration initial guess extrapolation order" type="int" value="1"/>
         <Parameter name="restart tolerance relaxation factor" type="double" value="1.0"/>
         <Parameter name="restart tolerance relaxation factor damping" type="double" value="1.0"/>
         -->
-        <ParameterList name="verbose object">
-          <Parameter name="verbosity level" type="string" value="high"/>
+          <ParameterList name="verbose object">
+            <Parameter name="verbosity level" type="string" value="high"/>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
-    <ParameterList name="boundary conditions">
-      <ParameterList name="pressure liquid">
-        <ParameterList name="BC 1">
-          <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary pressure">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0e+06"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="pressure liquid">
+          <ParameterList name="BC 1">
+            <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary pressure">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0e+6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="saturation">
+          <ParameterList name="BC 2">
+            <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="boundary saturation">
+              <ParameterList name="function-constant">
+                <Parameter name="value" type="double" value="1.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      <ParameterList name="saturation">
-        <ParameterList name="BC 2">
-          <Parameter name="regions" type="Array(string)" value="{Boundary}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <ParameterList name="boundary saturation">
-            <ParameterList name="function-constant">
-              <Parameter name="value" type="double" value="1.0"/>
+
+      <ParameterList name="source terms">
+        <ParameterList name="mass rate">
+          <ParameterList name="SRC 0">
+            <Parameter name="regions" type="Array(string)" value="{Middle domain}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="SH4"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="1.0e-6"/>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+          <ParameterList name="SRC 1">
+            <Parameter name="regions" type="Array(string)" value="{All}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <Parameter name="name" type="string" value="water"/>
+            <ParameterList name="injector">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="0.0"/>
+              </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
-        
-    <ParameterList name="source terms">
-      <ParameterList name="mass rate">
-        <ParameterList name="SRC 0">
-          <Parameter name="regions" type="Array(string)" value="{Middle domain}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="SH4"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="1.0e-6"/>
+      <ParameterList name="operators">
+        <ParameterList name="advection operator">
+          <Parameter name="discretization primary" type="string" value="upwind"/>
+          <Parameter name="reconstruction order" type="int" value="0"/>
+        </ParameterList>
+        <ParameterList name="diffusion operator">
+          <ParameterList name="upwind">
+            <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
+            <ParameterList name="upwind parameters">
+              <Parameter name="tolerance" type="double" value="1e-12"/>
             </ParameterList>
           </ParameterList>
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
+          </ParameterList>
         </ParameterList>
-
-        <ParameterList name="SRC 1">
-          <Parameter name="regions" type="Array(string)" value="{All}"/>
-          <Parameter name="spatial distribution method" type="string" value="none"/>
-          <Parameter name="name" type="string" value="water"/>
-          <ParameterList name="injector">
-            <ParameterList name="function-exprtk">
-              <Parameter name="number of arguments" type="int" value="4"/>
-              <Parameter name="formula" type="string" value="0.0"/>
-            </ParameterList>
+        <ParameterList name="molecular diffusion operator">
+          <ParameterList name="matrix">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
+          </ParameterList>
+          <ParameterList name="preconditioner">
+            <Parameter name="discretization primary" type="string" value="fv: default"/>
+            <Parameter name="discretization secondary" type="string" value="fv: default"/>
+            <Parameter name="schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
+            <Parameter name="nonlinear coefficient" type="string" value="none"/>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
+      <ParameterList name="verbose object">
+        <Parameter name="verbosity level" type="string" value="extreme"/>
+      </ParameterList>
+
     </ParameterList>
 
+  </ParameterList>
 
-    <ParameterList name="operators">
-      <ParameterList name="advection operator">
-        <Parameter name="discretization primary" type="string" value="upwind"/>
-        <Parameter name="reconstruction order" type="int" value="0"/>
-      </ParameterList>
-      <ParameterList name="diffusion operator">
-        <ParameterList name="upwind">
-          <Parameter name="upwind method" type="string" value="upwind: darcy velocity"/>
-          <ParameterList name="upwind parameters">
-             <Parameter name="tolerance" type="double" value="1e-12"/>
-          </ParameterList>
-        </ParameterList>
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="upwind: face"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="molecular diffusion operator">
-        <ParameterList name="matrix">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-        <ParameterList name="preconditioner">
-          <Parameter name="discretization primary" type="string" value="fv: default"/>
-          <Parameter name="discretization secondary" type="string" value="fv: default"/>
-          <Parameter name="schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="preconditioner schema" type="Array(string)" value="{cell}"/>
-          <Parameter name="nonlinear coefficient" type="string" value="none"/>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="verbose object">
-      <Parameter name="verbosity level" type="string" value="extreme"/>
-    </ParameterList>
-  </ParameterList> 
-  </ParameterList>  <!-- PKs, no shift -->
-
+  <!-- PKs, no shift -->
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="101325"/>
+        <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
 
       <ParameterList name="pressure_liquid">
@@ -335,7 +323,7 @@
             <ParameterList name="function">
               <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="4"/>
-                  <Parameter name="formula" type="string" value="1.0e+06"/>
+                <Parameter name="formula" type="string" value="1.0e+06"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -371,7 +359,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-     
+
       <ParameterList name="mass_density_liquid">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -386,6 +374,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="mass_density_gas">
         <ParameterList name="function">
           <ParameterList name="All">
@@ -405,25 +394,25 @@
           <ParameterList name="All">
             <Parameter name="regions" type="Array(string)" value="{All}"/>
             <Parameter name="component" type="string" value="cell"/>
-              <ParameterList name="function">
-                <Parameter name="number of dofs" type="int" value="2"/>
-                <Parameter name="function type" type="string" value="composite function"/>
-                <ParameterList name="dof 1 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
-                </ParameterList>
-                <ParameterList name="dof 2 function">
-                  <ParameterList name="function-constant">
-                    <Parameter name="value" type="double" value="5.0e-20"/>
-                  </ParameterList>
+            <ParameterList name="function">
+              <Parameter name="number of dofs" type="int" value="2"/>
+              <Parameter name="function type" type="string" value="composite function"/>
+              <ParameterList name="dof 1 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
                 </ParameterList>
               </ParameterList>
+              <ParameterList name="dof 2 function">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="5.0e-20"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="evaluators">
       <ParameterList name="temperature">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
@@ -433,13 +422,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="298"/>
+                <Parameter name="value" type="double" value="298.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="ncp_g">
         <Parameter name="evaluator type" type="string" value="ncp henry law"/>
         <Parameter name="tag" type="string" value=""/>
@@ -447,16 +435,12 @@
         <Parameter name="molar density liquid key" type="string" value="molar_density_liquid"/>
         <Parameter name="temperature key" type="string" value="temperature"/>
       </ParameterList>
-
       <ParameterList name="total_water_storage">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="total_component_storage">
         <Parameter name="evaluator type" type="string" value="storage component jaffre"/>
         <Parameter name="saturation liquid key" type="string" value="saturation_liquid"/>
@@ -465,43 +449,32 @@
         <Parameter name="molar density gas key" type="string" value="molar_density_gas"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- ADVECTION -->
       <ParameterList name="advection_water">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_water,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_water, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_liquid,
-                                                                     rel_permeability_liquid,
-                                                                     viscosity_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_liquid, rel_permeability_liquid, viscosity_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
       <ParameterList name="advection_gas">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molar_density_gas,
-                                                                     rel_permeability_gas,
-                                                                     viscosity_gas }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, -1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molar_density_gas, rel_permeability_gas, viscosity_gas}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, -1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <!-- DIFFUSION -->
       <ParameterList name="diffusion_liquid">
         <Parameter name="evaluator type" type="string" value="product"/>
-        <Parameter name="dependencies" type="Array(string)" value="{ molecular_diff_liquid,
-                                                                     porosity,
-                                                                     saturation_liquid }"/>
-        <Parameter name="powers" type="Array(int)" value="{ 1, 1, 1 }"/>
+        <Parameter name="dependencies" type="Array(string)" value="{molecular_diff_liquid, porosity, saturation_liquid}"/>
+        <Parameter name="powers" type="Array(int)" value="{1, 1, 1}"/>
         <Parameter name="tag" type="string" value=""/>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -516,7 +489,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -525,13 +497,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e-03"/>
+                <Parameter name="value" type="double" value="0.0010"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="viscosity_gas">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -540,13 +511,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="9.0e-06"/>
+                <Parameter name="value" type="double" value="0.0000090"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molar_density_water">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -555,13 +525,12 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="1.0e+05"/>
+                <Parameter name="value" type="double" value="1.0e+5"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-     
       <ParameterList name="molar_density_gas">
         <Parameter name="evaluator type" type="string" value="eos"/>
         <Parameter name="eos basis" type="string" value="both"/>
@@ -570,11 +539,10 @@
         <Parameter name="pressure key" type="string" value="pressure_gas"/>
         <ParameterList name="EOS parameters">
           <Parameter name="eos type" type="string" value="ideal gas"/>
-          <Parameter name="molar mass" type="double" value="2.0e-03"/>
+          <Parameter name="molar mass" type="double" value="0.0020"/>
           <Parameter name="density" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="molecular_diff_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -590,18 +558,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="verbose object">
       <Parameter name="verbosity level" type="string" value="extreme"/>
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="GMRES">
@@ -619,7 +584,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-   <!--
+    <!--
     <ParameterList name="AMESOS">
       <Parameter name="direct method" type="string" value="amesos"/>
       <ParameterList name="amesos parameters">
@@ -629,12 +594,8 @@
     </ParameterList>
     -->
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
- 
   <ParameterList name="preconditioners">
-  
-     
     <ParameterList name="ILU">
       <Parameter name="preconditioning method" type="string" value="ILU"/>
       <ParameterList name="ILU parameters">
@@ -642,7 +603,6 @@
         <Parameter name="verbosity" type="int" value="0"/>
       </ParameterList>
     </ParameterList>
-  
     <!--   
     <ParameterList name="SysTG">
       <Parameter name="preconditioning method" type="string" value="systg"/>
@@ -662,7 +622,6 @@
       </ParameterList>
     </ParameterList>
    -->
-    
     <!--
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioner type" type="string" value="boomer amg"/>
@@ -678,9 +637,7 @@
       </ParameterList>
     </ParameterList>
     -->
-  
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="extreme"/>
   </ParameterList>

--- a/src/pks/navier_stokes/test/navier_stokes_2D.xml
+++ b/src/pks/navier_stokes/test/navier_stokes_2D.xml
@@ -1,47 +1,46 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <Parameter name="end time" type="double" value="5000.0"/>
   <Parameter name="initial timestep" type="double" value="1000.0"/>
   <Parameter name="max iterations" type="int" value="50"/>
   <Parameter name="mesh resolution" type="int" value="20"/>
-
   <!--  REGIONS  -->
   <ParameterList name="regions">
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="Navier Stokes">
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
@@ -56,44 +55,44 @@
             <Parameter name="method order" type="int" value="1"/>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="divergence operator">
           <Parameter name="matrix type" type="string" value="divergence"/>
           <ParameterList name="schema domain">
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="BernardiRaugel"/>
-            <Parameter name="method order" type="int" value="-1"/> <!-- not used !-->
+            <Parameter name="method order" type="int" value="-1"/>
+            <!-- not used !-->
           </ParameterList>
           <ParameterList name="schema range">
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="dg modal"/>
-            <Parameter name="method order" type="int" value="0"/> 
-            <Parameter name="dg basis" type="string" value="regularized"/> 
+            <Parameter name="method order" type="int" value="0"/>
+            <Parameter name="dg basis" type="string" value="regularized"/>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="gradient operator">
           <Parameter name="matrix type" type="string" value="divergence transpose"/>
           <Parameter name="factory" type="string" value="schema range"/>
           <ParameterList name="schema range">
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="BernardiRaugel"/>
-            <Parameter name="method order" type="int" value="-1"/> <!-- not used !-->
+            <Parameter name="method order" type="int" value="-1"/>
+            <!-- not used !-->
           </ParameterList>
           <ParameterList name="schema domain">
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="dg modal"/>
-            <Parameter name="method order" type="int" value="0"/> 
-            <Parameter name="dg basis" type="string" value="regularized"/> 
+            <Parameter name="method order" type="int" value="0"/>
+            <Parameter name="dg basis" type="string" value="regularized"/>
           </ParameterList>
         </ParameterList>
-
         <ParameterList name="advection operator">
           <Parameter name="matrix type" type="string" value="advection"/>
           <ParameterList name="schema">
             <Parameter name="base" type="string" value="cell"/>
             <Parameter name="method" type="string" value="BernardiRaugel"/>
-            <Parameter name="method order" type="int" value="-1"/> <!-- not used !-->
+            <Parameter name="method order" type="int" value="-1"/>
+            <!-- not used !-->
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -103,11 +102,9 @@
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <!--Parameter name="preconditioner enhancement" type="string" value="linear operator"/-->
         <Parameter name="error control options" type="Array(string)" value="{pressure}"/>
-
         <Parameter name="time integration method" type="string" value="BDF1"/>
         <ParameterList name="BDF1">
           <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -117,10 +114,9 @@
             <Parameter name="max timestep" type="double" value="1e+8"/>
             <Parameter name="min timestep" type="double" value="0.0"/>
           </ParameterList>
-
           <Parameter name="solver type" type="string" value="nka"/>
           <ParameterList name="nka parameters">
-            <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
             <Parameter name="diverged tolerance" type="double" value="1e+10"/>
             <Parameter name="limit iterations" type="int" value="20"/>
             <Parameter name="max du growth factor" type="double" value="1e+5"/>
@@ -173,21 +169,25 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.0"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_viscosity">
         <Parameter name="value" type="double" value="0.01"/>
       </ParameterList>
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
@@ -241,9 +241,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="PCG with Hypre AMG">
@@ -253,7 +253,6 @@
         <Parameter name="error tolerance" type="double" value="1e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="linear operator">
       <Parameter name="iterative method" type="string" value="gmres"/>
       <ParameterList name="gmres parameters">
@@ -266,7 +265,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -288,4 +286,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/shallow_water/test/pipe_flow_lake_at_rest.xml
+++ b/src/pks/shallow_water/test/pipe_flow_lake_at_rest.xml
@@ -1,19 +1,19 @@
 <ParameterList name="Main">
   <ParameterList name="mesh">
     <ParameterList name="pipe">
-      <Parameter name="mesh type" type="string" value="aliased" />
+      <Parameter name="mesh type" type="string" value="aliased"/>
       <ParameterList name="aliased parameters">
-        <Parameter name="target" type="string" value="domain" />
+        <Parameter name="target" type="string" value="domain"/>
       </ParameterList>
       <ParameterList name="pipe">
       </ParameterList>
     </ParameterList>
     <ParameterList name="domain">
-      <Parameter name="mesh type" type="string" value="generate mesh" />
+      <Parameter name="mesh type" type="string" value="generate mesh"/>
       <ParameterList name="generate mesh parameters">
-        <Parameter name="number of cells" type="Array(int)" value="{50, 1}" />
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}" />
-        <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 2.0}" />
+        <Parameter name="number of cells" type="Array(int)" value="{50, 1}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -22,52 +22,50 @@
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,2.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left half">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,2.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
-    </ParameterList>      
+    </ParameterList>
     <ParameterList name="Junction">
       <ParameterList name="region: point">
-        <Parameter name="coordinate" type="Array(double)" value="{3.0,0.0}"/>
+        <Parameter name="coordinate" type="Array(double)" value="{3.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="cycle driver" type="ParameterList">
-    <Parameter name="start time" type="double" value=" 0" />
-    <Parameter name="start time units" type="string" value="s" />
-    <Parameter name="end time" type="double" value="100.0" />
-    <Parameter name="end time units" type="string" value="s" />
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="start time units" type="string" value="s"/>
+    <Parameter name="end time" type="double" value="100.0"/>
+    <Parameter name="end time units" type="string" value="s"/>
     <ParameterList name="PK tree" type="ParameterList">
       <ParameterList name="pipe flow" type="ParameterList">
-        <Parameter name="PK type" type="string" value="pipe flow" />
+        <Parameter name="PK type" type="string" value="pipe flow"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="PKs">
+
     <ParameterList name="pipe flow">
       <Parameter name="domain name" type="string" value="pipe"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
 
       <Parameter name="diameter key" type="string" value="pipe-diameter"/>
       <Parameter name="direction key" type="string" value="pipe-direction"/>
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
@@ -75,13 +73,12 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.6"/>
       </ParameterList>
-      
+
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="use limiter" type="bool" value="true"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-     
       <!--ParameterList name="boundary conditions">
         <ParameterList name="wetted area">
           <ParameterList name="BC 0">
@@ -116,37 +113,37 @@
           </ParameterList>
         </ParameterList>
       </ParameterList-->
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state" type="ParameterList">
     <ParameterList name="evaluators">
       <ParameterList name="pipe-diameter">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="Computational domain">
-           <Parameter name="region" type="string" value="Computational domain"/>
-            <Parameter name="component" type="string" value="cell" />
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <Parameter name="number of dofs" type="int" value="1" />
-              <Parameter name="function type" type="string" value="composite function" />
+              <Parameter name="number of dofs" type="int" value="1"/>
+              <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="10" />
+                  <Parameter name="value" type="double" value="10.0"/>
                 </ParameterList>
               </ParameterList>
-           </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="pipe-direction">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function" type="ParameterList">
-
           <ParameterList name="pipe">
-            <Parameter name="region" type="string" value="Computational domain" />
-            <Parameter name="component" type="string" value="cell" />
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <Parameter name="number of dofs" type="int" value="2"/>
               <Parameter name="function type" type="string" value="composite function"/>
@@ -162,10 +159,9 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-
           <ParameterList name="pipe junction">
-            <Parameter name="region" type="string" value="Junction" />
-            <Parameter name="component" type="string" value="cell" />
+            <Parameter name="region" type="string" value="Junction"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <Parameter name="number of dofs" type="int" value="2"/>
               <Parameter name="function type" type="string" value="composite function"/>
@@ -183,7 +179,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="field evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -199,8 +194,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -219,7 +214,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-exprtk"> <!-- time component -->
+              <ParameterList name="function-exprtk">
+                <!-- time component -->
                 <Parameter name="number of arguments" type="int" value="4"/>
                 <Parameter name="formula" type="string" value="0.5 * abs(x - 5.0)"/>
               </ParameterList>
@@ -234,7 +230,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-exprtk"> <!-- time component -->
+              <ParameterList name="function-exprtk">
+                <!-- time component -->
                 <Parameter name="number of arguments" type="int" value="4"/>
                 <Parameter name="formula" type="string" value="4.0"/>
               </ParameterList>
@@ -265,17 +262,16 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization">
     <ParameterList name="domain" type="ParameterList">
-      <Parameter name="times start period stop" type="Array(double)" value="{ 0, 1, -1}" /> 
+      <Parameter name="times start period stop" type="Array(double)" value="{0.0, 1.0, -1.0}"/>
     </ParameterList>
     <ParameterList name="pipe" type="ParameterList">
-      <Parameter name="times start period stop" type="Array(double)" value="{ 0, 1, -1}" /> 
+      <Parameter name="times start period stop" type="Array(double)" value="{0.0, 1.0, -1.0}"/>
       <!--Parameter name="cycles start period stop" type="Array(int)" value="{ 0, 20, -1}" /-->
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/shallow_water/test/pipe_flow_mass_balance.xml
+++ b/src/pks/shallow_water/test/pipe_flow_mass_balance.xml
@@ -1,19 +1,19 @@
 <ParameterList name="Main" type="ParameterList">
   <ParameterList name="mesh" type="ParameterList">
     <ParameterList name="pipe" type="ParameterList">
-      <Parameter name="mesh type" type="string" value="aliased" />
+      <Parameter name="mesh type" type="string" value="aliased"/>
       <ParameterList name="aliased parameters" type="ParameterList">
-        <Parameter name="target" type="string" value="domain" />
+        <Parameter name="target" type="string" value="domain"/>
       </ParameterList>
       <ParameterList name="pipe">
       </ParameterList>
     </ParameterList>
     <ParameterList name="domain" type="ParameterList">
-      <Parameter name="mesh type" type="string" value="generate mesh" />
+      <Parameter name="mesh type" type="string" value="generate mesh"/>
       <ParameterList name="generate mesh parameters" type="ParameterList">
-        <Parameter name="number of cells" type="Array(int)" value="{50, 1}" />
-        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0 }" />
-        <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 2.0}" />
+        <Parameter name="number of cells" type="Array(int)" value="{50, 1}"/>
+        <Parameter name="domain low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="domain high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -22,62 +22,56 @@
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,2.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left half">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,2.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>      
-    <ParameterList name="Right">
-      <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{10.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,1.0}"/>
-      </ParameterList>
-    </ParameterList>      
-    
-    <ParameterList name="Junction">
-      <ParameterList name="region: point">
-        <Parameter name="coordinate" type="Array(double)" value="{3.0,0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
-
+    <ParameterList name="Right">
+      <ParameterList name="region: box">
+        <Parameter name="low coordinate" type="Array(double)" value="{10.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Junction">
+      <ParameterList name="region: point">
+        <Parameter name="coordinate" type="Array(double)" value="{3.0, 0.0}"/>
+      </ParameterList>
+    </ParameterList>
   </ParameterList>
 
   <ParameterList name="cycle driver" type="ParameterList">
-    <Parameter name="start time" type="double" value=" 0" />
-    <Parameter name="start time units" type="string" value="s" />
-    <Parameter name="end time" type="double" value="100.0" />
-    <Parameter name="end time units" type="string" value="s" />
+    <Parameter name="start time" type="double" value="0.0"/>
+    <Parameter name="start time units" type="string" value="s"/>
+    <Parameter name="end time" type="double" value="100.0"/>
+    <Parameter name="end time units" type="string" value="s"/>
     <ParameterList name="PK tree" type="ParameterList">
       <ParameterList name="pipe flow" type="ParameterList">
-        <Parameter name="PK type" type="string" value="pipe flow" />
+        <Parameter name="PK type" type="string" value="pipe flow"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="PKs" type="ParameterList">
 
     <ParameterList name="pipe flow">
       <Parameter name="domain name" type="string" value="pipe"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
       </ParameterList>
 
       <Parameter name="diameter key" type="string" value="pipe-diameter"/>
-
       <Parameter name="direction key" type="string" value="pipe-direction"/>
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="limiter" type="string" value="Barth-Jespersen"/>
@@ -85,14 +79,12 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
-      
+
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="use limiter" type="bool" value="true"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-     
-      
       <ParameterList name="boundary conditions">
         <ParameterList name="discharge">
           <ParameterList name="BC 1">
@@ -103,7 +95,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1e-2"/>
+                  <Parameter name="value" type="double" value="0.01"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -121,7 +113,7 @@
               <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1e-2"/>
+                  <Parameter name="value" type="double" value="0.01"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -131,46 +123,40 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-
-
         </ParameterList>
       </ParameterList>
-      
 
     </ParameterList>
-    
+
   </ParameterList>
 
   <ParameterList name="state" type="ParameterList">
-
     <ParameterList name="evaluators">
-
       <ParameterList name="pipe-diameter" type="ParameterList">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
           <ParameterList name="Computational domain">
-           <Parameter name="region" type="string" value="Computational domain" />
-            <Parameter name="component" type="string" value="cell" />
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <Parameter name="number of dofs" type="int" value="1" />
-              <Parameter name="function type" type="string" value="composite function" />
+              <Parameter name="number of dofs" type="int" value="1"/>
+              <Parameter name="function type" type="string" value="composite function"/>
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="5" />
+                  <Parameter name="value" type="double" value="5.0"/>
                 </ParameterList>
               </ParameterList>
-           </ParameterList>
+            </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="pipe-direction">
-        <Parameter name="evaluator type" type="string" value="independent variable" />
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function" type="ParameterList">
-
-          <ParameterList name="pipe" type="ParameterList">  <!-- USER DEFINED NAME -->
-            <Parameter name="region" type="string" value="Computational domain" />
-            <Parameter name="component" type="string" value="cell" />
+          <ParameterList name="pipe" type="ParameterList">
+            <!-- USER DEFINED NAME -->
+            <Parameter name="region" type="string" value="Computational domain"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <Parameter name="number of dofs" type="int" value="2"/>
               <Parameter name="function type" type="string" value="composite function"/>
@@ -186,10 +172,10 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-
-          <ParameterList name="pipe junction" type="ParameterList">  <!-- USER DEFINED NAME -->
-            <Parameter name="region" type="string" value="Junction" />
-            <Parameter name="component" type="string" value="cell" />
+          <ParameterList name="pipe junction" type="ParameterList">
+            <!-- USER DEFINED NAME -->
+            <Parameter name="region" type="string" value="Junction"/>
+            <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <Parameter name="number of dofs" type="int" value="2"/>
               <Parameter name="function type" type="string" value="composite function"/>
@@ -205,11 +191,8 @@
               </ParameterList>
             </ParameterList>
           </ParameterList>
-
-
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="porosity">
         <Parameter name="field evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -225,9 +208,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -246,7 +228,7 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-exprtk"> 
+              <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="4"/>
                 <Parameter name="formula" type="string" value="0.5 * abs(x - 5.0)"/>
               </ParameterList>
@@ -261,7 +243,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-exprtk"> <!-- time component -->
+              <ParameterList name="function-exprtk">
+                <!-- time component -->
                 <Parameter name="number of arguments" type="int" value="4"/>
                 <Parameter name="formula" type="string" value="4.0"/>
               </ParameterList>
@@ -292,19 +275,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
+
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="visualization">
     <ParameterList name="domain" type="ParameterList">
-      <Parameter name="times start period stop" type="Array(double)" value="{ 0, 1, -1}" /> 
+      <Parameter name="times start period stop" type="Array(double)" value="{0.0, 1.0, -1.0}"/>
       <!-- <Parameter name="cycles start period stop" type="Array(int)" value="{ 0, 20, -1}" /> -->
     </ParameterList>
     <ParameterList name="pipe" type="ParameterList">
-      <Parameter name="times start period stop" type="Array(double)" value="{ 0, 1, -1}" /> 
+      <Parameter name="times start period stop" type="Array(double)" value="{0.0, 1.0, -1.0}"/>
       <!-- <Parameter name="cycles start period stop" type="Array(int)" value="{ 0, 20, -1}" /> -->
     </ParameterList>
   </ParameterList>
-  
 </ParameterList>

--- a/src/pks/shallow_water/test/shallow_water_1D.xml
+++ b/src/pks/shallow_water/test/shallow_water_1D.xml
@@ -1,27 +1,26 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{2000.0,50.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{2000.0, 50.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -33,12 +32,11 @@
         <Parameter name="limiter location" type="string" value="node"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-      
-
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -73,7 +71,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -94,8 +94,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -114,7 +114,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -128,7 +129,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -158,10 +160,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-

--- a/src/pks/shallow_water/test/shallow_water_2D_smooth.xml
+++ b/src/pks/shallow_water/test/shallow_water_2D_smooth.xml
@@ -1,27 +1,26 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,10.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 10.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
@@ -33,12 +32,15 @@
         <Parameter name="limiter location" type="string" value="node"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <Parameter name="cfl" type="double" value="0.1"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="central upwind"/>
+      <ParameterList name="boundary conditions">
+      </ParameterList>
 
-      <ParameterList name="boundary conditions"/>
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -59,8 +61,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -79,7 +81,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -93,7 +96,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -123,10 +127,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-

--- a/src/pks/shallow_water/test/shallow_water_Thacker.xml
+++ b/src/pks/shallow_water/test/shallow_water_Thacker.xml
@@ -1,28 +1,25 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-3.0,-3.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{3.0,3.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-3.0, -3.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{3.0, 3.0}"/>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="AllBoundary">
       <ParameterList name="region: boundary">
         <Parameter name="entity" type="string" value="face"/>
       </ParameterList>
     </ParameterList>
-      
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
@@ -34,25 +31,25 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="1.0"/>
       </ParameterList>
+
       <Parameter name="use limiter" type="bool" value="true"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="central upwind"/>
-
       <ParameterList name="boundary conditions">
-          <ParameterList name="ponded depth">
-            <ParameterList name="BC 0">
-              <Parameter name="regions" type="Array(string)" value="{AllBoundary}"/>
-              <Parameter name="spatial distribution method" type="string" value="none"/>
-              <ParameterList name="ponded depth">
-                <ParameterList name="function-exprtk">
-                  <Parameter name="number of arguments" type="int" value="4"/>
-                  <Parameter name="formula" type="string" value="2.0*(2.064220183486238/(2.064220183486238 + t*t))*( 1.0 - (2.064220183486238*(x*x + y*y))/(81.0*(2.064220183486238 + t*t)) )"/>
-                </ParameterList>
+        <ParameterList name="ponded depth">
+          <ParameterList name="BC 0">
+            <Parameter name="regions" type="Array(string)" value="{AllBoundary}"/>
+            <Parameter name="spatial distribution method" type="string" value="none"/>
+            <ParameterList name="ponded depth">
+              <ParameterList name="function-exprtk">
+                <Parameter name="number of arguments" type="int" value="4"/>
+                <Parameter name="formula" type="string" value="2.0*(2.064220183486238/(2.064220183486238 + t*t))*( 1.0 - (2.064220183486238*(x*x + y*y))/(81.0*(2.064220183486238 + t*t)) )"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
+        </ParameterList>
         <ParameterList name="velocity">
           <ParameterList name="BC 1">
             <Parameter name="regions" type="Array(string)" value="{AllBoundary}"/>
@@ -76,7 +73,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -97,8 +96,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -117,7 +116,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -131,7 +131,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -161,6 +162,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/pks/shallow_water/test/shallow_water_bathymetry.xml
+++ b/src/pks/shallow_water/test/shallow_water_bathymetry.xml
@@ -1,10 +1,8 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="verbose object">
-     <Parameter name="verbosity level" type="string" value="high"/>
+    <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="TopSurface">
@@ -27,11 +25,11 @@
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
       <Parameter name="cfl" type="double" value="0.1"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -71,15 +69,17 @@
           </ParameterList>
         </ParameterList>
       </ParameterList-->
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="evaluators">
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -121,6 +121,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
       <ParameterList name="surface-velocity">
         <ParameterList name="function">
           <ParameterList name="domain">
@@ -143,10 +144,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-

--- a/src/pks/shallow_water/test/shallow_water_dry_bed.xml
+++ b/src/pks/shallow_water/test/shallow_water_dry_bed.xml
@@ -1,45 +1,44 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{1.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{1.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,1.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 1.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
@@ -52,12 +51,11 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.5"/>
       </ParameterList>
+
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="cfl" type="double" value="0.2"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-      
-
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -102,7 +100,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -123,8 +123,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -143,7 +143,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -157,7 +158,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -187,6 +189,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>

--- a/src/pks/shallow_water/test/shallow_water_lake_at_rest.xml
+++ b/src/pks/shallow_water/test/shallow_water_lake_at_rest.xml
@@ -1,25 +1,24 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
-        <ParameterList name="region: boundary">
-        </ParameterList>
+      <ParameterList name="region: boundary">
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -31,10 +30,10 @@
         <Parameter name="limiter location" type="string" value="node"/>
         <Parameter name="limiter cfl" type="double" value="0.1"/>
       </ParameterList>
+
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="central upwind"/>
-
       <ParameterList name="boundary conditions">
         <ParameterList name="velocity">
           <ParameterList name="BC 0">
@@ -62,7 +61,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
@@ -83,8 +84,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -96,22 +97,23 @@
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
-      
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
-      
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
-      
+
       <ParameterList name="surface-bathymetry">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -125,7 +127,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -155,13 +158,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-
-
-
-

--- a/src/pks/shallow_water/test/shallow_water_lake_at_rest_case1.xml
+++ b/src/pks/shallow_water/test/shallow_water_lake_at_rest_case1.xml
@@ -1,25 +1,24 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
-        <ParameterList name="region: boundary">
-        </ParameterList>
+      <ParameterList name="region: boundary">
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -31,11 +30,11 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.1"/>
       </ParameterList>
+
       <Parameter name="use limiter" type="bool" value="true"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="central upwind"/>
-
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -70,12 +69,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="field evaluators">
+
       <ParameterList name="porosity">
         <Parameter name="field evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -90,9 +92,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -104,22 +107,23 @@
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
-      
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
-      
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
-      
+
       <ParameterList name="surface-bathymetry">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -133,7 +137,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -163,13 +168,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-
-
-
-

--- a/src/pks/shallow_water/test/shallow_water_lake_at_rest_case2.xml
+++ b/src/pks/shallow_water/test/shallow_water_lake_at_rest_case2.xml
@@ -1,25 +1,24 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <!-- REGIONS -->
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Boundary">
-        <ParameterList name="region: boundary">
-        </ParameterList>
+      <ParameterList name="region: boundary">
+      </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <!-- FLOW -->
   <ParameterList name="PKs">
+
     <ParameterList name="shallow water">
       <Parameter name="domain name" type="string" value="surface"/>
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -31,12 +30,12 @@
         <Parameter name="limiter location" type="string" value="face"/>
         <Parameter name="limiter cfl" type="double" value="0.1"/>
       </ParameterList>
+
       <Parameter name="use limiter" type="bool" value="true"/>
       <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="number of reduced cfl cycles" type="int" value="10"/>
       <Parameter name="numerical flux" type="string" value="Rusanov"/>
-	
-      <!-- No flow conditions only -->	       
+      <!-- No flow conditions only -->
       <ParameterList name="boundary conditions">
         <ParameterList name="ponded depth">
           <ParameterList name="BC 0">
@@ -72,12 +71,15 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!--  STATE  -->
   <ParameterList name="state">
     <ParameterList name="field evaluators">
+
       <ParameterList name="porosity">
         <Parameter name="field evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -92,9 +94,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="initial conditions">
+
       <ParameterList name="fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
@@ -106,22 +109,23 @@
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, -9.81}"/>
       </ParameterList>
-      
+
       <ParameterList name="const_fluid_density">
-        <Parameter name="value" type="double" value="9.98200000000000045e+02"/>
+        <Parameter name="value" type="double" value="998.200000000000045"/>
       </ParameterList>
-      
+
       <ParameterList name="atmospheric_pressure">
-        <Parameter name="value" type="double" value="1.01325000000000000e+05"/>
+        <Parameter name="value" type="double" value="101325.000000000000"/>
       </ParameterList>
-      
+
       <ParameterList name="surface-bathymetry">
         <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="components" type="Array(string)" value="{cell, node}"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
@@ -135,7 +139,8 @@
             <Parameter name="region" type="string" value="Computational domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
+              <ParameterList name="function-constant">
+                <!-- time component -->
                 <Parameter name="value" type="double" value="1.0"/>
               </ParameterList>
             </ParameterList>
@@ -165,13 +170,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-
-
-
-
-
-
-

--- a/src/pks/transport/test/transport_2D.xml
+++ b/src/pks/transport/test/transport_2D.xml
@@ -1,41 +1,40 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="2"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="2"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -46,6 +45,7 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Component 0">
@@ -87,7 +87,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -109,7 +111,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -127,4 +128,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_2D_long.xml
+++ b/src/pks/transport/test/transport_2D_long.xml
@@ -1,10 +1,9 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mstk::mesh"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -33,15 +32,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="2"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="2"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -68,8 +67,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -88,7 +89,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -106,4 +106,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_2D_source.xml
+++ b/src/pks/transport/test/transport_2D_source.xml
@@ -1,10 +1,9 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -32,25 +31,26 @@
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-0.1,-0.1}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.1,0.1}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-0.1, -0.1}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.1, 0.1}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <ParameterList name="physical models and assumptions">
         <Parameter name="permeability field is required" type="bool" value="true"/>
       </ParameterList>
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="0"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -60,7 +60,6 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
-
 
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
@@ -78,7 +77,7 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="concentration">
@@ -88,7 +87,7 @@
               <Parameter name="spatial distribution method" type="string" value="permeability"/>
               <ParameterList name="injector">
                 <ParameterList name="function-constant">
-                  <Parameter name="value" type="double" value="1e-4"/>
+                  <Parameter name="value" type="double" value="0.0001"/>
                 </ParameterList>
               </ParameterList>
             </ParameterList>
@@ -106,7 +105,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -125,7 +126,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -141,8 +141,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="permeability">
         <ParameterList name="function">
           <ParameterList name="Mesh Block 1">
@@ -165,7 +165,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_3D_long.xml
+++ b/src/pks/transport/test/transport_3D_long.xml
@@ -1,6 +1,5 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -29,15 +28,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="2"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="2"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -61,11 +60,13 @@
                   <Parameter name="y values" type="Array(double)" value="{1.0, 0.0}"/>
                 </ParameterList>
               </ParameterList>
-            </ParameterList>         
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -84,7 +85,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -102,4 +102,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_advance.xml
+++ b/src/pks/transport/test/transport_advance.xml
@@ -1,11 +1,10 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -19,15 +18,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
@@ -61,8 +60,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -81,7 +82,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -99,4 +99,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_advance_simple.xml
+++ b/src/pks/transport/test/transport_advance_simple.xml
@@ -1,42 +1,41 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mesh::simple"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
-  <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <Parameter name="advection limiter" type="string" value="tensorial"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+  <ParameterList name="PKs">
+
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <Parameter name="advection limiter" type="string" value="tensorial"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
@@ -58,7 +57,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -77,7 +78,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -95,4 +95,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_convergence.xml
+++ b/src/pks/transport/test/transport_convergence.xml
@@ -1,35 +1,34 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mesh::simple"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
-  <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+  <ParameterList name="PKs">
+
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -57,7 +56,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -79,7 +80,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -97,4 +97,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_convergence_poly.xml
+++ b/src/pks/transport/test/transport_convergence_poly.xml
@@ -1,10 +1,8 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="mesh">
     <ParameterList name="unstructured">
       <ParameterList name="Read">
@@ -15,33 +13,33 @@
         <Parameter name="framework" type="string" value="MSTK"/>
       </ParameterList>
     </ParameterList>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate"  type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point"  type="Array(double)" value="{ 0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
-  <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+  <ParameterList name="PKs">
+
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -69,7 +67,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -91,7 +91,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -109,4 +108,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_diffusion.xml
+++ b/src/pks/transport/test/transport_diffusion.xml
@@ -1,21 +1,20 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
+
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="Dispersion Solver">
@@ -25,22 +24,20 @@
         <Parameter name="error tolerance" type="double" value="1e-20"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, make one iteration}"/>
         <Parameter name="size of Krylov space" type="int" value="5"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="material properties">
         <ParameterList name="Brown soil">
           <Parameter name="regions" type="Array(string)" value="{Computational domain}"/>
@@ -50,7 +47,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Component 0}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-3}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -64,11 +61,10 @@
         </ParameterList>
       </ParameterList>
 
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -95,8 +91,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- PRECONDITIONERS -->
@@ -105,13 +103,12 @@
       <Parameter name="discretization method" type="string" value="optimized mfd"/>
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Trilinos ML">
       <ParameterList name="ML Parameters">
         <Parameter name="ML output" type="int" value="0"/>
@@ -134,7 +131,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -151,7 +147,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -169,4 +164,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_diffusion_gas.xml
+++ b/src/pks/transport/test/transport_diffusion_gas.xml
@@ -1,31 +1,30 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mesh::simple"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.49,  0.49}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.49, 0.49}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.51, 0.51}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
+
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="Dispersion Solver">
@@ -35,22 +34,20 @@
         <Parameter name="error tolerance" type="double" value="1e-20"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, make one iteration}"/>
         <Parameter name="size of Krylov space" type="int" value="5"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="material properties">
         <ParameterList name="Brown soil">
           <Parameter name="regions" type="Array(string)" value="{Computational domain}"/>
@@ -61,9 +58,9 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Component 0}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-3}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.001}"/>
         <Parameter name="gaseous names" type="Array(string)" value="{Component 1}"/>
-        <Parameter name="gaseous values" type="Array(double)" value="{1e-2}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.01}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -77,11 +74,10 @@
         </ParameterList>
       </ParameterList>
 
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -108,7 +104,7 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
 
       <ParameterList name="source terms">
         <ParameterList name="concentration">
@@ -118,8 +114,8 @@
               <Parameter name="spatial distribution method" type="string" value="volume"/>
               <ParameterList name="injector">
                 <ParameterList name="function-tabular">
-                  <Parameter name="x values" type="Array(double)" value="{0.000000e+00, 1.000000e+09}"/>
-                  <Parameter name="y values" type="Array(double)" value="{8.148300e-08, 8.148300e-08}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.000000, 1.000000e+9}"/>
+                  <Parameter name="y values" type="Array(double)" value="{8.148300e-8, 8.148300e-8}"/>
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
                 </ParameterList>
               </ParameterList>
@@ -130,7 +126,9 @@
 
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="1"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- PRECONDITIONERS -->
@@ -139,13 +137,12 @@
       <Parameter name="discretization method" type="string" value="optimized mfd"/>
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Trilinos ML">
       <ParameterList name="ML Parameters">
         <Parameter name="ML output" type="int" value="0"/>
@@ -168,7 +165,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -185,7 +181,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -203,4 +198,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_diffusion_smiles.xml
+++ b/src/pks/transport/test/transport_diffusion_smiles.xml
@@ -1,25 +1,24 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mesh::simple"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{10.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{10.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
+
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="Dispersion Solver">
@@ -29,22 +28,20 @@
         <Parameter name="error tolerance" type="double" value="1e-20"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, make one iteration}"/>
         <Parameter name="size of Krylov space" type="int" value="5"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="high"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport diffusion" type="bool" value="true"/>
       </ParameterList>
@@ -61,8 +58,8 @@
         <Parameter name="aqueous names" type="Array(string)" value="{Tritium(l)}"/>
         <Parameter name="aqueous values" type="Array(double)" value="{1e-9}"/>
         <Parameter name="gaseous names" type="Array(string)" value="{Tritium(g)}"/>
-        <Parameter name="gaseous values" type="Array(double)" value="{1e-5}"/>
-        <Parameter name="air-water partitioning coefficient" type="Array(double)" value="{1.76e-5}"/>
+        <Parameter name="gaseous values" type="Array(double)" value="{0.00001}"/>
+        <Parameter name="air-water partitioning coefficient" type="Array(double)" value="{0.0000176}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -76,11 +73,10 @@
         </ParameterList>
       </ParameterList>
 
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -105,11 +101,13 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
 
       <Parameter name="number of aqueous components" type="int" value="1"/>
       <Parameter name="number of gaseous components" type="int" value="1"/>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- PRECONDITIONERS -->
@@ -118,14 +116,13 @@
       <Parameter name="discretization method" type="string" value="optimized mfd"/>
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -142,7 +139,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -158,22 +154,23 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="1000.0"/>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="verbose object">
     <Parameter name="verbosity level" type="string" value="high"/>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_dispersion.xml
+++ b/src/pks/transport/test/transport_dispersion.xml
@@ -1,33 +1,32 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Part1">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.0,0.5,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 0.5, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Part2">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{5.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{5.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
+
   <!-- SOLVERS -->
   <ParameterList name="solvers">
     <ParameterList name="Dispersion Solver">
@@ -37,22 +36,20 @@
         <Parameter name="error tolerance" type="double" value="1e-20"/>
         <Parameter name="convergence criteria" type="Array(string)" value="{relative rhs, make one iteration}"/>
         <Parameter name="size of Krylov space" type="int" value="5"/>
-
         <ParameterList name="verbose object">
           <Parameter name="verbosity level" type="string" value="extreme"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="solver" type="string" value="Dispersion Solver"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="material properties">
         <ParameterList name="Soil1">
           <Parameter name="regions" type="Array(string)" value="{Part1}"/>
@@ -94,17 +91,15 @@
         </ParameterList>
       </ParameterList>
 
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <!--ParameterList name="reconstruction">
           <Parameter name="polynomial order" type="int" value="0"/>
           <Parameter name="limiter" type="string" value="tensorial"/>
           <Parameter name="limiter extension for transport" type="bool" value="true"/>
           </ParameterList-->
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
@@ -125,8 +120,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <!-- PRECONDITIONERS -->
@@ -135,13 +132,12 @@
       <Parameter name="discretization method" type="string" value="optimized mfd"/>
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
       <ParameterList name="boomer amg parameters">
-        <Parameter name="tolerance" type="double" value="0.00000000000000000e+00"/>
+        <Parameter name="tolerance" type="double" value="0e-17"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.00000000000000000e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.500000000000000000"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Trilinos ML">
       <ParameterList name="ML Parameters">
         <Parameter name="ML output" type="int" value="0"/>
@@ -164,7 +160,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -181,7 +176,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -199,4 +193,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_fct.xml
+++ b/src/pks/transport/test/transport_fct.xml
@@ -1,28 +1,27 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="method" type="string" value="fct"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="method" type="string" value="fct"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
@@ -56,8 +55,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -76,7 +77,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -94,4 +94,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_fractures.xml
+++ b/src/pks/transport/test/transport_fractures.xml
@@ -1,39 +1,38 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
@@ -61,11 +60,13 @@
                   <Parameter name="y values" type="Array(double)" value="{1.0, 0.0}"/>
                 </ParameterList>
               </ParameterList>
-            </ParameterList>         
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -115,4 +116,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_fractures_implicit.xml
+++ b/src/pks/transport/test/transport_fractures_implicit.xml
@@ -1,53 +1,50 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,0.5}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 0.5}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 1">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="fracture 2">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <Parameter name="PK type" type="string" value="transport implicit"/>
-      <Parameter name="cfl" type="double" value="0.5"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="flow and transport in fractures" type="bool" value="true"/>
       </ParameterList>
 
       <ParameterList name="time integrator">
-        <Parameter name="time integration method" type="string" value="BDF1"/>                
+        <Parameter name="time integration method" type="string" value="BDF1"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
-
         <ParameterList name="BDF1">
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="5"/>
@@ -57,21 +54,20 @@
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-5"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="15"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.00001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="15"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
             <Parameter name="make one iteration" type="bool" value="true"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="high"/>
-	    </ParameterList>
-	  </ParameterList>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
@@ -98,11 +94,13 @@
                   <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
                 </ParameterList>
               </ParameterList>
-            </ParameterList>         
+            </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="cycle driver">
@@ -113,7 +111,6 @@
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{tracer}"/>
   </ParameterList>
-
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -160,7 +157,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -168,7 +164,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -176,7 +172,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -202,4 +197,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_implicit_2D.xml
+++ b/src/pks/transport/test/transport_implicit_2D.xml
@@ -1,16 +1,15 @@
 <ParameterList>
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="SurfaceLeft">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{ 0.0, 0.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{0.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="All">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98,-9.9e+98}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{-9.9e+98, -9.9e+98}"/>
         <Parameter name="high coordinate" type="Array(double)" value="{9.9e+98, 9.9e+98}"/>
       </ParameterList>
     </ParameterList>
@@ -29,7 +28,6 @@
   <ParameterList name="domain">
     <Parameter name="spatial dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="cycle driver">
     <ParameterList name="PK tree">
       <ParameterList name="transport">
@@ -38,7 +36,6 @@
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{tracer}"/>
   </ParameterList>
-  
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -55,7 +52,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -71,14 +67,16 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="atmospheric_pressure">
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
+
       <ParameterList name="gravity">
         <Parameter name="value" type="Array(double)" value="{0.0, 0.0, -9.81}"/>
       </ParameterList>
+
       <ParameterList name="const_fluid_density">
         <Parameter name="value" type="double" value="998.2"/>
       </ParameterList>
@@ -124,15 +122,14 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-    </ParameterList>
 
+    </ParameterList>
     <ParameterList name="mesh partitions">
       <ParameterList name="materials">
         <Parameter name="region list" type="Array(string)" value="{All}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
       <Parameter name="preconditioning method" type="string" value="boomer amg"/>
@@ -140,7 +137,7 @@
         <Parameter name="tolerance" type="double" value="0.0"/>
         <Parameter name="smoother sweeps" type="int" value="3"/>
         <Parameter name="cycle applications" type="int" value="5"/>
-        <Parameter name="strong threshold" type="double" value="5.0e-01"/>
+        <Parameter name="strong threshold" type="double" value="0.50"/>
         <Parameter name="cycle type" type="int" value="1"/>
         <Parameter name="coarsen type" type="int" value="0"/>
         <Parameter name="verbosity" type="int" value="0"/>
@@ -148,7 +145,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="solvers">
     <ParameterList name="PCG">
       <Parameter name="iterative method" type="string" value="pcg"/>
@@ -162,18 +158,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <Parameter name="PK type" type="string" value="transport implicit"/>
-      <Parameter name="domain name" type="string" value="domain"/>      
-      <Parameter name="cfl" type="double" value="1.0"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
+      <Parameter name="domain name" type="string" value="domain"/>
+      <Parameter name="cfl" type="double" value="1.0"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
       <Parameter name="transport subcycling" type="bool" value="false"/>
       <Parameter name="solver" type="string" value="PCG"/>
       <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
-
       <ParameterList name="physical models and assumptions">
         <Parameter name="effective transport porosity" type="bool" value="false"/>
         <Parameter name="permeability field is required" type="bool" value="false"/>
@@ -182,14 +177,12 @@
       </ParameterList>
 
       <ParameterList name="time integrator">
-        <Parameter name="time integration method" type="string" value="BDF1"/>                
+        <Parameter name="time integration method" type="string" value="BDF1"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
-
         <ParameterList name="BDF1">
-	  <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
+          <Parameter name="max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="5"/>
@@ -199,21 +192,20 @@
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="12"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="12"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
             <Parameter name="make one iteration" type="bool" value="true"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="high"/>
-	    </ParameterList>
-	  </ParameterList>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
@@ -237,7 +229,7 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{tracer}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1e-5}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{0.00001}"/>
       </ParameterList>
 
       <ParameterList name="operators">
@@ -252,25 +244,27 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="boundary conditions">      
-	<ParameterList name="concentration">
-	  <ParameterList name="tracer">
-	    <ParameterList name="BC 0">
-	      <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
+      <ParameterList name="boundary conditions">
+        <ParameterList name="concentration">
+          <ParameterList name="tracer">
+            <ParameterList name="BC 0">
+              <Parameter name="regions" type="Array(string)" value="{SurfaceLeft}"/>
               <Parameter name="spatial distribution method" type="string" value="none"/>
-	      <ParameterList name="boundary concentration">
-		<ParameterList name="function-constant">
-		  <Parameter name="value" type="double" value="1.0"/>
-		</ParameterList>
-	      </ParameterList>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
+              <ParameterList name="boundary concentration">
+                <ParameterList name="function-constant">
+                  <Parameter name="value" type="double" value="1.0"/>
+                </ParameterList>
+              </ParameterList>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
+
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_implicit_3D.xml
+++ b/src/pks/transport/test/transport_implicit_3D.xml
@@ -1,11 +1,10 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -16,18 +15,18 @@
         <Parameter name="entity" type="string" value="face"/>
       </ParameterList-->
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front side">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,0.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 0.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
+
   <ParameterList name="cycle driver">
     <ParameterList name="PK tree">
       <ParameterList name="transport implicit">
@@ -36,17 +35,16 @@
     </ParameterList>
     <Parameter name="component names" type="Array(string)" value="{Component 0, Component 1}"/>
   </ParameterList>
-  
   <ParameterList name="PKs">
-    <ParameterList name="transport implicit">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport implicit">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="operators">
         <ParameterList name="advection operator">
           <ParameterList name="matrix">
@@ -55,18 +53,16 @@
             <Parameter name="matrix type" type="string" value="advection"/>
             <Parameter name="single domain" type="Array(string)" value="{domain}"/>
           </ParameterList>
-        </ParameterList>          
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="time integrator">
-        <Parameter name="time integration method" type="string" value="BDF1"/>                
+        <Parameter name="time integration method" type="string" value="BDF1"/>
         <Parameter name="preconditioner" type="string" value="Hypre AMG"/>
         <Parameter name="linear solver" type="string" value="PCG"/>
-
         <ParameterList name="BDF1">
-	  <Parameter name="max preconditioner lag iterations" type="int" value="2"/>
-	  <Parameter name="extrapolate initial guess" type="bool" value="false"/>
-
+          <Parameter name="max preconditioner lag iterations" type="int" value="2"/>
+          <Parameter name="extrapolate initial guess" type="bool" value="false"/>
           <Parameter name="timestep controller type" type="string" value="standard"/>
           <ParameterList name="timestep controller standard parameters">
             <Parameter name="min iterations" type="int" value="10"/>
@@ -76,21 +72,20 @@
             <Parameter name="min timestep" type="double" value="0.0"/>
             <Parameter name="max timestep" type="double" value="1.0"/>
           </ParameterList>
-
-	  <Parameter name="solver type" type="string" value="nka"/>
-	  <ParameterList name="nka parameters">
-	    <Parameter name="nonlinear tolerance" type="double" value="1e-4"/>
-	    <Parameter name="diverged tolerance" type="double" value="1e+10"/>
-	    <Parameter name="limit iterations" type="int" value="20"/>
-	    <Parameter name="max du growth factor" type="double" value="1e+5"/>
-	    <Parameter name="max divergent iterations" type="int" value="3"/>
-	    <Parameter name="max nka vectors" type="int" value="10"/>
+          <Parameter name="solver type" type="string" value="nka"/>
+          <ParameterList name="nka parameters">
+            <Parameter name="nonlinear tolerance" type="double" value="0.0001"/>
+            <Parameter name="diverged tolerance" type="double" value="1e+10"/>
+            <Parameter name="limit iterations" type="int" value="20"/>
+            <Parameter name="max du growth factor" type="double" value="1e+5"/>
+            <Parameter name="max divergent iterations" type="int" value="3"/>
+            <Parameter name="max nka vectors" type="int" value="10"/>
             <Parameter name="monitor" type="string" value="monitor update"/>
             <Parameter name="make one iteration" type="bool" value="true"/>
-	    <ParameterList name="verbose object">
-	      <Parameter name="verbosity level" type="string" value="high"/>
-	    </ParameterList>
-	  </ParameterList>
+            <ParameterList name="verbose object">
+              <Parameter name="verbosity level" type="string" value="high"/>
+            </ParameterList>
+          </ParameterList>
         </ParameterList>
       </ParameterList>
 
@@ -113,7 +108,7 @@
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.0, 100.}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 100.0}"/>
                   <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
                 </ParameterList>
               </ParameterList>
@@ -126,7 +121,7 @@
               <ParameterList name="boundary concentration">
                 <ParameterList name="function-tabular">
                   <Parameter name="forms" type="Array(string)" value="{constant}"/>
-                  <Parameter name="x values" type="Array(double)" value="{0.0, 100.}"/>
+                  <Parameter name="x values" type="Array(double)" value="{0.0, 100.0}"/>
                   <Parameter name="y values" type="Array(double)" value="{1.0, 1.0}"/>
                 </ParameterList>
               </ParameterList>
@@ -134,10 +129,10 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-      
-    </ParameterList>
-  </ParameterList>
 
+    </ParameterList>
+
+  </ParameterList>
 
   <!-- SOLVERS -->
   <ParameterList name="solvers">
@@ -152,7 +147,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PRECONDITIONERS -->
   <ParameterList name="preconditioners">
     <ParameterList name="Hypre AMG">
@@ -169,7 +163,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-    
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
@@ -203,4 +196,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_mics.xml
+++ b/src/pks/transport/test/transport_mics.xml
@@ -1,39 +1,36 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
+
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
@@ -89,8 +86,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
-    </ParameterList>        
+      </ParameterList>
+
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -126,4 +125,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_multiscale.xml
+++ b/src/pks/transport/test/transport_multiscale.xml
@@ -1,42 +1,41 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="mesh::simple"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.5,0.5}"/>
-        <Parameter name="normal" type="Array(double)" value="{1.0,0.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.5, 0.5}"/>
+        <Parameter name="normal" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom side">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{0.0,0.0,-1.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
-  <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <Parameter name="advection limiter" type="string" value="tensorial"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+  <ParameterList name="PKs">
+
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <Parameter name="advection limiter" type="string" value="tensorial"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="physical models and assumptions">
         <Parameter name="multiscale model" type="string" value="dual continuum discontinuous matrix"/>
       </ParameterList>
@@ -47,17 +46,17 @@
 
       <ParameterList name="molecular diffusion">
         <Parameter name="aqueous names" type="Array(string)" value="{Component 0, Component 1}"/>
-        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-09, 1.0e-09}"/>
-        <Parameter name="molar masses" type="Array(double)" value="{9.89e-02, 9.89e-02}"/>
+        <Parameter name="aqueous values" type="Array(double)" value="{1.0e-9, 1.0e-9}"/>
+        <Parameter name="molar masses" type="Array(double)" value="{0.0989, 0.0989}"/>
       </ParameterList>
 
       <ParameterList name="multiscale models">
         <ParameterList name="MSM 0">
           <ParameterList name="dual porosity parameters">
-            <Parameter name="matrix tortuosity" type="double" value="9.0e-01"/>
+            <Parameter name="matrix tortuosity" type="double" value="0.90"/>
             <Parameter name="Warren Root parameter" type="double" value="4.0"/>
             <Parameter name="matrix depth" type="double" value="0.08"/>
-            <Parameter name="matrix volume fraction" type="double" value="9.999e-01"/>
+            <Parameter name="matrix volume fraction" type="double" value="0.9999"/>
           </ParameterList>
           <Parameter name="regions" type="Array(string)" value="{Computational domain}"/>
           <Parameter name="multiscale model" type="string" value="dual porosity"/>
@@ -93,8 +92,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
-    </ParameterList>        
+      </ParameterList>
+
+    </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -128,8 +129,8 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="porosity_msp">
         <ParameterList name="function">
           <ParameterList name="RegionMiddle">
@@ -137,13 +138,13 @@
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-                <Parameter name="value" type="double" value="2.5e-01"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_parallel_mstk.xml
+++ b/src/pks/transport/test/transport_parallel_mstk.xml
@@ -1,15 +1,14 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -23,15 +22,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -71,8 +70,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -108,4 +109,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_parallel_read_mstk.xml
+++ b/src/pks/transport/test/transport_parallel_read_mstk.xml
@@ -1,15 +1,14 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left side">
@@ -23,15 +22,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="2"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="2"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -71,8 +70,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -111,4 +112,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_subcycling.xml
+++ b/src/pks/transport/test/transport_subcycling.xml
@@ -1,10 +1,9 @@
 <ParameterList name="Main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: labeled set">
@@ -33,15 +32,15 @@
   </ParameterList>
 
   <ParameterList name="PKs">
-    <ParameterList name="transport">
-      <Parameter name="cfl" type="double" value="0.5"/>   
-      <Parameter name="spatial discretization order" type="int" value="1"/>   
-      <Parameter name="temporal discretization order" type="int" value="1"/>   
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/>   
-      <!-- end of developers parameters -->
 
+    <ParameterList name="transport">
+      <Parameter name="cfl" type="double" value="0.5"/>
+      <Parameter name="spatial discretization order" type="int" value="1"/>
+      <Parameter name="temporal discretization order" type="int" value="1"/>
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
+      <!-- end of developers parameters -->
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="medium"/>
       </ParameterList>
@@ -97,8 +96,10 @@
             </ParameterList>
           </ParameterList>
         </ParameterList>
-      </ParameterList>        
+      </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -134,4 +135,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/pks/transport/test/transport_wet_dry.xml
+++ b/src/pks/transport/test/transport_wet_dry.xml
@@ -1,35 +1,34 @@
 <ParameterList name="main">
   <Parameter name="Native Unstructured Input" type="bool" value="true"/>
-
   <ParameterList name="mesh">
     <Parameter name="framework" type="string" value="MSTK"/>
-  </ParameterList>    
-   
+  </ParameterList>
+
   <ParameterList name="regions">
     <ParameterList name="Computational domain">
       <ParameterList name="region: box">
-        <Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left">
       <ParameterList name="region: plane">
-        <Parameter name="point" type="Array(double)" value="{0.0,0.0}"/>
-        <Parameter name="normal" type="Array(double)" value="{-1.0,0.0}"/>
+        <Parameter name="point" type="Array(double)" value="{0.0, 0.0}"/>
+        <Parameter name="normal" type="Array(double)" value="{-1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
 
   <ParameterList name="PKs">
+
     <ParameterList name="transport">
       <Parameter name="cfl" type="double" value="1.0"/>
       <Parameter name="spatial discretization order" type="int" value="1"/>
       <Parameter name="temporal discretization order" type="int" value="1"/>
-      <!-- developers parameters --> 
-      <Parameter name="enable internal tests" type="bool" value="true"/>   
-      <Parameter name="internal tests tolerance" type="double" value="1e-5"/> 
+      <!-- developers parameters -->
+      <Parameter name="enable internal tests" type="bool" value="true"/>
+      <Parameter name="internal tests tolerance" type="double" value="0.00001"/>
       <!-- end of developers parameters -->
-
       <ParameterList name="reconstruction">
         <Parameter name="polynomial order" type="int" value="1"/>
         <Parameter name="limiter" type="string" value="tensorial"/>
@@ -40,6 +39,7 @@
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="low"/>
       </ParameterList>
+
       <ParameterList name="boundary conditions">
         <ParameterList name="concentration">
           <ParameterList name="Component 0">
@@ -57,7 +57,9 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
+
   </ParameterList>
 
   <ParameterList name="state">
@@ -79,7 +81,6 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
       <ParameterList name="saturation_liquid">
         <Parameter name="evaluator type" type="string" value="independent variable"/>
         <ParameterList name="function">
@@ -89,15 +90,15 @@
             <ParameterList name="function">
               <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="4"/>
-                <Parameter name="formula" type="string" value="if (x > 0.8, 0.0, 1.0)"/>
+                <Parameter name="formula" type="string" value="if (x &gt; 0.8, 0.0, 1.0)"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="initial conditions">
+
       <ParameterList name="volumetric_flow_rate">
         <Parameter name="dot with normal" type="bool" value="true"/>
         <ParameterList name="function">
@@ -110,7 +111,7 @@
               <ParameterList name="dof 1 function">
                 <ParameterList name="function-exprtk">
                   <Parameter name="number of arguments" type="int" value="4"/>
-                  <Parameter name="formula" type="string" value="if (x > 0.8, 0.0, 0.8 - x)"/>
+                  <Parameter name="formula" type="string" value="if (x &gt; 0.8, 0.0, 0.8 - x)"/>
                 </ParameterList>
               </ParameterList>
               <ParameterList name="dof 2 function">
@@ -123,7 +124,7 @@
           </ParameterList>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/src/state/test/state_extensibility.xml
+++ b/src/state/test/state_extensibility.xml
@@ -1,20 +1,20 @@
 <ParameterList name="Main">
-
   <ParameterList name="visualization">
     <Parameter name="file name base" type="string" value="visdump"/>
-    <Parameter name="file name digits" type="int" value="5"/>    
-    <Parameter name="cycle start period stop" type="Array(double)" value="{0,1,10}"/>
+    <Parameter name="file name digits" type="int" value="5"/>
+    <Parameter name="cycle start period stop" type="Array(double)" value="{0.0, 1.0, 10.0}"/>
   </ParameterList>
 
   <ParameterList name="checkpoint">
-    <Parameter name="cycle start period stop" type="Array(double)" value="{0,1,10}"/>
+    <Parameter name="cycle start period stop" type="Array(double)" value="{0.0, 1.0, 10.0}"/>
   </ParameterList>
 
   <ParameterList name="state">
     <ParameterList name="initial conditions">
+
       <ParameterList name="my_points">
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-  
 </ParameterList>

--- a/src/state/test/state_init.xml
+++ b/src/state/test/state_init.xml
@@ -2,43 +2,43 @@
   <ParameterList name="regions">
     <ParameterList name="domain">
       <ParameterList name="region: box">
-	<Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
+
   <ParameterList name="state">
     <ParameterList name="evaluators">
       <ParameterList name="porosity">
-	<Parameter name="evaluator type" type="string" value="independent variable"/>
-	<ParameterList name="function">
+        <Parameter name="evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.25"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>      
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="initial conditions">
+
       <ParameterList name="porosity">
-	<ParameterList name="function">
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
               <ParameterList name="function-constant">
-		<Parameter name="value" type="double" value="0.25"/>
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
 
       <ParameterList name="field">
@@ -54,7 +54,7 @@
           <Parameter name="attributes" type="Array(string)" value="{permx, permy, permz}"/>
         </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-</ParameterList>  
-
+</ParameterList>

--- a/src/state/test/state_restart.xml
+++ b/src/state/test/state_restart.xml
@@ -1,53 +1,56 @@
 <ParameterList name="Main">
-
   <ParameterList name="regions">
     <ParameterList name="domain">
       <ParameterList name="region: box">
-	<Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
+
   <ParameterList name="checkpoint">
     <Parameter name="file name base" type="string" value="restartdump"/>
-    <Parameter name="file name digits" type="int" value="5"/>    
-    <Parameter name="cycle start period stop" type="Array(double)" value="{0,1,10}"/>
+    <Parameter name="file name digits" type="int" value="5"/>
+    <Parameter name="cycle start period stop" type="Array(double)" value="{0.0, 1.0, 10.0}"/>
   </ParameterList>
 
   <ParameterList name="state">
     <ParameterList name="field evaluators">
+
       <ParameterList name="celldata">
-	<Parameter name="field evaluator type" type="string" value="independent variable"/>
-	<ParameterList name="function">
+        <Parameter name="field evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-		<Parameter name="value" type="double" value="0.25"/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>      
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
-    
     <ParameterList name="initial conditions">
+
       <ParameterList name="celldata">
-	<ParameterList name="function">
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-		<Parameter name="value" type="double" value="0.5"/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.5"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-</ParameterList>  
-
+</ParameterList>

--- a/src/state/test/state_vis.xml
+++ b/src/state/test/state_vis.xml
@@ -1,53 +1,56 @@
 <ParameterList name="Main">
-
   <ParameterList name="regions">
     <ParameterList name="domain">
       <ParameterList name="region: box">
-	<Parameter name="low coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="high coordinate" type="Array(double)" value="{1.0,1.0,1.0}"/>
+        <Parameter name="low coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="high coordinate" type="Array(double)" value="{1.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
+
   <ParameterList name="visualization">
     <Parameter name="file name base" type="string" value="visdump"/>
-    <Parameter name="file name digits" type="int" value="5"/>    
-    <Parameter name="cycle start period stop" type="Array(double)" value="{0,1,10}"/>
+    <Parameter name="file name digits" type="int" value="5"/>
+    <Parameter name="cycle start period stop" type="Array(double)" value="{0.0, 1.0, 10.0}"/>
   </ParameterList>
 
   <ParameterList name="state">
     <ParameterList name="field evaluators">
+
       <ParameterList name="celldata">
-	<Parameter name="field evaluator type" type="string" value="independent variable"/>
-	<ParameterList name="function">
+        <Parameter name="field evaluator type" type="string" value="independent variable"/>
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-		<Parameter name="value" type="double" value="0.25"/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.25"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>      
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
-    
     <ParameterList name="initial conditions">
+
       <ParameterList name="celldata">
-	<ParameterList name="function">
+        <ParameterList name="function">
           <ParameterList name="domain">
             <Parameter name="region" type="string" value="domain"/>
             <Parameter name="component" type="string" value="cell"/>
             <ParameterList name="function">
-              <ParameterList name="function-constant"> <!-- time component -->
-		<Parameter name="value" type="double" value="0.5"/>
+              <ParameterList name="function-constant">
+                <!-- time component -->
+                <Parameter name="value" type="double" value="0.5"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
-	</ParameterList>
+        </ParameterList>
       </ParameterList>
+
     </ParameterList>
   </ParameterList>
-</ParameterList>  
-
+</ParameterList>

--- a/test_suites/benchmarking/chemistry/calcite_het_1d/s_calcite_alq_crunch.xml
+++ b/test_suites/benchmarking/chemistry/calcite_het_1d/s_calcite_alq_crunch.xml
@@ -1,7 +1,6 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="1D, calcite dissolution, heterogeneous calcite"/>
   </ParameterList>
@@ -12,8 +11,8 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
-        <Parameter name="Initial Time Step" type="double" value="3153600"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
+        <Parameter name="Initial Time Step" type="double" value="3153600.0"/>
         <Parameter name="Maximum Cycle Number" type="int" value="1000000"/>
       </ParameterList>
     </ParameterList>
@@ -21,9 +20,9 @@
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="gravity" type="double" value="0"/>
+          <Parameter name="gravity" type="double" value="0.0"/>
           <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
-          <Parameter name="cfl" type="double" value="0.1"/> 
+          <Parameter name="cfl" type="double" value="0.1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -34,68 +33,64 @@
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{100, 2}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Regions">
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 0.0, 25.0, 25.0, 0.0 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.0, 0.0, 1.0, 1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{0.0, 25.0, 25.0, 0.0}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 25.0, 100.0, 100.0, 0.0 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.0, 0.0, 1.0, 1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{25.0, 100.0, 100.0, 0.0}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
         <ParameterList name="Calcite">
-          <Parameter name="Volume Fraction" type="double" value="1.0e-5"/>
-          <Parameter name="Specific Surface Area" type="double" value="1.1"/>    
+          <Parameter name="Volume Fraction" type="double" value="0.000010"/>
+          <Parameter name="Specific Surface Area" type="double" value="1.1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="SoilnoCalcite">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive, XLOBC}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0e+0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -108,7 +103,6 @@
       <Parameter name="Minerals" type="Array(string)" value="{Calcite}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
@@ -138,12 +132,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -167,23 +160,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>       
+        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -198,15 +188,15 @@
       <Parameter name="File Name Base" type="string" value="struct_amanzi-output-crunch/chk"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="CrunchFlow"/>
     <Parameter name="Engine Input File" type="string" value="1d-calcite-crunch.in"/>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/calcite_het_1d/s_calcite_alq_pflo.xml
+++ b/test_suites/benchmarking/chemistry/calcite_het_1d/s_calcite_alq_pflo.xml
@@ -1,7 +1,6 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="1D, calcite dissolution, heterogeneous calcite"/>
   </ParameterList>
@@ -12,8 +11,8 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
-        <Parameter name="Initial Time Step" type="double" value="3153600"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
+        <Parameter name="Initial Time Step" type="double" value="3153600.0"/>
         <Parameter name="Maximum Cycle Number" type="int" value="1000000"/>
       </ParameterList>
     </ParameterList>
@@ -21,9 +20,9 @@
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="gravity" type="double" value="0"/>
+          <Parameter name="gravity" type="double" value="0.0"/>
           <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
-          <Parameter name="cfl" type="double" value="0.1"/> 
+          <Parameter name="cfl" type="double" value="0.1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -34,68 +33,64 @@
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{100, 2}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Regions">
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 0.0, 25.0, 25.0, 0.0 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.0, 0.0, 1.0, 1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{0.0, 25.0, 25.0, 0.0}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Polygon">
-        <Parameter name="VerticesV1" type="Array(double)" value="{ 25.0, 100.0, 100.0, 0.0 }"/>
-        <Parameter name="VerticesV2" type="Array(double)" value="{ 0.0, 0.0, 1.0, 1.0 }"/>
+        <Parameter name="VerticesV1" type="Array(double)" value="{25.0, 100.0, 100.0, 0.0}"/>
+        <Parameter name="VerticesV2" type="Array(double)" value="{0.0, 0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
         <ParameterList name="Calcite">
-          <Parameter name="Volume Fraction" type="double" value="1.0e-5"/>
-          <Parameter name="Specific Surface Area" type="double" value="1.1"/>    
+          <Parameter name="Volume Fraction" type="double" value="0.000010"/>
+          <Parameter name="Specific Surface Area" type="double" value="1.1"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="SoilnoCalcite">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive, XLOBC}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0e+0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -108,7 +103,6 @@
       <Parameter name="Minerals" type="Array(string)" value="{Calcite}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
@@ -138,12 +132,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -167,23 +160,20 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>       
+        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -198,15 +188,15 @@
       <Parameter name="File Name Base" type="string" value="struct_amanzi-output-pflo/chk"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="1d-calcite.in"/>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite.xml
+++ b/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite.xml
@@ -10,9 +10,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	      <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -61,8 +61,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -70,26 +70,26 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -100,13 +100,13 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="1.0e-5"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.000010"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
     <ParameterList name="SoilnoCalcite">
@@ -115,13 +115,13 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0e+0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -129,10 +129,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -147,7 +147,7 @@
   </ParameterList>
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <Parameter name="PFloTran Constraint" type="string" value="initial"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
@@ -158,19 +158,19 @@
           <ParameterList name="Water">
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.6290737950863135E-05"/>
+                <Parameter name="Value" type="double" value="0.000016290737950863135"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="HCO3-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.7348824177512681E-03"/>
+                <Parameter name="Value" type="double" value="0.0017348824177512681"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="5.2312130065730166E-04"/>
+                <Parameter name="Value" type="double" value="0.00052312130065730166"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -183,35 +183,35 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.6641473107457617E-04, 9.6641473107457617E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00096641473107457617, 0.00096641473107457617}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
             <ParameterList name="HCO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{9.9999999902971649E-04, 9.9999999902971649E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00099999999902971649, 0.00099999999902971649}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.6792633971909330E-05, 1.6792633971909330E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000016792633971909330, 0.000016792633971909330}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
@@ -222,34 +222,34 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="H+">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
             <ParameterList name="HCO3-">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
             <ParameterList name="Ca++">
               <ParameterList name="BC: Zero Gradient">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-20, 1.e-20}"/>
+                <Parameter name="Values" type="Array(double)" value="{1e-20, 1e-20}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
@@ -261,30 +261,31 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="calcite"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-       <Parameter name="Format" type="string" value="simple" />
-       <Parameter name="File" type="string" value="calcite.bgd" />
-    </ParameterList> <!-- Thermodynamic Database -->    
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="calcite.bgd"/>
+    </ParameterList>
+    <!-- Thermodynamic Database -->
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite_alq_crunch.xml
+++ b/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite_alq_crunch.xml
@@ -10,7 +10,7 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
         <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
@@ -61,8 +61,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -70,26 +70,26 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -100,12 +100,12 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
         <ParameterList name="Calcite">
-          <Parameter name="Volume Fraction" type="double" value="1.0e-5"/>
-          <Parameter name="Specific Surface Area" type="double" value="1.0"/>    
+          <Parameter name="Volume Fraction" type="double" value="0.000010"/>
+          <Parameter name="Specific Surface Area" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -115,13 +115,13 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0e+0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -129,10 +129,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -146,9 +146,8 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
@@ -178,8 +177,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!--    <ParameterList name="Initial Condition 2">
+    <!--    <ParameterList name="Initial Condition 2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
@@ -210,18 +208,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList> -->
-
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>       -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>       -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -248,13 +243,12 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>       
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -281,28 +275,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="calcite"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!--   <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
+      <!--   <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="CrunchFlow"/>
     <Parameter name="Engine Input File" type="string" value="1d-calcite-crunch.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite_alq_pflo.xml
+++ b/test_suites/benchmarking/chemistry/calcite_het_1d/u_calcite_alq_pflo.xml
@@ -10,7 +10,7 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
         <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
@@ -61,8 +61,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -70,26 +70,26 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -100,12 +100,12 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
         <ParameterList name="Calcite">
-          <Parameter name="Volume Fraction" type="double" value="1.0e-5"/>
-          <Parameter name="Specific Surface Area" type="double" value="1.0"/>    
+          <Parameter name="Volume Fraction" type="double" value="0.000010"/>
+          <Parameter name="Specific Surface Area" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -115,13 +115,13 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0e+0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="100.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="100.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -129,10 +129,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -147,7 +147,7 @@
   </ParameterList>
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
@@ -177,8 +177,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!--    <ParameterList name="Initial Condition 2">
+    <!--    <ParameterList name="Initial Condition 2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
@@ -209,18 +208,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList> -->
-
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>       -->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>       -->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -247,13 +243,12 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>       
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -280,28 +275,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="calcite"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!--   <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
+      <!--   <Parameter name="Time Macros" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="1d-calcite.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/farea_1d/amanzi-s-1d-farea-full-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/farea_1d/amanzi-s-1d-farea-full-alq-pflo.xml
@@ -1,13 +1,10 @@
-
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
   <Parameter name="Dump ParmParse Table" type="string" value="run_data/ppfile"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="1-D advection with ASCEM 2012 F-Area full chemistry"/>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
@@ -15,9 +12,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.e20"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+20"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Maximum Cycle Number" type="int" value="2000"/>
       </ParameterList>
@@ -27,10 +24,10 @@
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="1.e30"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="1e+30"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="false"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e18"/>
-          <Parameter name="gravity" type="double" value="0"/> 
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+18"/>
+          <Parameter name="gravity" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Iterative Linear Solver Control">
@@ -53,39 +50,35 @@
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{100, 2}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0, 0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100, 2}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Regions">
-  </ParameterList> <!-- Regions -->
-
+  </ParameterList>
+  <!-- Regions -->
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-      
       <ParameterList name="Phase Components">
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-    
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Quartz, Goethite, Kaolinite, Schoepite, Gibbsite, Jurbanite, Basaluminite, Opal}"/>
-      <Parameter name="Sorption Sites" type="Array(string)" value="{>davis_OH}"/>
+      <Parameter name="Sorption Sites" type="Array(string)" value="{&gt;davis_OH}"/>
     </ParameterList>
-
-  </ParameterList> <!-- Phase Definitions -->
-
+  </ParameterList>
+  <!-- Phase Definitions -->
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All, XLOBC}"/>
@@ -93,68 +86,53 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
-
-
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="0.1"/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="3262.3"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="59093.9"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="0.1"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="11076.3"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
     </ParameterList>
-  </ParameterList> <!-- Material Properties -->
-
+  </ParameterList>
+  <!-- Material Properties -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -162,294 +140,246 @@
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
       </ParameterList>
-
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="background"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-  </ParameterList> <!-- Initial Conditions -->
-
+  </ParameterList>
+  <!-- Initial Conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-       <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="seepage"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-
-    </ParameterList> <!-- West BC -->
-
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- West BC -->
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-	<Parameter name="Values" type="Array(double)" value="{201325.0}"/>
+        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-
-    </ParameterList> <!-- East BC -->
-  </ParameterList> <!-- Boundary Conditions -->
-
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- East BC -->
+  </ParameterList>
+  <!-- Boundary Conditions -->
   <ParameterList name="Output">
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_step">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -462,12 +392,12 @@
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{}"/>
     </ParameterList>
-  </ParameterList> <!-- Output -->
-
+  </ParameterList>
+  <!-- Output -->
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="1d-farea-full-trim.in"/>
-    <Parameter name="Max Time Step (s)" type="double" value="31556926.0"/> 
-  </ParameterList> <!-- Chemistry -->
-
-</ParameterList> <!-- Main -->
+    <Parameter name="Max Time Step (s)" type="double" value="31556926.0"/>
+  </ParameterList>
+  <!-- Chemistry -->
+</ParameterList>

--- a/test_suites/benchmarking/chemistry/farea_1d/amanzi-s-1d-farea-full.xml
+++ b/test_suites/benchmarking/chemistry/farea_1d/amanzi-s-1d-farea-full.xml
@@ -1,13 +1,10 @@
-
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc"/>
   <Parameter name="Dump ParmParse Table" type="string" value="run_data/ppfile"/>
-
   <ParameterList name="General Description">
     <Parameter name="Model ID" type="string" value="1-D advection with ASCEM 2012 F-Area full chemistry"/>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
@@ -15,9 +12,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.e20"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1e+20"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Maximum Cycle Number" type="int" value="2000"/>
       </ParameterList>
@@ -27,10 +24,10 @@
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="do_richard_init_to_steady" type="int" value="1"/>
-          <Parameter name="steady_max_psuedo_time" type="double" value="1.e30"/>
+          <Parameter name="steady_max_psuedo_time" type="double" value="1e+30"/>
           <Parameter name="richard_semi_analytic_J" type="bool" value="false"/>
-          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1.e18"/>
-          <Parameter name="gravity" type="double" value="0"/> 
+          <Parameter name="richard_dt_thresh_pure_steady" type="double" value="1e+18"/>
+          <Parameter name="gravity" type="double" value="0.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Iterative Linear Solver Control">
@@ -53,39 +50,35 @@
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
       <Parameter name="Number of Cells" type="Array(int)" value="{100, 2}"/>
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0, 0}" />
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100, 2}" />
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Regions">
-  </ParameterList> <!-- Regions -->
-
+  </ParameterList>
+  <!-- Regions -->
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-      
       <ParameterList name="Phase Components">
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{H+, Al+++, Ca++, Cl-, Fe+++, CO2(aq), K+, Mg++, Na+, SiO2(aq), SO4--, Tritium, NO3-, UO2++}"/>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-    
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Quartz, Goethite, Kaolinite, Schoepite, Gibbsite, Jurbanite, Basaluminite, Opal}"/>
-      <Parameter name="Sorption Sites" type="Array(string)" value="{>davis_OH}"/>
+      <Parameter name="Sorption Sites" type="Array(string)" value="{&gt;davis_OH}"/>
     </ParameterList>
-
-  </ParameterList> <!-- Phase Definitions -->
-
+  </ParameterList>
+  <!-- Phase Definitions -->
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -93,68 +86,53 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
-
       <ParameterList name="Mineralogy">
-
-	<ParameterList name="Quartz">
-	  <Parameter name="Volume Fraction" type="double" value="0.88"/>
-	  <Parameter name="Specific Surface Area" type="double" value="326230."/>
-	</ParameterList>
-
-	<ParameterList name="Goethite">
-	  <Parameter name="Volume Fraction" type="double" value="0.016"/>
-	  <Parameter name="Specific Surface Area" type="double" value="1107630."/>
-	</ParameterList>
-
-	<ParameterList name="Kaolinite">
-	  <Parameter name="Volume Fraction" type="double" value="0.11"/>
-	  <Parameter name="Specific Surface Area" type="double" value="5909390."/>
-	</ParameterList>
-
-	<ParameterList name="Schoepite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="10."/>
-	</ParameterList>
-
-	<ParameterList name="Gibbsite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="10."/>
-	</ParameterList>
-
-	<ParameterList name="Jurbanite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="10."/>
-	</ParameterList>
-
-	<ParameterList name="Basaluminite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="10."/>
-	</ParameterList>
-
-	<ParameterList name="Opal">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="10."/>
-	</ParameterList>
-
-      </ParameterList> <!-- Mineralogy -->
-
-
+        <ParameterList name="Quartz">
+          <Parameter name="Volume Fraction" type="double" value="0.88"/>
+          <Parameter name="Specific Surface Area" type="double" value="326230.0"/>
+        </ParameterList>
+        <ParameterList name="Goethite">
+          <Parameter name="Volume Fraction" type="double" value="0.016"/>
+          <Parameter name="Specific Surface Area" type="double" value="1107630.0"/>
+        </ParameterList>
+        <ParameterList name="Kaolinite">
+          <Parameter name="Volume Fraction" type="double" value="0.11"/>
+          <Parameter name="Specific Surface Area" type="double" value="5909390.0"/>
+        </ParameterList>
+        <ParameterList name="Schoepite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="10.0"/>
+        </ParameterList>
+        <ParameterList name="Gibbsite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="10.0"/>
+        </ParameterList>
+        <ParameterList name="Jurbanite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="10.0"/>
+        </ParameterList>
+        <ParameterList name="Basaluminite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="10.0"/>
+        </ParameterList>
+        <ParameterList name="Opal">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="10.0"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Mineralogy -->
       <Parameter name="Cation Exchange Capacity" type="double" value="2.75"/>
-
-
       <ParameterList name="Surface Complexation Sites">
-
-	<ParameterList name=">davis_OH">
-	  <Parameter name="Site Density" type="double" value="0.156199"/>
-	</ParameterList>
-
-      </ParameterList> <!-- Surface Complexation Sites -->
-
+        <ParameterList name="&gt;davis_OH">
+          <Parameter name="Site Density" type="double" value="0.156199"/>
+        </ParameterList>
+      </ParameterList>
+      <!-- Surface Complexation Sites -->
     </ParameterList>
-  </ParameterList> <!-- Material Properties -->
-
+  </ParameterList>
+  <!-- Material Properties -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -162,308 +140,260 @@
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
       </ParameterList>
-
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.9578630770689822E-06"/>
-                <Parameter name="Free Ion Guess" type="double" value="4.4349219948232250E-06"/>
+                <Parameter name="Value" type="double" value="0.0000029578630770689822"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0000044349219948232250"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2134319178343449E-08"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030E-09"/>
+                <Parameter name="Value" type="double" value="2.2134319178343449e-8"/>
+                <Parameter name="Free Ion Guess" type="double" value="5.7872778934634030e-9"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028381797381277E-05"/>
+                <Parameter name="Value" type="double" value="0.000010000000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010028381797381277"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="9.9892245160353443E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0017671789459564E-02"/>
+                <Parameter name="Value" type="double" value="0.0099892245160353443"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.010017671789459564"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.5231281704019796E-16"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987E-16"/>
+                <Parameter name="Value" type="double" value="2.5231281704019796e-16"/>
+                <Parameter name="Free Ion Guess" type="double" value="2.5303135246636987e-16"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2146187645233065E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0742367360218137E-05"/>
+                <Parameter name="Value" type="double" value="0.000012146187645233065"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000010742367360218137"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="3.3200000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.3294546826549702E-05"/>
+                <Parameter name="Value" type="double" value="0.000033200000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000033294546826549702"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="5.3499999999999997E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="5.3651825870676614E-03"/>
+                <Parameter name="Value" type="double" value="0.0053499999999999997"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0053651825870676614"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.7799999999999998E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.7879126028761809E-04"/>
+                <Parameter name="Value" type="double" value="0.00027799999999999998"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00027879126028761809"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.7728213902597242E-04"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.7778699932375911E-04"/>
+                <Parameter name="Value" type="double" value="0.00017728213902597242"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.00017778699932375911"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="2.2500000000000001E-05"/>
-                <Parameter name="Free Ion Guess" type="double" value="2.2564075409559286E-05"/>
+                <Parameter name="Value" type="double" value="0.000022500000000000001"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.000022564075409559286"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000001E-15"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128E-15"/>
+                <Parameter name="Value" type="double" value="1.0000000000000001e-15"/>
+                <Parameter name="Free Ion Guess" type="double" value="1.0028477959804128e-15"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.0000000000000000E-03"/>
-                <Parameter name="Free Ion Guess" type="double" value="1.0028477959449073E-03"/>
+                <Parameter name="Value" type="double" value="0.0010000000000000000"/>
+                <Parameter name="Free Ion Guess" type="double" value="0.0010028477959449073"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.2499999999951748E-10"/>
-                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163E-11"/>
+                <Parameter name="Value" type="double" value="1.2499999999951748e-10"/>
+                <Parameter name="Free Ion Guess" type="double" value="3.0944807860172163e-11"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
-  </ParameterList> <!-- Initial Conditions -->
-
+  </ParameterList>
+  <!-- Initial Conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-       <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{9.7317820303283020E-03}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0097317820303283020}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000002E-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{1.0000000000000002e-8}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{3.3899999999999997E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000033899999999999997}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{2.4142508014351454E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000024142508014351454}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.0712465873417377E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000010712465873417377}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.7200000000000000E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000017200000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{2.4700000000000001E-06}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0000024700000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{3.0398521726429520E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00030398521726429520}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.1800000000000000E-04}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.00011800000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{4.8000000000000001E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000048000000000000001}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{2.1700000000000002E-09}"/>
+                <Parameter name="Values" type="Array(double)" value="{2.1700000000000002e-9}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{1.0000000000000000E-02}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.010000000000000000}"/>
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{3.0099999999999854E-05}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.000030099999999999854}"/>
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-
-    </ParameterList> <!-- West BC -->
-
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- West BC -->
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-	<Parameter name="Values" type="Array(double)" value="{201325.0}"/>
+        <Parameter name="Values" type="Array(double)" value="{201325.0}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="H+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Al+++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Ca++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Cl-">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Fe+++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="CO2(aq)">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="K+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Mg++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Na+">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SiO2(aq)">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="SO4--">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="Tritium">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="NO3-">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
             <ParameterList name="UO2++">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
-      </ParameterList> <!-- Solute BC -->
-
-    </ParameterList> <!-- East BC -->
-  </ParameterList> <!-- Boundary Conditions -->
-
+      </ParameterList>
+      <!-- Solute BC -->
+    </ParameterList>
+    <!-- East BC -->
+  </ParameterList>
+  <!-- Boundary Conditions -->
   <ParameterList name="Output">
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every_step">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
@@ -476,20 +406,20 @@
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{}"/>
     </ParameterList>
-  </ParameterList> <!-- Output -->
-
+  </ParameterList>
+  <!-- Output -->
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="farea-full.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="farea-full.bgd"/>
     </ParameterList>
     <Parameter name="Engine" type="string" value="Amanzi"/>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Auxiliary Data" type="Array(string)" value="{pH}"/>
     <Parameter name="Max Time Step (s)" type="double" value="31556926.0"/>
-  </ParameterList> <!-- Chemistry -->
-
-</ParameterList> <!-- Main -->
+  </ParameterList>
+  <!-- Chemistry -->
+</ParameterList>

--- a/test_suites/benchmarking/chemistry/kd_het_1d/u_kd.xml
+++ b/test_suites/benchmarking/chemistry/kd_het_1d/u_kd.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -65,8 +65,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -74,71 +74,67 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="10.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="10.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="SoilnoKd">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="0.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -150,26 +146,22 @@
   </ParameterList>
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
       </ParameterList>
       <ParameterList name="Solute IC">
-
         <ParameterList name="Aqueous">
-
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
           </ParameterList>
-
         </ParameterList>
-
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -177,24 +169,22 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="A">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-3, 1.e-3}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.001, 0.001}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -202,20 +192,18 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="A">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -224,29 +212,29 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="isotherms"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="isotherms.bgd" />
-    </ParameterList> 
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="isotherms.bgd"/>
+    </ParameterList>
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_crunch.xml
+++ b/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_crunch.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -65,8 +65,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -74,72 +74,67 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="10.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="10.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="SoilnoKd">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="0.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -151,7 +146,7 @@
   </ParameterList>
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
@@ -161,7 +156,7 @@
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Geochemical Condition" type="string" value="initial"/> 
+                <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -174,10 +169,10 @@
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -195,9 +190,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -215,23 +210,23 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="isotherms"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="CrunchFlow"/>
     <Parameter name="Engine Input File" type="string" value="1d-isotherms-crunch.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_pflo.xml
+++ b/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_pflo.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -65,8 +65,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -74,72 +74,67 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="10.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="10.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="SoilnoKd">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="0.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="0.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -149,11 +144,9 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
         <Parameter name="Value" type="double" value="201325.0"/>
@@ -163,7 +156,7 @@
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Geochemical Condition" type="string" value="initial"/> 
+                <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -171,8 +164,7 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!--    <ParameterList name="Initial Condition2">
+    <!--    <ParameterList name="Initial Condition2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Phase" type="string" value="Aqueous"/>
@@ -191,17 +183,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList> -->
-
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -219,9 +209,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -236,27 +226,26 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="isotherms"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="1d-isotherms.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_pflo_fail.xml
+++ b/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_alq_pflo_fail.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -65,8 +65,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -74,48 +74,45 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="10.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="10.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!--    <ParameterList name="SoilnoKd">
+    <!--    <ParameterList name="SoilnoKd">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
@@ -129,17 +126,15 @@
 	</ParameterList>
       </ParameterList>
     </ParameterList> -->
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -149,9 +144,7 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -163,7 +156,7 @@
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Geochemical Condition" type="string" value="initial"/> 
+                <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -171,7 +164,6 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -183,7 +175,7 @@
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Geochemical Condition" type="string" value="initial"/> 
+                <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
@@ -191,17 +183,15 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -219,9 +209,9 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
@@ -236,27 +226,26 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="isotherms"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="1d-isotherms.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_fail.xml
+++ b/test_suites/benchmarking/chemistry/kd_het_1d/u_kd_fail.xml
@@ -11,9 +11,9 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Initialize To Steady">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="1.5778463e9"/>
+        <Parameter name="End" type="double" value="1.5778463e+9"/>
         <Parameter name="Switch" type="double" value="0.0"/>
-	<Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
+        <Parameter name="Steady Initial Time Step" type="double" value="1.5768e+5"/>
         <Parameter name="Transient Initial Time Step" type="double" value="1.5768e+5"/>
       </ParameterList>
     </ParameterList>
@@ -65,8 +65,8 @@
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{100, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -74,47 +74,45 @@
   <ParameterList name="Regions">
     <ParameterList name="Almost Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{25.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="West">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="twentyfive">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{25.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{25.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="East">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0,0.0,0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{100.0,1.0,1.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{100.0, 0.0, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{100.0, 1.0, 1.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Material Properties">
-
     <ParameterList name="Soil">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain,twentyfive}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain, twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.E-12"/>
+        <Parameter name="Value" type="double" value="1e-12"/>
       </ParameterList>
       <ParameterList name="Sorption Isotherms">
- 	<ParameterList name="A">
-	  <Parameter name="Kd" type="double" value="10.0"/>
-	</ParameterList>
+        <ParameterList name="A">
+          <Parameter name="Kd" type="double" value="10.0"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
-<!--    <ParameterList name="SoilnoKd">
+    <!--    <ParameterList name="SoilnoKd">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
@@ -128,17 +126,15 @@
 	</ParameterList>
       </ParameterList>
     </ParameterList> -->
-
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="998.2 "/>
+          <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -149,7 +145,6 @@
     </ParameterList>
   </ParameterList>
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Almost Entire Domain}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -157,23 +152,18 @@
         <Parameter name="Value" type="double" value="201325.0"/>
       </ParameterList>
       <ParameterList name="Solute IC">
-
         <ParameterList name="Aqueous">
-
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
           </ParameterList>
-
         </ParameterList>
-
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Initial Condition2">
       <Parameter name="Assigned Regions" type="Array(string)" value="{twentyfive}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -181,47 +171,39 @@
         <Parameter name="Value" type="double" value="201325.0"/>
       </ParameterList>
       <ParameterList name="Solute IC">
-
         <ParameterList name="Aqueous">
-
           <ParameterList name="Water">
             <ParameterList name="A">
               <ParameterList name="IC: Uniform Concentration">
-                <Parameter name="Value" type="double" value="1.e-20"/>
+                <Parameter name="Value" type="double" value="1e-20"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="TBC"/>
             </ParameterList>
           </ParameterList>
-
         </ParameterList>
-
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-  
   <ParameterList name="Boundary Conditions">
     <ParameterList name="West BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{West}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{7.91317859e-6, 7.91317859e-6}"/>
-<!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00000791317859, 0.00000791317859}"/>
+        <!--        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{7.927447996e-9,7.927447996e-9}"/>	 		-->
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="A">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+                <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
                 <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-                <Parameter name="Values" type="Array(double)" value="{1.e-3, 1.e-3}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.001, 0.001}"/>
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -229,20 +211,18 @@
     <ParameterList name="East BC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{East}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e9}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.5778463e+9}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-	<Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>	 		
+        <Parameter name="Values" type="Array(double)" value="{201325.0, 201325.0}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="A">
               <ParameterList name="BC: Zero Gradient">
               </ParameterList>
               <Parameter name="Concentration Units" type="string" value="Molar Concentration"/>
             </ParameterList>
-
           </ParameterList>
         </ParameterList>
       </ParameterList>
@@ -251,29 +231,29 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Every_0.05_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0., 1.5768e6, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 1.5768e+6, -1.0}"/>
       </ParameterList>
       <ParameterList name="Every_year">
-	<Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 31556926.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="isotherms"/>
       <Parameter name="File Name Digits" type="string" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Every_year}"/>
-<!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
+      <!-- 	<Parameter name="Time Macro" type="string" value="Every_0.05_year"/> -->
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="isotherms.bgd" />
-    </ParameterList> 
-    <Parameter name="Verbosity" type="Array(string)" value="{verbose}" />
-    <Parameter name="Activity Model" type="string" value="unit" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="isotherms.bgd"/>
+    </ParameterList>
+    <Parameter name="Verbosity" type="Array(string)" value="{verbose}"/>
+    <Parameter name="Activity Model" type="string" value="unit"/>
     <Parameter name="Tolerance" type="double" value="1.0e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="250"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/non_grid_aligned/non_grid_aligned-s-alq.xml
+++ b/test_suites/benchmarking/chemistry/non_grid_aligned/non_grid_aligned-s-alq.xml
@@ -8,7 +8,7 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="72"/>
+        <Parameter name="End" type="double" value="72.0"/>
         <Parameter name="Initial Time Step" type="double" value="0.38"/>
         <Parameter name="Maximum Cycle Number" type="int" value="1000000"/>
       </ParameterList>
@@ -34,21 +34,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <!-- MESH -->
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       <Parameter name="Domain High Coordinate" type="Array(double)" value="{0.6, 0.5}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{120,100}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{120, 100}"/>
     </ParameterList>
   </ParameterList>
-
-
   <!-- REGIONS -->
   <ParameterList name="Regions">
     <ParameterList name="Left bottom">
@@ -70,46 +66,39 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Materials -->
   <ParameterList name="Material Properties">
     <ParameterList name="Aquifers">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All, Left bottom, Left top}"/>
-      
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
-      
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="0.38e-2"/>
+        <Parameter name="Value" type="double" value="0.0038"/>
       </ParameterList>
-
       <ParameterList name="Dispersion Tensor: Uniform Isotropic">
         <Parameter name="alphaL" type="double" value="0.0001"/>
         <Parameter name="alphaT" type="double" value="0.0001"/>
       </ParameterList>
-      
       <ParameterList name="Tortuosity: Uniform">
         <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
-
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="250.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="250.0"/>
+        </ParameterList>
       </ParameterList>
-      
-    </ParameterList> <!--Aquifers-->
-  </ParameterList> <!--Material Properties-->
-
+    </ParameterList>
+    <!--Aquifers-->
+  </ParameterList>
+  <!--Material Properties-->
   <!-- Phases: -->
   <ParameterList name="Phase Definitions">
-    
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="1000.0"/>
@@ -119,142 +108,124 @@
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{CO3--, Ca++}"/>
         </ParameterList>
-      </ParameterList>      
+      </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Calcite}"/>
     </ParameterList>
-    
   </ParameterList>
-
   <!-- Initial Conditions: -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Value" type="double" value="101325.0"/>
       </ParameterList>
-
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="CO3--">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="initial"/>
               </ParameterList>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Boundary Conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="BC For Left top">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left top}"/>
-
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{5}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{5.0}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            
             <ParameterList name="CO3--">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="top"/>
               </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="top"/>
               </ParameterList>
             </ParameterList>
-            
-          </ParameterList> <!--Water-->                    
-        </ParameterList> <!--Aqueous-->        
-      </ParameterList> <!--Solute BC-->
-    </ParameterList> <!--BC For Left Top-->
-
+          </ParameterList>
+          <!--Water-->
+        </ParameterList>
+        <!--Aqueous-->
+      </ParameterList>
+      <!--Solute BC-->
+    </ParameterList>
+    <!--BC For Left Top-->
     <ParameterList name="BC For Left Bottom">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left bottom}"/>
-      
       <ParameterList name="BC: Flux">
         <Parameter name="Inward Mass Flux" type="Array(double)" value="{2.6}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            
             <ParameterList name="CO3--">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="bottom"/>
-              </ParameterList>              
+              </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Geochemical Condition" type="string" value="bottom"/>
-              </ParameterList>              
+              </ParameterList>
             </ParameterList>
-            
-          </ParameterList> <!--Water-->
-        </ParameterList> <!--Aqueous-->
-      </ParameterList> <!--Solute BC-->
-    </ParameterList> <!--BC For Left Bottom-->
-
+          </ParameterList>
+          <!--Water-->
+        </ParameterList>
+        <!--Aqueous-->
+      </ParameterList>
+      <!--Solute BC-->
+    </ParameterList>
+    <!--BC For Left Bottom-->
     <ParameterList name="BC For Right">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right}"/>
       <ParameterList name="BC: Hydrostatic">
         <Parameter name="Water Table Height" type="Array(double)" value="{1.0}"/>
       </ParameterList>
     </ParameterList>
-    
-  </ParameterList> <!--Boundary Conditions-->
-
+  </ParameterList>
+  <!--Boundary Conditions-->
   <!-- Source Terms -->
-  <ParameterList name="Sources"/>
-
+  <ParameterList name="Sources">
+  </ParameterList>
   <!-- Output -->
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{1.2096E+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{1.2096e+8}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 100">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="run_data/chk"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100}"/>
     </ParameterList>
-
     <!--ParameterList name="Observation Data">
     <Parameter name="Observation Output Filename" type="string" value="dispersion.out"/>
     <ParameterList name="Point 01">
@@ -265,11 +236,10 @@
     </ParameterList>
     </ParameterList-->
   </ParameterList>
-  
   <ParameterList name="Chemistry">
     <Parameter name="Engine" type="string" value="PFloTran"/>
     <Parameter name="Engine Input File" type="string" value="calcite_pflotran.in"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
-
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/benchmarking/chemistry/non_grid_aligned/non_grid_aligned-s.xml
+++ b/test_suites/benchmarking/chemistry/non_grid_aligned/non_grid_aligned-s.xml
@@ -8,7 +8,7 @@
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
         <Parameter name="Start" type="double" value="0.0"/>
-        <Parameter name="End" type="double" value="72"/>
+        <Parameter name="End" type="double" value="72.0"/>
         <Parameter name="Initial Time Step" type="double" value="0.38"/>
         <Parameter name="Maximum Cycle Number" type="int" value="1000000"/>
       </ParameterList>
@@ -34,21 +34,17 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <!-- MESH -->
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0,0}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       <Parameter name="Domain High Coordinate" type="Array(double)" value="{0.6, 0.5}"/>
-      <Parameter name="Number of Cells" type="Array(int)" value="{120,100}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{120, 100}"/>
     </ParameterList>
   </ParameterList>
-
-
   <!-- REGIONS -->
   <ParameterList name="Regions">
     <ParameterList name="Left bottom">
@@ -70,46 +66,39 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Materials -->
   <ParameterList name="Material Properties">
     <ParameterList name="Aquifers">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-      
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.38"/>
       </ParameterList>
-      
       <ParameterList name="Hydraulic Conductivity: Uniform">
-        <Parameter name="Value" type="double" value="0.38e-2"/>
+        <Parameter name="Value" type="double" value="0.0038"/>
       </ParameterList>
-
       <ParameterList name="Dispersion Tensor: Uniform Isotropic">
         <Parameter name="alphaL" type="double" value="0.0001"/>
         <Parameter name="alphaT" type="double" value="0.0001"/>
       </ParameterList>
-      
       <ParameterList name="Tortuosity: Uniform">
         <Parameter name="Value" type="double" value="1.0"/>
       </ParameterList>
-
       <ParameterList name="Mineralogy">
-	<ParameterList name="Calcite">
-	  <Parameter name="Volume Fraction" type="double" value="0.0"/>
-	  <Parameter name="Specific Surface Area" type="double" value="250.0"/>	  
-	</ParameterList>
+        <ParameterList name="Calcite">
+          <Parameter name="Volume Fraction" type="double" value="0.0"/>
+          <Parameter name="Specific Surface Area" type="double" value="250.0"/>
+        </ParameterList>
       </ParameterList>
-      
-    </ParameterList> <!--Aquifers-->
-  </ParameterList> <!--Material Properties-->
-
+    </ParameterList>
+    <!--Aquifers-->
+  </ParameterList>
+  <!--Material Properties-->
   <!-- Phases: -->
   <ParameterList name="Phase Definitions">
-    
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.0e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.0010"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="1000.0"/>
@@ -119,142 +108,124 @@
         <ParameterList name="Water">
           <Parameter name="Component Solutes" type="Array(string)" value="{CO3--, Ca++}"/>
         </ParameterList>
-      </ParameterList>      
+      </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Solid">
       <Parameter name="Minerals" type="Array(string)" value="{Calcite}"/>
     </ParameterList>
-    
   </ParameterList>
-
   <!-- Initial Conditions: -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-
       <ParameterList name="IC: Uniform Pressure">
         <Parameter name="Value" type="double" value="101325.0"/>
       </ParameterList>
-
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-
             <ParameterList name="CO3--">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Value" type="double" value="1e-10"/>
               </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="IC: Uniform Concentration">
                 <Parameter name="Value" type="double" value="1e-10"/>
               </ParameterList>
             </ParameterList>
-            
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Boundary Conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="BC For Left top">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left top}"/>
-
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Mass Flux" type="Array(double)" value="{5}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{5.0}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            
             <ParameterList name="CO3--">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Values" type="Array(double)" value="{1e-10}"/>
               </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{5e-2}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.05}"/>
               </ParameterList>
             </ParameterList>
-            
-          </ParameterList> <!--Water-->                    
-        </ParameterList> <!--Aqueous-->        
-      </ParameterList> <!--Solute BC-->
-    </ParameterList> <!--BC For Left Top-->
-
+          </ParameterList>
+          <!--Water-->
+        </ParameterList>
+        <!--Aqueous-->
+      </ParameterList>
+      <!--Solute BC-->
+    </ParameterList>
+    <!--BC For Left Top-->
     <ParameterList name="BC For Left Bottom">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left bottom}"/>
-      
       <ParameterList name="BC: Flux">
         <Parameter name="Inward Mass Flux" type="Array(double)" value="{2.6}"/>
       </ParameterList>
-
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            
             <ParameterList name="CO3--">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{5e-2}"/>
-              </ParameterList>              
+                <Parameter name="Values" type="Array(double)" value="{0.05}"/>
+              </ParameterList>
             </ParameterList>
-            
             <ParameterList name="Ca++">
               <ParameterList name="BC: Uniform Concentration">
                 <Parameter name="Values" type="Array(double)" value="{1e-10}"/>
-              </ParameterList>              
+              </ParameterList>
             </ParameterList>
-            
-          </ParameterList> <!--Water-->
-        </ParameterList> <!--Aqueous-->
-      </ParameterList> <!--Solute BC-->
-    </ParameterList> <!--BC For Left Bottom-->
-
+          </ParameterList>
+          <!--Water-->
+        </ParameterList>
+        <!--Aqueous-->
+      </ParameterList>
+      <!--Solute BC-->
+    </ParameterList>
+    <!--BC For Left Bottom-->
     <ParameterList name="BC For Right">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right}"/>
       <ParameterList name="BC: Hydrostatic">
         <Parameter name="Water Table Height" type="Array(double)" value="{1.0}"/>
       </ParameterList>
     </ParameterList>
-    
-  </ParameterList> <!--Boundary Conditions-->
-
+  </ParameterList>
+  <!--Boundary Conditions-->
   <!-- Source Terms -->
-  <ParameterList name="Sources"/>
-
+  <ParameterList name="Sources">
+  </ParameterList>
   <!-- Output -->
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{1.2096E+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{1.2096e+8}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 100">
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="run_data/chk"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 100}"/>
     </ParameterList>
-
     <!--ParameterList name="Observation Data">
     <Parameter name="Observation Output Filename" type="string" value="dispersion.out"/>
     <ParameterList name="Point 01">
@@ -265,17 +236,16 @@
     </ParameterList>
     </ParameterList-->
   </ParameterList>
-  
   <ParameterList name="Chemistry">
     <ParameterList name="Thermodynamic Database">
-      <Parameter name="Format" type="string" value="simple" />
-      <Parameter name="File" type="string" value="calcite_dbs.bgd" />
+      <Parameter name="Format" type="string" value="simple"/>
+      <Parameter name="File" type="string" value="calcite_dbs.bgd"/>
     </ParameterList>
-    <Parameter name="Verbosity" type="string" value="verbose" />
-    <Parameter name="Activity Model" type="string" value="debye-huckel" />
+    <Parameter name="Verbosity" type="string" value="verbose"/>
+    <Parameter name="Activity Model" type="string" value="debye-huckel"/>
     <Parameter name="Tolerance" type="double" value="1.5e-12"/>
     <Parameter name="Maximum Newton Iterations" type="int" value="150"/>
     <Parameter name="Max Time Step (s)" type="double" value="15778463.0"/>
-  </ParameterList> <!-- Chemistry -->
-
+  </ParameterList>
+  <!-- Chemistry -->
 </ParameterList>

--- a/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_clay_sand_1d.xml
+++ b/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_clay_sand_1d.xml
@@ -1,190 +1,193 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Castleton"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="3.16E11"/>
-	  <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
-          <Parameter name="Initial Time Step" type="double" value="2.0"/>
-        </ParameterList>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="steady max timestep" type="double" value="3.16E11"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Castleton"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="3.16e+11"/>
+        <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
+        <Parameter name="Initial Time Step" type="double" value="2.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-        </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"  units="m" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}"  units="m"/>
-	  </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="steady max timestep" type="double" value="3.16e+11"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Top Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,2.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.0}"  units="m"/>
-			<!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
-      <ParameterList name="Bottom Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,0.0}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.5}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,1.5}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.}"  units="m"/>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}" units="m"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="clay">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43"  units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="1.18e-13" />
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.02e-4" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.25" units="fraction"/>
-			<!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
-          <Parameter name="m" type="double" value=".0909"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="sand">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43" units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="1.18472e-11" />
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.532333e-3" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
-			<!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
-          <Parameter name="m" type="double" value="0.6666667"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Top Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 2.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+        <!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
+    <ParameterList name="Bottom Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.5}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 1.5}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="clay">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="1.18e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.000102" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.25" units="fraction"/>
+        <!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
+        <Parameter name="m" type="double" value="0.0909"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="sand">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="1.18472e-11"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.001532333" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
+        <!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
+        <Parameter name="m" type="double" value="0.6666667"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
-        <ParameterList name="Phase Components">
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Uniform Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Value" type="double" value="81747.0" units="Pa"/>
+        <!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Uniform Pressure">
-         <Parameter name="Phase" type="string" value="Aqueous"/>
-         <Parameter name="Value" type="double" value="81747."  units="Pa"/>
-			<!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
-		<ParameterList name="BC: Uniform Pressure">
-  	    <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}" units="s"/>
-            <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-            <Parameter name="Values" type="Array(double)" value="{99630.6336,99630.6336}" units="Pa"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{5.776620e-5, 5.776620e-5}"/>
-			<!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}" units="s"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{99630.6336, 99630.6336}" units="Pa"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="case_2c_plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="case_2c_checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    <ParameterList name="BC For Top Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00005776620, 0.00005776620}"/>
+        <!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="case_2c_plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="case_2c_checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_loam_sand_1d.xml
+++ b/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_loam_sand_1d.xml
@@ -1,190 +1,193 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Castleton"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="3.16E11"/>
-	  <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
-          <Parameter name="Initial Time Step" type="double" value="2.0"/>
-        </ParameterList>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="steady max timestep" type="double" value="3.16E11"  units="s"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Castleton"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="3.16e+11"/>
+        <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
+        <Parameter name="Initial Time Step" type="double" value="2.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-        </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"  units="m" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}"  units="m"/>
-	  </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="steady max timestep" type="double" value="3.16e+11" units="s"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Top Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,2.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.0}"  units="m"/>
-			<!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
-      <ParameterList name="Bottom Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,0.0}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.5}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,1.5}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.}"  units="m"/>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}" units="m"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="loam">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43"  units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="5.92360e-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="4.08622e-4" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.186047" units="fraction"/>
-			<!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
-          <Parameter name="m" type="double" value="0.375"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
-      </ParameterList>
-      <ParameterList name="sand">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43" units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="1.18472e-11"  units="m/s"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.532333e-3" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
-			<!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
-          <Parameter name="m" type="double" value="0.6666667"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Top Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 2.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+        <!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
+    <ParameterList name="Bottom Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.5}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 1.5}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="loam">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="5.92360e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.000408622" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.186047" units="fraction"/>
+        <!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
+        <Parameter name="m" type="double" value="0.375"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+    <ParameterList name="sand">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="1.18472e-11" units="m/s"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.001532333" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
+        <!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
+        <Parameter name="m" type="double" value="0.6666667"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
-        <ParameterList name="Phase Components">
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Uniform Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Value" type="double" value="81747.0" units="Pa"/>
+        <!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Uniform Pressure">
-         <Parameter name="Phase" type="string" value="Aqueous"/>
-         <Parameter name="Value" type="double" value="81747."  units="Pa"/>
-			<!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
-		<ParameterList name="BC: Uniform Pressure">
-  	    <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}" units="s"/>
-            <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-            <Parameter name="Values" type="Array(double)" value="{99630.6336,99630.6336}" units="Pa"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{5.776620e-5, 5.776620e-5}"/>
-			<!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}" units="s"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{99630.6336, 99630.6336}" units="Pa"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="case_2a_plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="case_2a_checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    <ParameterList name="BC For Top Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00005776620, 0.00005776620}"/>
+        <!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="case_2a_plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="case_2a_checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_sand_loam_1d.xml
+++ b/test_suites/verification/flow/richards/steady-state/infiltration_1d/amanzi_infiltration_sand_loam_1d.xml
@@ -1,190 +1,193 @@
 <ParameterList name="Main">
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Castleton"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="3.16E11"/>
-	  <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
-          <Parameter name="Initial Time Step" type="double" value="2.0"/>
-        </ParameterList>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="steady max timestep" type="double" value="3.16E11"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Castleton"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="3.16e+11"/>
+        <!-- want steady state so run to 10,000 years = 3.16E11 seconds -->
+        <Parameter name="Initial Time Step" type="double" value="2.0"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
-        </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"  units="m" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}"  units="m"/>
-	  </ParameterList>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="steady max timestep" type="double" value="3.16e+11"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.8"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Top Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,2.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.0}"  units="m"/>
-			<!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
-      <ParameterList name="Bottom Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,0.0}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,1.5}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,1.5}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,2.}"  units="m"/>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 200}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.00}" units="m"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="loam">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43"  units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="5.92360e-13"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="4.08622e-4" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.186047" units="fraction"/>
-			<!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
-          <Parameter name="m" type="double" value="0.375"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
-      </ParameterList>
-      <ParameterList name="sand">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43" units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Uniform">
-          <Parameter name="Value" type="double" value="1.18472e-11"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.532333e-3" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
-			<!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
-          <Parameter name="m" type="double" value="0.6666667"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Top Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 2.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+        <!-- 2 meter column represented by 200 1x1x0.01 meter grid cells -->
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
+    <ParameterList name="Bottom Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 1.5}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 1 and Plane Surface 2">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 1.5}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 2.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="loam">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="5.92360e-13"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.000408622" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.186047" units="fraction"/>
+        <!-- changed residual saturation from 0.09 to 0.186407 (theta-r/theta-s =0.08/0.43) -->
+        <Parameter name="m" type="double" value="0.375"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+    <ParameterList name="sand">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Uniform">
+        <Parameter name="Value" type="double" value="1.18472e-11"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.001532333" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
+        <!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
+        <Parameter name="m" type="double" value="0.6666667"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 1 and Plane Surface 2}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
-        <ParameterList name="Phase Components">
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Uniform Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Value" type="double" value="81747.0" units="Pa"/>
+        <!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Uniform Pressure">
-         <Parameter name="Phase" type="string" value="Aqueous"/>
-         <Parameter name="Value" type="double" value="81747."  units="Pa"/>
-			<!-- -2 m water initial condition based on 9.80665 m/s^2 gravity -->
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
-		<ParameterList name="BC: Uniform Pressure">
-  	    <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}" units="s"/>
-            <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-            <Parameter name="Values" type="Array(double)" value="{99630.6336,99630.6336}" units="Pa"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 3.16E11}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{5.776620e-5, 5.776620e-5}"/>
-			<!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}" units="s"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{99630.6336, 99630.6336}" units="Pa"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros"/>
-      <ParameterList name="Cycle Macros">
-        <ParameterList name="Every_1.0_1000.0_-1">
-          <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,100,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="case_2b_plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-	<Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="case_2b_checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    <ParameterList name="BC For Top Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 3.16e+11}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.00005776620, 0.00005776620}"/>
+        <!-- 0.5 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+    </ParameterList>
+    <ParameterList name="Cycle Macros">
+      <ParameterList name="Every_1.0_1000.0_-1">
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 100, -1}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="case_2b_plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Cycle Macros" type="Array(string)" value="{Every_1.0_1000.0_-1}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="case_2b_checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Cycle Macro" type="string" value="Every_1.0_1000.0_-1"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/test_suites/verification/flow/richards/steady-state/unconfined_layered_2d/amanzi_unconfined_layered_2d.xml
+++ b/test_suites/verification/flow/richards/steady-state/unconfined_layered_2d/amanzi_unconfined_layered_2d.xml
@@ -1,7 +1,5 @@
 <ParameterList name="Main">
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-
   <!--
      Getting started on a simple 2D steady-state saturated test
   -->
@@ -9,7 +7,6 @@
     <Parameter name="Model ID" type="string" value="2SSUncFlow1"/>
     <Parameter name="Author" type="string" value="Greg Flach, SRNL"/>
   </ParameterList>
-
   <!--
      Execution Control
   -->
@@ -17,17 +14,16 @@
     <Parameter name="Flow Model" type="string" value="Richards"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-<!--
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <!--
           <Parameter name="End" type="double" value="0.0"/>
 -->
-          <Parameter name="End" type="double" value="3.16e+12"/>
-          <Parameter name="Initial Time Step" type="double" value="1000"/>
-        </ParameterList>
-<!--
+        <Parameter name="End" type="double" value="3.16e+12"/>
+        <Parameter name="Initial Time Step" type="double" value="1000.0"/>
+      </ParameterList>
+      <!--
         <ParameterList name="Transient">
           <Parameter name="Start" type="double" value="0.0"/>
           <Parameter name="End" type="double" value="3.16e+9"/>
@@ -38,9 +34,7 @@
         </ParameterList>
 -->
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Linear Solver">
@@ -57,36 +51,32 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  
   </ParameterList>
-      
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="3"/>
   </ParameterList>
-
   <!--
      Mesh:  three-dimensional box 
   -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
       <ParameterList name="Expert">
-	<Parameter name="Framework" type="string" value="MSTK"/>
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
-<!--
+          <!--
           <Parameter name="Number of Cells" type="Array(int)" value="{50, 1, 105}"/>
           <Parameter name="Number of Cells" type="Array(int)" value="{150, 1, 315}"/>
           <Parameter name="Number of Cells" type="Array(int)" value="{250, 1, 525}"/>
 -->
           <Parameter name="Number of Cells" type="Array(int)" value="{50, 1, 105}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{304.8, 1.0, 64.008}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{304.8, 1.0, 64.008}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Regions: 
   -->
@@ -100,21 +90,18 @@
         <Parameter name="High Coordinate" type="Array(double)" value="{304.8, 1.0, 64.008}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Confined Aquifer">
       <ParameterList name="Region: Box">
         <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
         <Parameter name="High Coordinate" type="Array(double)" value="{304.8, 1.0, 30.48}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Confining Unit">
       <ParameterList name="Region: Box">
         <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 30.48}"/>
         <Parameter name="High Coordinate" type="Array(double)" value="{304.8, 1.0, 33.528}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Unconfined Aquifer">
       <ParameterList name="Region: Box">
         <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 33.528}"/>
@@ -142,7 +129,6 @@
         <Parameter name="High Coordinate" type="Array(double)" value="{0.0, 1.0, 64.008}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Right Confined Aquifer">
       <ParameterList name="Region: Box">
         <Parameter name="Low Coordinate" type="Array(double)" value="{304.8, 0.0, 0.0}"/>
@@ -166,882 +152,875 @@
     -->
     <ParameterList name="Confined x=10 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=90 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=190 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=290 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=390 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=490 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=590 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=690 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=790 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{243.79, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{243.79, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=890 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Confined x=990 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 15.5448}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 15.5448}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Unconfined x=10 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=90 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=190 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=290 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=390 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=490 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=590 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=690 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=790 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{240.79, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{240.79, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=890 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Unconfined x=990 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Top x=10 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{3.048, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=90 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{27.432, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=190 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{57.912, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=290 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{88.392, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=390 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{118.87, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=490 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.35, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=590 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{179.83, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=690 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{210.31, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=790 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{240.79, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{240.79, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=890 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{271.27, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Top x=990 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{301.75, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Left z=1 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 0.3048}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 0.3048}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=99 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 30.1752}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 30.1752}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=101 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 30.7848}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 30.7848}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=109 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 33.2232}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 33.2232}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=111 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=121 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 36.8808}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 36.8808}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=129 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 39.3192}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 39.3192}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=131 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 39.9288}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 39.9288}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=133 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 40.5384}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 40.5384}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=135 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 41.1480}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 41.1480}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=137 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 41.7576}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 41.7576}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=139 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 42.3672}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 42.3672}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=141 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 42.9768}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 42.9768}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=143 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 43.5864}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 43.5864}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=145 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 44.1960}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 44.1960}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=147 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 44.8056}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 44.8056}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=149 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 45.4152}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 45.4152}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=151 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 46.0248}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 46.0248}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=153 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 46.6344}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 46.6344}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=155 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 47.2440}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 47.2440}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=157 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 47.8536}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 47.8536}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=159 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 48.4632}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 48.4632}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=161 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 49.0728}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 49.0728}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=163 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 49.6824}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 49.6824}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=165 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 50.2920}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 50.2920}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=167 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 50.9016}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 50.9016}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=169 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 51.5112}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 51.5112}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=171 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 52.1208}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 52.1208}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=173 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 52.7304}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 52.7304}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=175 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 53.3400}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 53.3400}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=177 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 53.9496}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 53.9496}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=179 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 54.5592}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 54.5592}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=181 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 55.1688}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 55.1688}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=183 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 55.7784}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 55.7784}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=185 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 56.3880}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 56.3880}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=187 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 56.9976}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 56.9976}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=189 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 57.6072}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 57.6072}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=191 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 58.2168}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 58.2168}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=193 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 58.8264}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 58.8264}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=195 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 59.4360}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 59.4360}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=197 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 60.0456}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 60.0456}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=199 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 60.6552}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 60.6552}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=201 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 61.2648}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 61.2648}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=203 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 61.8744}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 61.8744}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=205 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 62.4840}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 62.4840}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=207 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 63.0936}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 63.0936}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Left z=209 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Right z=1 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 0.3048}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 0.3048}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=99 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 30.1752}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 30.1752}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=101 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 30.7848}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 30.7848}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=109 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 33.2232}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 33.2232}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=111 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=121 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 36.8808}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 36.8808}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=129 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 39.3192}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 39.3192}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=131 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 39.9288}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 39.9288}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=133 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 40.5384}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 40.5384}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=135 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 41.1480}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 41.1480}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=137 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 41.7576}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 41.7576}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=139 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 42.3672}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 42.3672}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=141 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 42.9768}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 42.9768}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=143 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 43.5864}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 43.5864}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=145 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 44.1960}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 44.1960}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=147 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 44.8056}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 44.8056}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=149 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 45.4152}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 45.4152}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=151 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 46.0248}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 46.0248}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=153 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 46.6344}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 46.6344}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=155 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 47.2440}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 47.2440}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=157 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 47.8536}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 47.8536}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=159 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 48.4632}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 48.4632}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=161 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 49.0728}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 49.0728}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=163 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 49.6824}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 49.6824}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=165 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 50.2920}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 50.2920}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=167 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 50.9016}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 50.9016}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=169 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 51.5112}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 51.5112}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=171 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 52.1208}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 52.1208}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=173 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 52.7304}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 52.7304}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=175 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 53.3400}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 53.3400}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=177 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 53.9496}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 53.9496}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=179 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 54.5592}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 54.5592}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=181 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 55.1688}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 55.1688}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=183 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 55.7784}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 55.7784}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=185 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 56.3880}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 56.3880}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=187 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 56.9976}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 56.9976}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=189 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 57.6072}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 57.6072}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=191 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 58.2168}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 58.2168}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=193 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 58.8264}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 58.8264}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=195 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 59.4360}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 59.4360}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=197 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 60.0456}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 60.0456}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=199 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 60.6552}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 60.6552}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=201 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 61.2648}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 61.2648}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=203 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 61.8744}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 61.8744}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=205 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 62.4840}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 62.4840}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=207 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 63.0936}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 63.0936}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right z=209 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{304.8, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Middle z=1 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 0.3048}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 0.3048}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=99 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 30.1752}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 30.1752}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=101 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 30.7848}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 30.7848}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=109 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 33.2232}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 33.2232}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=111 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 33.8328}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 33.8328}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=121 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 36.8808}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 36.8808}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=129 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 39.3192}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 39.3192}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=131 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 39.9288}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 39.9288}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=133 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 40.5384}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 40.5384}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=135 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 41.1480}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 41.1480}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=137 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 41.7576}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 41.7576}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=139 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 42.3672}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 42.3672}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=141 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 42.9768}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 42.9768}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=143 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 43.5864}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 43.5864}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=145 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 44.1960}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 44.1960}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=147 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 44.8056}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 44.8056}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=149 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 45.4152}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 45.4152}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=151 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 46.0248}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 46.0248}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=153 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 46.6344}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 46.6344}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=155 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 47.2440}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 47.2440}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=157 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 47.8536}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 47.8536}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=159 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 48.4632}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 48.4632}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=161 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 49.0728}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 49.0728}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=163 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 49.6824}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 49.6824}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=165 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 50.2920}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 50.2920}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=167 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 50.9016}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 50.9016}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=169 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 51.5112}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 51.5112}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=171 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 52.1208}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 52.1208}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=173 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 52.7304}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 52.7304}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=175 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 53.3400}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 53.3400}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=177 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 53.9496}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 53.9496}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=179 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 54.5592}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 54.5592}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=181 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 55.1688}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 55.1688}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=183 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 55.7784}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 55.7784}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=185 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 56.3880}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 56.3880}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=187 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 56.9976}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 56.9976}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=189 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 57.6072}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 57.6072}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=191 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 58.2168}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 58.2168}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=193 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 58.8264}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 58.8264}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=195 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 59.4360}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 59.4360}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=197 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 60.0456}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 60.0456}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=199 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 60.6552}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 60.6552}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=201 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 61.2648}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 61.2648}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=203 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 61.8744}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 61.8744}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=205 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 62.4840}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 62.4840}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=207 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 63.0936}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 63.0936}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Middle z=209 ft">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 63.7032}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{149.352, 0.5, 63.7032}"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <!--
     Materials:
   -->
@@ -1051,7 +1030,7 @@
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="3.6109e-13"/>
       </ParameterList>
@@ -1062,19 +1041,18 @@
         <Parameter name="z" type="double" value="3.6109e-12"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Aquitards">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Confining Unit}"/>
       <ParameterList name="Porosity: Uniform">
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="2.3073e-20"/>
       </ParameterList>
@@ -1085,14 +1063,13 @@
         <Parameter name="z" type="double" value="4.1059e-16"/>
       </ParameterList>
       <ParameterList name="Capillary Pressure: van Genuchten">
-        <Parameter name="alpha" type="double" value="1.46e-3"/>
+        <Parameter name="alpha" type="double" value="0.00146"/>
         <Parameter name="Sr" type="double" value="0.052"/>
         <Parameter name="m" type="double" value="0.314"/>
         <Parameter name="Relative Permeability" type="string" value="Mualem"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Phases:
   -->
@@ -1100,21 +1077,18 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
   </ParameterList>
-
   <!--
     Initial Conditions:
   -->
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Confined Aquifer, Unconfined Aquifer, Confining Unit}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -1122,14 +1096,11 @@
         <Parameter name="Value" type="double" value="190892.5"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <!--
     Boundary Conditions
   -->
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="LeftBC Confined Aquifer">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left Confined Aquifer}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -1151,7 +1122,6 @@
       <ParameterList name="BC: Impermeable">
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="RightBC Confined Aquifer">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right Confined Aquifer}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -1173,20 +1143,15 @@
       <ParameterList name="BC: Impermeable">
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
-
     <ParameterList name="Time Macros">
       <ParameterList name="Steady State">
-	<Parameter name="Values" type="Array(double)" value="{3.16e+12}"/>
+        <Parameter name="Values" type="Array(double)" value="{3.16e+12}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation_Leakage.out"/>
-
       <ParameterList name="Unconfined x=10 ft">
         <Parameter name="Region" type="string" value="Unconfined x=10 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -1253,7 +1218,6 @@
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="Confined x=10 ft">
         <Parameter name="Region" type="string" value="Confined x=10 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -1320,7 +1284,6 @@
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="P Top x=10 ft">
         <Parameter name="Region" type="string" value="Top x=10 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -1387,7 +1350,6 @@
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="S Top x=10 ft">
         <Parameter name="Region" type="string" value="Top x=10 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -1454,7 +1416,6 @@
         <Parameter name="Variable" type="string" value="Aqueous saturation"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="S Left z=1 ft">
         <Parameter name="Region" type="string" value="Left z=1 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -1737,7 +1698,6 @@
         <Parameter name="Variable" type="string" value="Aqueous saturation"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="S Middle z=1 ft">
         <Parameter name="Region" type="string" value="Middle z=1 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -2020,7 +1980,6 @@
         <Parameter name="Variable" type="string" value="Aqueous saturation"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="S Right z=1 ft">
         <Parameter name="Region" type="string" value="Right z=1 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -2303,7 +2262,6 @@
         <Parameter name="Variable" type="string" value="Aqueous saturation"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-
       <ParameterList name="P Middle z=1 ft">
         <Parameter name="Region" type="string" value="Middle z=1 ft"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -2586,7 +2544,7 @@
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macro" type="string" value="Steady State"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Darcy velocity / volumetric flux 3">
         <Parameter name="Region" type="string" value="MidpointCell"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -2595,16 +2553,12 @@
       </ParameterList>
 -->
     </ParameterList>
-
-<!--
+    <!--
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="steady-flow"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Steady State}"/>
     </ParameterList>
 -->
-
   </ParameterList>
-
 </ParameterList>
-

--- a/test_suites/verification/flow/richards/transient/infiltration_dry_sand_1d/amanzi_infiltration_dry_sand_1d.xml
+++ b/test_suites/verification/flow/richards/transient/infiltration_dry_sand_1d/amanzi_infiltration_dry_sand_1d.xml
@@ -1,184 +1,186 @@
 <ParameterList name="Main">
-    <!-- 1USUnsFlow1a: Transient infiltration into dry SAND -->
-    <!-- Vanderborght et al. 2005, A set of analytical benchmarks to test numerical -->
-    <!-- models of flow and transport in soils, Vadose Zone Journal 4:206.221 -->
-    <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-    <ParameterList name="General Description">
-      <Parameter name="Model ID" type="string" value="TBD"/>
-      <Parameter name="Author" type="string" value="Yabusaki"/>
-    </ParameterList>
-    <ParameterList name="Execution Control">
-      <Parameter name="Flow Model" type="string" value="Richards"/>
-      <Parameter name="Transport Model" type="string" value="Off"/>
-      <Parameter name="Chemistry Model" type="string" value="Off"/>
-      <ParameterList name="Time Integration Mode">
-        <ParameterList name="Transient">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="8.64E4"/>
-	  <!-- want transient run to 1 day = 8.64E4 seconds -->
-          <Parameter name="Initial Time Step" type="double" value="2.0E-3"/>
-        </ParameterList>
-      </ParameterList>
-      <Parameter name="Verbosity" type="string" value="High"/>
-      <ParameterList name="Numerical Control Parameters">
-        <ParameterList name="Unstructured Algorithm">
-          <ParameterList name="Steady-State Implicit Time Integration">
-            <Parameter name="steady max iterations" type="int" value="15"/>
-            <Parameter name="steady min iterations" type="int" value="10"/>
-            <Parameter name="steady limit iterations" type="int" value="20"/>
-            <Parameter name="steady nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="steady max timestep" type="double" value="3.16E11"  units="s"/>
-            <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
-            <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-          <ParameterList name="Transient Implicit Time Integration">
-            <Parameter name="transient max iterations" type="int" value="15"/>
-            <Parameter name="transient min iterations" type="int" value="10"/>
-            <Parameter name="transient limit iterations" type="int" value="20"/>
-            <Parameter name="transient nonlinear tolerance" type="double" value="1e-6"/>
-            <Parameter name="transient max timestep" type="double" value="8.64E3"  units="s"/>
-            <Parameter name="transient max preconditioner lag iterations" type="int" value="0"/>
-            <Parameter name="transient timestep reduction factor" type="double" value="0.5"/>
-            <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
-          </ParameterList>
-        </ParameterList>
+  <!-- 1USUnsFlow1a: Transient infiltration into dry SAND -->
+  <!-- Vanderborght et al. 2005, A set of analytical benchmarks to test numerical -->
+  <!-- models of flow and transport in soils, Vadose Zone Journal 4:206.221 -->
+  <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
+  <ParameterList name="General Description">
+    <Parameter name="Model ID" type="string" value="TBD"/>
+    <Parameter name="Author" type="string" value="Yabusaki"/>
+  </ParameterList>
+  <ParameterList name="Execution Control">
+    <Parameter name="Flow Model" type="string" value="Richards"/>
+    <Parameter name="Transport Model" type="string" value="Off"/>
+    <Parameter name="Chemistry Model" type="string" value="Off"/>
+    <ParameterList name="Time Integration Mode">
+      <ParameterList name="Transient">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="8.64e+4"/>
+        <!-- want transient run to 1 day = 8.64E4 seconds -->
+        <Parameter name="Initial Time Step" type="double" value="0.0020"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Domain">
-      <Parameter name="Spatial Dimension" type="int" value="3"/>
-    </ParameterList>
-    <ParameterList name="Mesh">
-      <ParameterList name="Unstructured">
-        <ParameterList name="Expert">
-	  <Parameter name="Framework" type="string" value="MSTK"/>
+    <Parameter name="Verbosity" type="string" value="High"/>
+    <ParameterList name="Numerical Control Parameters">
+      <ParameterList name="Unstructured Algorithm">
+        <ParameterList name="Steady-State Implicit Time Integration">
+          <Parameter name="steady max iterations" type="int" value="15"/>
+          <Parameter name="steady min iterations" type="int" value="10"/>
+          <Parameter name="steady limit iterations" type="int" value="20"/>
+          <Parameter name="steady nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="steady max timestep" type="double" value="3.16e+11" units="s"/>
+          <Parameter name="steady max preconditioner lag iterations" type="int" value="1"/>
+          <Parameter name="steady timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="steady timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
-        <ParameterList name="Generate Mesh">
-	  <ParameterList name="Uniform Structured">
-	    <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 400}"/>
-	    <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0,  0.0}"  units="m" />
-	    <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 4.00}"  units="m"/>
-	    <!-- extending domain from 2 to 4 m to avoid bottom boundary condition -->
-	  </ParameterList>
+        <ParameterList name="Transient Implicit Time Integration">
+          <Parameter name="transient max iterations" type="int" value="15"/>
+          <Parameter name="transient min iterations" type="int" value="10"/>
+          <Parameter name="transient limit iterations" type="int" value="20"/>
+          <Parameter name="transient nonlinear tolerance" type="double" value="0.000001"/>
+          <Parameter name="transient max timestep" type="double" value="8.64e+3" units="s"/>
+          <Parameter name="transient max preconditioner lag iterations" type="int" value="0"/>
+          <Parameter name="transient timestep reduction factor" type="double" value="0.5"/>
+          <Parameter name="transient timestep increase factor" type="double" value="1.25"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Regions">
-      <ParameterList name="Top Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,4.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,4.0}"  units="m"/>
-			<!-- 4 meter column represented by 400 1x1x0.01 meter grid cells -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Domain">
+    <Parameter name="Spatial Dimension" type="int" value="3"/>
+  </ParameterList>
+  <ParameterList name="Mesh">
+    <ParameterList name="Unstructured">
+      <ParameterList name="Expert">
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
-      <ParameterList name="Bottom Surface">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,0.0}"  units="m"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
-        <ParameterList name="Region: Box">
-          <Parameter name="Low Coordinate" type="Array(double)" value="{0.0,0.0,0.0}"  units="m"/>
-          <Parameter name="High Coordinate" type="Array(double)" value="{1.0,1.0,4.0}"  units="m"/>
+      <ParameterList name="Generate Mesh">
+        <ParameterList name="Uniform Structured">
+          <Parameter name="Number of Cells" type="Array(int)" value="{1, 1, 400}"/>
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{1.0, 1.0, 4.00}" units="m"/>
+          <!-- extending domain from 2 to 4 m to avoid bottom boundary condition -->
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Material Properties">
-      <ParameterList name="sand">
-        <ParameterList name="Porosity: Uniform">
-          <Parameter name="Value" type="double" value="0.43" units="fraction"/>
-        </ParameterList>
-        <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-          <Parameter name="x" type="double" value="1.18472e-11" units="m/s"/>
-          <Parameter name="y" type="double" value="1.18472e-11" units="m/s"/>
-          <Parameter name="z" type="double" value="1.18472e-11" units="m/s"/>
-        </ParameterList>
-        <ParameterList name="Capillary Pressure: van Genuchten">
-          <Parameter name="alpha" type="double" value="1.532333e-3" units="Pa^-1"/>
-          <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
-			<!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
-          <Parameter name="m" type="double" value="0.6666667"/>
-          <Parameter name="Relative Permeability" type="string" value="Mualem"/>
-          <Parameter name="krel smoothing interval" type="double" value="0.0"/>
-        </ParameterList>
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+  </ParameterList>
+  <ParameterList name="Regions">
+    <ParameterList name="Top Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 4.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 4.0}" units="m"/>
+        <!-- 4 meter column represented by 400 1x1x0.01 meter grid cells -->
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Phase Definitions">
-      <ParameterList name="Aqueous">
-        <ParameterList name="Phase Properties">
-          <ParameterList name="Viscosity: Uniform">
-            <Parameter name="Viscosity" type="double" value="1.002e-3 "/>
-          </ParameterList>
-          <ParameterList name="Density: Uniform">
-            <Parameter name="Density" type="double" value="998.2 "/>
-          </ParameterList>
+    <ParameterList name="Bottom Surface">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 0.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Region between Plane Surface 0 and Plane Surface 1">
+      <ParameterList name="Region: Box">
+        <Parameter name="Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" units="m"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.0, 1.0, 4.0}" units="m"/>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Material Properties">
+    <ParameterList name="sand">
+      <ParameterList name="Porosity: Uniform">
+        <Parameter name="Value" type="double" value="0.43" units="fraction"/>
+      </ParameterList>
+      <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
+        <Parameter name="x" type="double" value="1.18472e-11" units="m/s"/>
+        <Parameter name="y" type="double" value="1.18472e-11" units="m/s"/>
+        <Parameter name="z" type="double" value="1.18472e-11" units="m/s"/>
+      </ParameterList>
+      <ParameterList name="Capillary Pressure: van Genuchten">
+        <Parameter name="alpha" type="double" value="0.001532333" units="Pa^-1"/>
+        <Parameter name="Sr" type="double" value="0.104651" units="fraction"/>
+        <!-- changed from residual water content of 0.045 to residual saturation of 0.104651 -->
+        <Parameter name="m" type="double" value="0.6666667"/>
+        <Parameter name="Relative Permeability" type="string" value="Mualem"/>
+        <Parameter name="krel smoothing interval" type="double" value="0.0"/>
+      </ParameterList>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Region between Plane Surface 0 and Plane Surface 1}"/>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Phase Definitions">
+    <ParameterList name="Aqueous">
+      <ParameterList name="Phase Properties">
+        <ParameterList name="Viscosity: Uniform">
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
-        <ParameterList name="Phase Components">
+        <ParameterList name="Density: Uniform">
+          <Parameter name="Density" type="double" value="998.2"/>
+        </ParameterList>
+      </ParameterList>
+      <ParameterList name="Phase Components">
+        <ParameterList name="Water">
+          <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
+        </ParameterList>
+      </ParameterList>
+    </ParameterList>
+  </ParameterList>
+  <ParameterList name="Initial Conditions">
+    <ParameterList name="All">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
+      <ParameterList name="IC: Uniform Pressure">
+        <Parameter name="Phase" type="string" value="Aqueous"/>
+        <Parameter name="Value" type="double" value="62169.0" units="Pa"/>
+        <!-- -4 m water initial condition based on 9.80665 m/s^2 gravity -->
+      </ParameterList>
+      <ParameterList name="Solute IC">
+        <ParameterList name="Aqueous">
           <ParameterList name="Water">
-            <Parameter name="Component Solutes" type="Array(string)" value="{Tc-99}"/>
-          </ParameterList>
-        </ParameterList>
-      </ParameterList>
-    </ParameterList>
-    <ParameterList name="Initial Conditions">
-      <ParameterList name="All">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
-        <ParameterList name="IC: Uniform Pressure">
-         <Parameter name="Phase" type="string" value="Aqueous"/>
-         <Parameter name="Value" type="double" value="62169."  units="Pa"/>
-			<!-- -4 m water initial condition based on 9.80665 m/s^2 gravity -->
-        </ParameterList>
-        <ParameterList name="Solute IC">
-          <ParameterList name="Aqueous">
-            <ParameterList name="Water">
-              <ParameterList name="Tc-99">
-                <ParameterList name="IC: Uniform Concentration">
-                  <Parameter name="Value" type="double" value="0"/>
-                </ParameterList>
+            <ParameterList name="Tc-99">
+              <ParameterList name="IC: Uniform Concentration">
+                <Parameter name="Value" type="double" value="0.0"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Boundary Conditions">
-      <ParameterList name="BC For Bottom Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
-		<ParameterList name="BC: Uniform Pressure">
-  	    <Parameter name="Times" type="Array(double)" value="{0.0, 8.64E4}" units="s"/>
-            <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-            <Parameter name="Values" type="Array(double)" value="{62169.,62169.}" units="Pa"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="BC For Top Surface">
-        <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
-        <ParameterList name="BC: Flux">
-          <Parameter name="Times" type="Array(double)" value="{0.0, 8.64E4}"/>
-          <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
-          <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.0115532,0.0115532}"/>
-			<!-- 100 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
-        </ParameterList>
+  </ParameterList>
+  <ParameterList name="Boundary Conditions">
+    <ParameterList name="BC For Bottom Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Bottom Surface}"/>
+      <ParameterList name="BC: Uniform Pressure">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 8.64e+4}" units="s"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Values" type="Array(double)" value="{62169.0, 62169.0}" units="Pa"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Output">
-      <ParameterList name="Time Macros">
-        <ParameterList name="Every_0.1_day">
-          <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0,8.64E3,-1}"/>
-        </ParameterList>
-      </ParameterList>
-      <ParameterList name="Variable Macros"/>
-      <ParameterList name="Observation Data"/>
-      <ParameterList name="Visualization Data">
-        <Parameter name="File Name Base" type="string" value="plot"/>
-        <Parameter name="File Name Digits" type="int" value="5"/>
-        <Parameter name="Time Macros" type="Array(string)" value="{Every_0.1_day}"/>
-      </ParameterList>
-      <ParameterList name="Checkpoint Data">
-        <Parameter name="File Name Base" type="string" value="checkpoint"/>
-        <Parameter name="File Name Digit" type="int" value="5"/>
-        <Parameter name="Time Macros" type="Array(string)" value="{Every_0.1_day}"/>
+    <ParameterList name="BC For Top Surface">
+      <Parameter name="Assigned Regions" type="Array(string)" value="{Top Surface}"/>
+      <ParameterList name="BC: Flux">
+        <Parameter name="Times" type="Array(double)" value="{0.0, 8.64e+4}"/>
+        <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
+        <Parameter name="Inward Mass Flux" type="Array(double)" value="{0.0115532, 0.0115532}"/>
+        <!-- 100 cm/d * (1 m/100 cm)(1 d/24 h)(1 h/3600 s) (998.2 kg/m3) -->
       </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Output">
+    <ParameterList name="Time Macros">
+      <ParameterList name="Every_0.1_day">
+        <Parameter name="Start_Period_Stop" type="Array(double)" value="{0.0, 8.64e+3, -1.0}"/>
+      </ParameterList>
+    </ParameterList>
+    <ParameterList name="Variable Macros">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+      <Parameter name="File Name Base" type="string" value="plot"/>
+      <Parameter name="File Name Digits" type="int" value="5"/>
+      <Parameter name="Time Macros" type="Array(string)" value="{Every_0.1_day}"/>
+    </ParameterList>
+    <ParameterList name="Checkpoint Data">
+      <Parameter name="File Name Base" type="string" value="checkpoint"/>
+      <Parameter name="File Name Digit" type="int" value="5"/>
+      <Parameter name="Time Macros" type="Array(string)" value="{Every_0.1_day}"/>
+    </ParameterList>
+  </ParameterList>
+</ParameterList>

--- a/test_suites/verification/flow/saturated/steady-state/linear_head_head_1d/amanzi_linear_head_head_1d.xml
+++ b/test_suites/verification/flow/saturated/steady-state/linear_head_head_1d/amanzi_linear_head_head_1d.xml
@@ -1,7 +1,5 @@
 <ParameterList name="Main">
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-
   <!--
      Getting started on a simple 2D steady-state saturated test
   -->
@@ -9,7 +7,6 @@
     <Parameter name="Model ID" type="string" value="1SSConFlow1"/>
     <Parameter name="Author" type="string" value="Greg Flach, SRNL"/>
   </ParameterList>
-
   <!--
      Execution Control
   -->
@@ -17,17 +14,14 @@
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="1000.0"/>
-          <Parameter name="Initial Time Step" type="double" value="1.0"/>
-        </ParameterList>
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1000.0"/>
+        <Parameter name="Initial Time Step" type="double" value="1.0"/>
+      </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Linear Solver">
@@ -36,31 +30,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  
   </ParameterList>
-      
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="3"/>
   </ParameterList>
-
   <!--
      Mesh:  three-dimensional box 100m x 2m x 10m 
   -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
       <ParameterList name="Expert">
-	<Parameter name="Framework" type="string" value="MSTK"/>
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{20, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0, 10.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0, 10.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Regions: 
   -->
@@ -94,42 +84,40 @@
     -->
     <ParameterList name="LeftBoundary">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightBoundary">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{100.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{100.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Midpoint">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{50.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{50.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="LeftmostCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{2.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{2.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightmostCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{97.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{97.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="LeftMidpointCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{47.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{47.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightMidpointCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{52.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{52.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Materials:
   -->
@@ -144,7 +132,6 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Phases:
   -->
@@ -152,21 +139,18 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
   </ParameterList>
-
   <!--
     Initial Conditions:
   -->
   <ParameterList name="Initial Conditions">
-
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -174,14 +158,11 @@
         <Parameter name="Value" type="double" value="190892.5"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <!--
     Boundary Conditions
   -->
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="LeftBC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -190,7 +171,6 @@
         <Parameter name="Water Table Height" type="Array(double)" value="{20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="RightBC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -199,19 +179,14 @@
         <Parameter name="Water Table Height" type="Array(double)" value="{19.0, 19.0}"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
-
     <ParameterList name="Time Macros">
       <ParameterList name="Steady State">
-	<Parameter name="Values" type="Array(double)" value="{1000.0}"/>
+        <Parameter name="Values" type="Array(double)" value="{1000.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation Data">
-
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="Pressure 1">
         <Parameter name="Region" type="string" value="LeftBoundary"/>
@@ -255,7 +230,7 @@
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macros" type="Array(string)" value="{Steady State}"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Darcy velocity / volumetric flux 3">
         <Parameter name="Region" type="string" value="MidpointCell"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -264,14 +239,10 @@
       </ParameterList>
 -->
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="steady-flow"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Steady State}"/>
     </ParameterList>
-
   </ParameterList>
-
 </ParameterList>
-

--- a/test_suites/verification/flow/saturated/steady-state/linear_materials_serial_1d/amanzi_linear_materials_serial_1d.xml
+++ b/test_suites/verification/flow/saturated/steady-state/linear_materials_serial_1d/amanzi_linear_materials_serial_1d.xml
@@ -1,7 +1,5 @@
 <ParameterList name="Main">
-
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.3"/>
-
   <!--
      Getting started on a simple 2D steady-state saturated test
   -->
@@ -9,7 +7,6 @@
     <Parameter name="Model ID" type="string" value="1SSConFlow3"/>
     <Parameter name="Author" type="string" value="Greg Flach, SRNL"/>
   </ParameterList>
-
   <!--
      Execution Control
   -->
@@ -17,17 +14,14 @@
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
-        <ParameterList name="Steady">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="1000.0"/>
-          <Parameter name="Initial Time Step" type="double" value="1.0"/>
-        </ParameterList>
+      <ParameterList name="Steady">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1000.0"/>
+        <Parameter name="Initial Time Step" type="double" value="1.0"/>
+      </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Linear Solver">
@@ -36,31 +30,27 @@
         </ParameterList>
       </ParameterList>
     </ParameterList>
-  
   </ParameterList>
-      
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="3"/>
   </ParameterList>
-
   <!--
      Mesh:  three-dimensional box 100m x 2m x 10m 
   -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
       <ParameterList name="Expert">
-	<Parameter name="Framework" type="string" value="MSTK"/>
+        <Parameter name="Framework" type="string" value="MSTK"/>
       </ParameterList>
       <ParameterList name="Generate Mesh">
         <ParameterList name="Uniform Structured">
           <Parameter name="Number of Cells" type="Array(int)" value="{20, 1, 1}"/>
-          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}" />
-          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0, 10.0}" />
+          <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0, 0.0}"/>
+          <Parameter name="Domain High Coordinate" type="Array(double)" value="{100.0, 2.0, 10.0}"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Regions: 
   -->
@@ -106,52 +96,49 @@
     -->
     <ParameterList name="LeftBoundary">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{0.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightBoundary">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{100.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{100.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Midpoint">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{50.0, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{50.0, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="LeftmostCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{2.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{2.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightmostCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{97.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{97.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="LeftMidpointCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{47.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{47.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="RightMidpointCell">
       <ParameterList name="Region: Point">
-	<Parameter name="Coordinate" type="Array(double)" value="{52.5, 1.0, 5.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{52.5, 1.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!--
     Materials:
   -->
   <ParameterList name="Material Properties">
-
-<!-- 
+    <!-- 
 block below produces error message "Permeability can only be specified as 
 Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform" 
 -->
-<!--
+    <!--
     <ParameterList name="Both Materials">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
       <ParameterList name="Porosity: Uniform">
@@ -182,7 +169,6 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Value" type="double" value="1.1847e-12"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Right Material">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right Half}"/>
       <ParameterList name="Porosity: Uniform">
@@ -192,9 +178,7 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Value" type="double" value="1.1847e-11"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <!--
     Phases:
   -->
@@ -202,22 +186,19 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.2"/>
         </ParameterList>
       </ParameterList>
-
     </ParameterList>
   </ParameterList>
-
   <!--
     Initial Conditions:
   -->
   <ParameterList name="Initial Conditions">
-
-<!--
+    <!--
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -233,7 +214,6 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Value" type="double" value="190892.5"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Right IC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right Half}"/>
       <ParameterList name="IC: Uniform Pressure">
@@ -241,14 +221,11 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Value" type="double" value="190892.5"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <!--
     Boundary Conditions
   -->
   <ParameterList name="Boundary Conditions">
-
     <ParameterList name="LeftBC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -257,7 +234,6 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Water Table Height" type="Array(double)" value="{20.0, 20.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="RightBC">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Right}"/>
       <ParameterList name="BC: Hydrostatic">
@@ -266,19 +242,14 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Water Table Height" type="Array(double)" value="{19.0, 19.0}"/>
       </ParameterList>
     </ParameterList>
-
   </ParameterList>
-
   <ParameterList name="Output">
-
     <ParameterList name="Time Macros">
       <ParameterList name="Steady State">
-	<Parameter name="Values" type="Array(double)" value="{1000.0}"/>
+        <Parameter name="Values" type="Array(double)" value="{1000.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Observation Data">
-
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="Pressure 1">
         <Parameter name="Region" type="string" value="LeftBoundary"/>
@@ -322,7 +293,7 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
         <Parameter name="Variable" type="string" value="Aqueous pressure"/>
         <Parameter name="Time Macros" type="Array(string)" value="{Steady State}"/>
       </ParameterList>
-<!--
+      <!--
       <ParameterList name="Darcy velocity / volumetric flux 3">
         <Parameter name="Region" type="string" value="MidpointCell"/>
         <Parameter name="Functional" type="string" value="Observation Data: Point"/>
@@ -331,14 +302,10 @@ Intrinsic Permeability: Uniform, or Intrinsic Permeability: Anisotropic Uniform"
       </ParameterList>
 -->
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="steady-flow"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Time Macros" type="Array(string)" value="{Steady State}"/>
     </ParameterList>
-
   </ParameterList>
-
 </ParameterList>
-

--- a/test_suites/verification/flow/saturated/transient/butler_pod_2d/amanzi_butler_pod_2d-s.xml
+++ b/test_suites/verification/flow/saturated/transient/butler_pod_2d/amanzi_butler_pod_2d-s.xml
@@ -1,7 +1,6 @@
 <ParameterList>
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc_hypre"/>
-
   <ParameterList name="General Description">
     <Parameter name="model_id" type="string" value="Theis"/>
     <Parameter name="comments" type="string" value="Confind aquifer transient drawdown (Theis 1935)"/>
@@ -13,9 +12,9 @@
   </ParameterList>
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{20200,20200}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{  600,  600}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{20200.0, 20200.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{600, 600}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -28,20 +27,20 @@
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.e09"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+9"/>
         <Parameter name="Initial Time Step" type="double" value="3.64"/>
-        <Parameter name="Maximum Time Step Size" type="double" value="3.15576e+08"/>
-	<Parameter name="Maximum Cycle Number" type="int" value="1000"/>
+        <Parameter name="Maximum Time Step Size" type="double" value="3.15576e+8"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="do_richard_init_to_steady" type="int" value="0"/> 
-          <Parameter name="gravity_dir" type="int" value="2"/> 
-          <Parameter name="z_location" type="double" value="0"/> 
-          <Parameter name="domain_thickness" type="double" value="1"/> 
+          <Parameter name="do_richard_init_to_steady" type="int" value="0"/>
+          <Parameter name="gravity_dir" type="int" value="2"/>
+          <Parameter name="z_location" type="double" value="0.0"/>
+          <Parameter name="domain_thickness" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -50,10 +49,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="1000"/>
+          <Parameter name="Density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -65,8 +64,8 @@
   <ParameterList name="Regions">
     <ParameterList name="cylinder">
       <ParameterList name="Region: Ellipse">
-        <Parameter name="Center" type="Array(double)" value="{10100,10100}"/>
-        <Parameter name="Radius" type="Array(double)" value="{100,100}"/>
+        <Parameter name="Center" type="Array(double)" value="{10100.0, 10100.0}"/>
+        <Parameter name="Radius" type="Array(double)" value="{100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="bg">
@@ -75,30 +74,26 @@
         <Parameter name="Region" type="string" value="cylinder"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is a small box around the well location, big enough that it registers on the grid -->
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{10672, 10066}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{10706, 10134}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{10672.0, 10066.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{10706.0, 10134.0}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is r=40, 60 deg from +ve x, center at cylinder axis -->
     <ParameterList name="Obs1">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{10120,10134.64}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{10120.0, 10134.64}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is r=360, 120 deg from +ve x, center at cylinder axis -->
     <ParameterList name="Obs2">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{9920, 10411.77}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{9920.0, 10411.77}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Soil_1">
       <Parameter name="Assigned Regions" type="Array(string)" value="{cylinder}"/>
@@ -106,7 +101,7 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-04"/>
+        <Parameter name="Value" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="1.187e-10"/>
@@ -118,10 +113,10 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-04"/>
+        <Parameter name="Value" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.187e-09"/>
+        <Parameter name="Value" type="double" value="1.187e-9"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -129,15 +124,15 @@
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Hydrostatic">
-        <Parameter name="Water Table Height" type="double" value="100"/>
+        <Parameter name="Water Table Height" type="double" value="100.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Far Field Head">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC,XHIBC,YLOBC,YHIBC}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, XHIBC, YLOBC, YHIBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
-        <Parameter name="Values" type="Array(double)" value="{100}"/>
+        <Parameter name="Values" type="Array(double)" value="{100.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -152,10 +147,11 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383, 32767,65535,131071,262143,524287,1.e6,1.e7,1.e8,1.e9}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 1.0, 3.0, 7.0, 15.0, 31.0, 63.0, 127.0, 255.0, 511.0, 1023.0, 2047.0, 4095.0, 8191.0, 16383.0, 32767.0, 65535.0, 131071.0, 262143.0, 524287.0, 1e+6, 1e+7, 1e+8, 1e+9}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Cycle Macros"/>
+    <ParameterList name="Cycle Macros">
+    </ParameterList>
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observations.out"/>
       <ParameterList name="observation-2:Water">

--- a/test_suites/verification/flow/saturated/transient/butler_pod_2d/amanzi_butler_pod_2d-sAMR.xml
+++ b/test_suites/verification/flow/saturated/transient/butler_pod_2d/amanzi_butler_pod_2d-sAMR.xml
@@ -1,7 +1,6 @@
 <ParameterList>
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc_slu"/>
-
   <ParameterList name="General Description">
     <Parameter name="model_id" type="string" value="Theis"/>
     <Parameter name="comments" type="string" value="Confind aquifer transient drawdown (Theis 1935)"/>
@@ -13,9 +12,9 @@
   </ParameterList>
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{0,0}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{20200,20200}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{  300,  300}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{20200.0, 20200.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{300, 300}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -28,54 +27,48 @@
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.e09"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1e+9"/>
         <Parameter name="Initial Time Step" type="double" value="3.64"/>
-        <Parameter name="Maximum Time Step Size" type="double" value="3.15576e+08"/>
-	<Parameter name="Maximum Cycle Number" type="int" value="1000"/>
+        <Parameter name="Maximum Time Step Size" type="double" value="3.15576e+8"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
           <Parameter name="gravity_dir" type="int" value="2"/>
-          <Parameter name="z_location" type="double" value="0"/>
-          <Parameter name="domain_thickness" type="double" value="1"/>
+          <Parameter name="z_location" type="double" value="0.0"/>
+          <Parameter name="domain_thickness" type="double" value="1.0"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{4}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{4, 4, 4}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{96, 32, 32}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{4, 2}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref, Disk ref, Head ref}"/>
-
-	  <ParameterList name="Well ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Well}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-
-	  <ParameterList name="Disk ref">
-	    <Parameter name="Regions" type="Array(string)" value="{cylinder}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-
-	  <ParameterList name="Head ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Hydraulic Head"/>
-	    <Parameter name="Adjacent Difference Greater" type="double" value=".05"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
-
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{4}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{4, 4, 4}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{96, 32, 32}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{4, 2}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref, Disk ref, Head ref}"/>
+          <ParameterList name="Well ref">
+            <Parameter name="Regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Disk ref">
+            <Parameter name="Regions" type="Array(string)" value="{cylinder}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Head ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Hydraulic Head"/>
+            <Parameter name="Adjacent Difference Greater" type="double" value="0.05"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -83,10 +76,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="1000"/>
+          <Parameter name="Density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -98,8 +91,8 @@
   <ParameterList name="Regions">
     <ParameterList name="cylinder">
       <ParameterList name="Region: Ellipse">
-        <Parameter name="Center" type="Array(double)" value="{10100,10100}"/>
-        <Parameter name="Radius" type="Array(double)" value="{100,100}"/>
+        <Parameter name="Center" type="Array(double)" value="{10100.0, 10100.0}"/>
+        <Parameter name="Radius" type="Array(double)" value="{100.0, 100.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="bg">
@@ -108,30 +101,26 @@
         <Parameter name="Region" type="string" value="cylinder"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is a small box around the well location, big enough that it registers on the grid -->
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{10696, 10096}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{10704, 10104}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{10696.0, 10096.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{10704.0, 10104.0}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is r=40, 60 deg from +ve x, center at cylinder axis -->
     <ParameterList name="Obs1">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{10120,10134.64}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{10120.0, 10134.64}"/>
       </ParameterList>
     </ParameterList>
-
     <!-- This is r=360, 120 deg from +ve x, center at cylinder axis -->
     <ParameterList name="Obs2">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{9920, 10411.77}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{9920.0, 10411.77}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Soil_1">
       <Parameter name="Assigned Regions" type="Array(string)" value="{cylinder}"/>
@@ -139,7 +128,7 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-04"/>
+        <Parameter name="Value" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="1.187e-10"/>
@@ -151,10 +140,10 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-04"/>
+        <Parameter name="Value" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.187e-09"/>
+        <Parameter name="Value" type="double" value="1.187e-9"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -162,15 +151,15 @@
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Hydrostatic">
-        <Parameter name="Water Table Height" type="double" value="100"/>
+        <Parameter name="Water Table Height" type="double" value="100.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Far Field Head">
-      <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC,XHIBC,YLOBC,YHIBC}"/>
+      <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, XHIBC, YLOBC, YHIBC}"/>
       <ParameterList name="BC: Uniform Hydraulic Head">
-        <Parameter name="Values" type="Array(double)" value="{100}"/>
+        <Parameter name="Values" type="Array(double)" value="{100.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -185,10 +174,11 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383, 32767,65535,131071,262143,524287,1.e6,1.e7,1.e8,1.e9}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 1.0, 3.0, 7.0, 15.0, 31.0, 63.0, 127.0, 255.0, 511.0, 1023.0, 2047.0, 4095.0, 8191.0, 16383.0, 32767.0, 65535.0, 131071.0, 262143.0, 524287.0, 1e+6, 1e+7, 1e+8, 1e+9}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Cycle Macros"/>
+    <ParameterList name="Cycle Macros">
+    </ParameterList>
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observations.out"/>
       <ParameterList name="observation-2:Water">

--- a/test_suites/verification/flow/saturated/transient/butler_strip_2d/amanzi_butler_strip_2d-s.xml
+++ b/test_suites/verification/flow/saturated/transient/butler_strip_2d/amanzi_butler_strip_2d-s.xml
@@ -1,7 +1,6 @@
 <ParameterList>
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc_hypre"/>
-
   <ParameterList name="General Description">
     <Parameter name="model_id" type="string" value="Butler"/>
     <Parameter name="comments" type="string" value="Confined aquifer transient drawdown (Butler and Liu, 1991)"/>
@@ -13,9 +12,9 @@
   </ParameterList>
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{-1200,-1200}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{ 1200, 1200}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{  600,  600}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-1200.0, -1200.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{1200.0, 1200.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{600, 600}"/>
     </ParameterList>
   </ParameterList>
   <ParameterList name="Domain">
@@ -28,20 +27,20 @@
     <Parameter name="Verbosity" type="string" value="High"/>
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
-        <Parameter name="Start" type="double" value="0"/>
-        <Parameter name="End" type="double" value="1.64e+07"/>
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1.64e+7"/>
         <Parameter name="Initial Time Step" type="double" value="3.64"/>
-        <Parameter name="Maximum Time Step Size" type="double" value="1.64e+07"/>
-	<Parameter name="Maximum Cycle Number" type="int" value="1000"/>
+        <Parameter name="Maximum Time Step Size" type="double" value="1.64e+7"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="do_richard_init_to_steady" type="int" value="0"/> 
-          <Parameter name="gravity_dir" type="int" value="2"/> 
-          <Parameter name="z_location" type="double" value="0"/> 
-          <Parameter name="domain_thickness" type="double" value="1"/> 
+          <Parameter name="do_richard_init_to_steady" type="int" value="0"/>
+          <Parameter name="gravity_dir" type="int" value="2"/>
+          <Parameter name="z_location" type="double" value="0.0"/>
+          <Parameter name="domain_thickness" type="double" value="1.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
@@ -50,10 +49,10 @@
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="1000"/>
+          <Parameter name="Density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -65,36 +64,36 @@
   <ParameterList name="Regions">
     <ParameterList name="Zone_1">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{-1200, -1200}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{-9, 1200}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-1200.0, -1200.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{-9.0, 1200.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Zone_2">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{-9,-1200}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{9, 1200}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-9.0, -1200.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{9.0, 1200.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Zone_3">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{9, -1200}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1200, 1200}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{9.0, -1200.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1200.0, 1200.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{-4,-4}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{4,4}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-4.0, -4.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{4.0, 4.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r24">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{24,0}}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{24.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r100">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{100,0}}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{100.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -105,10 +104,10 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="5.e-04"/>
+        <Parameter name="Value" type="double" value="0.0005"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.187e-08"/>
+        <Parameter name="Value" type="double" value="1.187e-8"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_2">
@@ -117,10 +116,10 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-04"/>
+        <Parameter name="Value" type="double" value="0.0002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="1.187e-09"/>
+        <Parameter name="Value" type="double" value="1.187e-9"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Soil_3">
@@ -129,7 +128,7 @@
         <Parameter name="Value" type="double" value="0.25"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="2.e-05"/>
+        <Parameter name="Value" type="double" value="0.00002"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
         <Parameter name="Value" type="double" value="1.187e-10"/>
@@ -140,9 +139,9 @@
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-        <Parameter name="Reference Value" type="double" value="1.07785e+06"/>
-        <Parameter name="Reference Point" type="Array(double)" value="{1200,1200}}"/>
-        <Parameter name="Gradient Value" type="Array(double)" value="{0,0}}"/>
+        <Parameter name="Reference Value" type="double" value="1.07785e+6"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{1200.0, 1200.0}"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -150,7 +149,7 @@
     <ParameterList name="Far Field Head">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, XHIBC, YLOBC, YHIBC}"/>
       <ParameterList name="BC: Uniform Pressure">
-        <Parameter name="Values" type="Array(double)" value="{1.07785e+06}"/>
+        <Parameter name="Values" type="Array(double)" value="{1.07785e+6}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
@@ -165,29 +164,30 @@
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32677,65535,13107,26214,52428,1e6,1e7,1e8,1e9}"/>
-	</ParameterList>
-      </ParameterList>
-      <ParameterList name="Cycle Macros"/>
-      <ParameterList name="Visualization Data">
-      </ParameterList>
-      <ParameterList name="Observation Data">
-	<Parameter name="Observation Output Filename" type="string" value="observations.out"/>
-	<ParameterList name="observation-2:Water">
-	  <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	  <Parameter name="Region" type="string" value="Obs_r24"/>
-	  <Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	  <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
-	</ParameterList>
-	<ParameterList name="observation-4:Water">
-	  <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	  <Parameter name="Region" type="string" value="Obs_r100"/>
-	  <Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	  <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
-	</ParameterList>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 1.0, 3.0, 7.0, 15.0, 31.0, 63.0, 127.0, 255.0, 511.0, 1023.0, 2047.0, 4095.0, 8191.0, 16383.0, 32677.0, 65535.0, 13107.0, 26214.0, 52428.0, 1e+6, 1e+7, 1e+8, 1e+9}"/>
       </ParameterList>
     </ParameterList>
-    <ParameterList name="Chemistry">
-      <Parameter name="Verbosity" type="Array(string)" value="{warning}"/>
+    <ParameterList name="Cycle Macros">
+    </ParameterList>
+    <ParameterList name="Visualization Data">
+    </ParameterList>
+    <ParameterList name="Observation Data">
+      <Parameter name="Observation Output Filename" type="string" value="observations.out"/>
+      <ParameterList name="observation-2:Water">
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Region" type="string" value="Obs_r24"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+      </ParameterList>
+      <ParameterList name="observation-4:Water">
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Region" type="string" value="Obs_r100"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+      </ParameterList>
     </ParameterList>
   </ParameterList>
+  <ParameterList name="Chemistry">
+    <Parameter name="Verbosity" type="Array(string)" value="{warning}"/>
+  </ParameterList>
+</ParameterList>

--- a/test_suites/verification/flow/saturated/transient/hantush_anisotropic_2d/amanzi_hantush_anisotropic_2d.xml
+++ b/test_suites/verification/flow/saturated/transient/hantush_anisotropic_2d/amanzi_hantush_anisotropic_2d.xml
@@ -1,6 +1,5 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.3"/>
-
   <!--
     Transient, Two-Dimensional Flow to a Well in an Anisotropic Confined Aquifer (Hantush and Thomas, 1966)
   -->
@@ -8,13 +7,11 @@
     <Parameter name="Model ID" type="string" value="Anisotropic"/>
     <Parameter name="Author" type="string" value="Alec Thomas"/>
   </ParameterList>
-
   <!-- EXECUTION CONTROL -->
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient">
         <Parameter name="Start" type="double" value="0.0"/>
@@ -22,9 +19,7 @@
         <Parameter name="Initial Time Step" type="double" value="3.64"/>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Unstructured Algorithm">
         <ParameterList name="Linear Solver">
@@ -35,18 +30,15 @@
         <ParameterList name="Transient Implicit Time Integration">
           <Parameter name="Transient Time Step Increase Factor" type="double" value="1.1"/>
         </ParameterList>
-	<ParameterList name="Initialization">
-	  <Parameter name="time integration method" type="string" value="Darcy Solver"/>
-	</ParameterList>
+        <ParameterList name="Initialization">
+          <Parameter name="time integration method" type="string" value="Darcy Solver"/>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-  
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="3"/>
   </ParameterList>
-
-
   <!-- MESH:  three-dimensional box [-100, 100 ] x [-100, 100] x [0,XX] -->
   <ParameterList name="Mesh">
     <ParameterList name="Unstructured">
@@ -59,22 +51,20 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- REGIONS -->
   <ParameterList name="Regions">
     <ParameterList name="Entire Domain">
       <ParameterList name="Region: Box">
-        <Parameter name="Low Coordinate" type="Array(double)" value="{-1.2e3, -1.2e3, 0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{1.2e3,  1.2e3, 5.0}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-1.2e+3, -1.2e+3, 0.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{1.2e+3, 1.2e+3, 5.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
         <Parameter name="Low Coordinate" type="Array(double)" value="{-0.9, -0.9, 0.0}"/>
-        <Parameter name="High Coordinate" type="Array(double)" value="{0.9,  0.9, 5.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.9, 0.9, 5.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Obs_x">
       <ParameterList name="Region: Point">
         <Parameter name="Coordinate" type="Array(double)" value="{55.0, 0.0, 2.0}"/>
@@ -90,40 +80,38 @@
         <Parameter name="Coordinate" type="Array(double)" value="{55.0, 55.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Left">
       <ParameterList name="Region: Plane">
-        <Parameter name="Location" type="Array(double)" value="{-1.2e3, -1.2e3, 0.0}"/>
+        <Parameter name="Location" type="Array(double)" value="{-1.2e+3, -1.2e+3, 0.0}"/>
         <Parameter name="Direction" type="Array(double)" value="{-1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Front">
       <ParameterList name="Region: Plane">
-        <Parameter name="Location" type="Array(double)" value="{-1.2e3, -1.2e3, 0.0}"/>
+        <Parameter name="Location" type="Array(double)" value="{-1.2e+3, -1.2e+3, 0.0}"/>
         <Parameter name="Direction" type="Array(double)" value="{0.0, -1.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Bottom">
       <ParameterList name="Region: Plane">
-        <Parameter name="Location" type="Array(double)" value="{-1.2e3, -1.2e3, 0.0}"/>
+        <Parameter name="Location" type="Array(double)" value="{-1.2e+3, -1.2e+3, 0.0}"/>
         <Parameter name="Direction" type="Array(double)" value="{0.0, 0.0, -1.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Right">
       <ParameterList name="Region: Plane">
-        <Parameter name="Location" type="Array(double)" value="{1.2e3, 1.2e3, 5.0}"/>
+        <Parameter name="Location" type="Array(double)" value="{1.2e+3, 1.2e+3, 5.0}"/>
         <Parameter name="Direction" type="Array(double)" value="{1.0, 0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Back">
       <ParameterList name="Region: Plane">
-        <Parameter name="Location" type="Array(double)" value="{1.2e3, 1.2e3, 5.0}"/>
+        <Parameter name="Location" type="Array(double)" value="{1.2e+3, 1.2e+3, 5.0}"/>
         <Parameter name="Direction" type="Array(double)" value="{0.0, 1.0, 0.0}"/>
       </ParameterList>
-    </ParameterList>  
+    </ParameterList>
   </ParameterList>
-
-  <!-- MATERIALS --> 
+  <!-- MATERIALS -->
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
@@ -131,25 +119,24 @@
         <Parameter name="Value" type="double" value="0.30"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Anisotropic Uniform">
-        <Parameter name="x" type="double" value="2.3543E-11"/>
-        <Parameter name="y" type="double" value="2.3543E-12"/>
-        <Parameter name="z" type="double" value="2.3543E-12"/>
+        <Parameter name="x" type="double" value="2.3543e-11"/>
+        <Parameter name="y" type="double" value="2.3543e-12"/>
+        <Parameter name="z" type="double" value="2.3543e-12"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-        <Parameter name="Value" type="double" value="7.5E-5"/>
+        <Parameter name="Value" type="double" value="0.000075"/>
       </ParameterList>
       <ParameterList name="Specific Yield: Uniform">
         <Parameter name="Value" type="double" value="0.0"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- PHASES -->
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.20"/>
@@ -157,12 +144,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- INITIAL CONDITONS -->
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Entire Domain}"/>
-      
       <!-- Confined Aquifer with h=200m -->
       <ParameterList name="IC: Linear Pressure">
         <Parameter name="Reference Point" type="Array(double)" value="{0.0, 0.0, 5.0}"/>
@@ -171,45 +156,40 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
- 
   <!-- Source Terms: -->
   <ParameterList name="Sources">
     <ParameterList name="Pumping Well">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Well}"/>
       <ParameterList name="Source: Volume Weighted">
-        <Parameter name="Times" type="Array(double)" value="{0.0,1.64e5}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.64e+5}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="Values" type="Array(double)" value="{-2.0, -2.0}"/>
-      </ParameterList>   
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Boundary Conditions -->
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Far Field Head">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Left, Right, Front, Back}"/>
       <ParameterList name="BC: Hydrostatic">
-        <Parameter name="Times" type="Array(double)" value="{0.0, 1.64e5}"/>
+        <Parameter name="Times" type="Array(double)" value="{0.0, 1.64e+5}"/>
         <Parameter name="Time Functions" type="Array(string)" value="{Constant}"/>
         <Parameter name="Water Table Height" type="Array(double)" value="{5.0, 5.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <!-- Output -->
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{0.0,172.8,345.6,518.4,777.6,1209.6,1728.0,2419.2,3196.8,4320.0,5788.8,7689.6,1.0022e+4,1.3306e+4,1.7539e+4,2.2896e+4,3.0067e+4,3.9053e+4,5.0026e+4,6.6010e+4,8.64e+4}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 172.8, 345.6, 518.4, 777.6, 1209.6, 1728.0, 2419.2, 3196.8, 4320.0, 5788.8, 7689.6, 10022.0, 13306.0, 17539.0, 22896.0, 30067.0, 39053.0, 50026.0, 66010.0, 8.64e+4}"/>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every 10">
-        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0,10,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 10, -1}"/>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="Pressure 01">
@@ -231,7 +211,6 @@
         <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
     </ParameterList>
-    
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plot"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
@@ -239,4 +218,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/test_suites/verification/flow/saturated/transient/theis_isotropic_1d/amanzi_theis_isotropic_1d-s.xml
+++ b/test_suites/verification/flow/saturated/transient/theis_isotropic_1d/amanzi_theis_isotropic_1d-s.xml
@@ -1,7 +1,6 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.3"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc_hypre"/>
-
   <!--
      Confined Aquifer Transient Drawdown (Theis 1935)
   -->
@@ -9,73 +8,63 @@
     <Parameter name="Model ID" type="string" value="Theis"/>
     <Parameter name="Author" type="string" value="Marc Day, Dylan Harp"/>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
-        <ParameterList name="Transient">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="1.64e5"/>
-          <Parameter name="Initial Time Step" type="double" value="3.64"/>
-          <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
-        </ParameterList>
+      <ParameterList name="Transient">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1.64e+5"/>
+        <Parameter name="Initial Time Step" type="double" value="3.64"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
+      </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Extreme"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="do_richard_init_to_steady" type="int" value="0"/> 
-          <Parameter name="gravity_dir" type="int" value="2"/> 
-          <Parameter name="z_location" type="double" value="5"/> 
-          <Parameter name="domain_thickness" type="double" value="10"/> 
+          <Parameter name="do_richard_init_to_steady" type="int" value="0"/>
+          <Parameter name="gravity_dir" type="int" value="2"/>
+          <Parameter name="z_location" type="double" value="5.0"/>
+          <Parameter name="domain_thickness" type="double" value="10.0"/>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-    
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{-1200,-1200}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{ 1200, 1200}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{  600,  600}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-1200.0, -1200.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{1200.0, 1200.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{600, 600}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
-	<Parameter name="Low Coordinate" type="Array(double)" value="{-2,-2}"/>
-	<Parameter name="High Coordinate" type="Array(double)" value="{2,2}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-2.0, -2.0}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{2.0, 2.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Obs_r10">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-33,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-33.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r30">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-55,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-55.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r50">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-161,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-161.0, 0.0}"/>
       </ParameterList>
-    </ParameterList>    
+    </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -83,22 +72,21 @@
         <Parameter name="Value" type="double" value="0.20"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="2.350E-11"/>
+        <Parameter name="Value" type="double" value="2.350e-11"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-	<Parameter name="Value" type="double" value="7.5E-5"/>
+        <Parameter name="Value" type="double" value="0.000075"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="1000"/>
+          <Parameter name="Density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -107,18 +95,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-	<Parameter name="Reference Point" type="Array(double)" value="{1200,1200}"/>
-	<Parameter name="Reference Value" type="double" value="248430"/>
-	<Parameter name="Gradient Value" type="Array(double)" value="{0,0}"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{1200.0, 1200.0}"/>
+        <Parameter name="Reference Value" type="double" value="248430.0"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Far Field Head">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, YLOBC, XHIBC, YHIBC}"/>
@@ -127,51 +113,46 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Sources">
     <ParameterList name="Pumping Well">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Well}"/>
       <ParameterList name="Source: Volume Weighted">
-        <Parameter name="Values" type="Array(double)" value="{-4}"/>
+        <Parameter name="Values" type="Array(double)" value="{-4.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-	<Parameter name="Values" type="Array(double)" value="{0.0,0.0864,0.4,400,500,600,5000,8000,10000,28000,35000,43000,81000,90000,100000,164000}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 0.0864, 0.4, 400.0, 500.0, 600.0, 5000.0, 8000.0, 10000.0, 28000.0, 35000.0, 43000.0, 81000.0, 90000.0, 100000.0, 164000.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every Cycle">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="Pressure 01">
-	<Parameter name="Region" type="string" value="Obs_r10"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r10"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
       <ParameterList name="Pressure 02">
-	<Parameter name="Region" type="string" value="Obs_r30"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r30"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
       <ParameterList name="Pressure 03">
-	<Parameter name="Region" type="string" value="Obs_r50"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r50"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>

--- a/test_suites/verification/flow/saturated/transient/theis_isotropic_1d/amanzi_theis_isotropic_1d-sAMR.xml
+++ b/test_suites/verification/flow/saturated/transient/theis_isotropic_1d/amanzi_theis_isotropic_1d-sAMR.xml
@@ -1,7 +1,6 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.3"/>
   <Parameter name="Petsc Options File" type="string" value=".petsc_slu"/>
-
   <!--
      Confined Aquifer Transient Drawdown (Theis 1935)
   -->
@@ -9,101 +8,85 @@
     <Parameter name="Model ID" type="string" value="Theis"/>
     <Parameter name="Author" type="string" value="Marc Day, Dylan Harp"/>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="Off"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
-        <ParameterList name="Transient">
-          <Parameter name="Start" type="double" value="0.0"/>
-          <Parameter name="End" type="double" value="1.64e5"/>
-          <Parameter name="Initial Time Step" type="double" value="3.64"/>
-          <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
-        </ParameterList>
+      <ParameterList name="Transient">
+        <Parameter name="Start" type="double" value="0.0"/>
+        <Parameter name="End" type="double" value="1.64e+5"/>
+        <Parameter name="Initial Time Step" type="double" value="3.64"/>
+        <Parameter name="Maximum Cycle Number" type="int" value="1000"/>
+      </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="Extreme"/>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-          <Parameter name="gravity_dir" type="int" value="2"/> 
-          <Parameter name="z_location" type="double" value="5"/> 
-          <Parameter name="domain_thickness" type="double" value="10"/> 
+          <Parameter name="gravity_dir" type="int" value="2"/>
+          <Parameter name="z_location" type="double" value="5.0"/>
+          <Parameter name="domain_thickness" type="double" value="10.0"/>
         </ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{4}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{4, 4, 4}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{96, 96, 96}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{4, 2}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref, Head ref}"/>
-
-	  <ParameterList name="Well ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Well}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="2"/>
-	  </ParameterList>
-
-	  <ParameterList name="Head ref">
-	    <Parameter name="Regions" type="Array(string)" value="{All}"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	    <Parameter name="Field Name" type="string" value="Hydraulic Head"/>
-	    <Parameter name="Adjacent Difference Greater" type="double" value=".05"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-	</ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{4}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{4, 4, 4}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{96, 96, 96}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{4, 2}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref, Head ref}"/>
+          <ParameterList name="Well ref">
+            <Parameter name="Regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="2"/>
+          </ParameterList>
+          <ParameterList name="Head ref">
+            <Parameter name="Regions" type="Array(string)" value="{All}"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+            <Parameter name="Field Name" type="string" value="Hydraulic Head"/>
+            <Parameter name="Adjacent Difference Greater" type="double" value="0.05"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
-
-
     </ParameterList>
-    
   </ParameterList>
-
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{-1200,-1200}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{ 1200, 1200}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{  300,  300}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-1200.0, -1200.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{1200.0, 1200.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{300, 300}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Well">
       <ParameterList name="Region: Box">
-	<Parameter name="Low Coordinate" type="Array(double)" value="{-.5,-.5}"/>
-	<Parameter name="High Coordinate" type="Array(double)" value="{.5,.5}"/>
+        <Parameter name="Low Coordinate" type="Array(double)" value="{-0.5, -0.5}"/>
+        <Parameter name="High Coordinate" type="Array(double)" value="{0.5, 0.5}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Obs_r10">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-33,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-33.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r30">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-55,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-55.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Obs_r50">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-161,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-161.0, 0.0}"/>
       </ParameterList>
-    </ParameterList>    
+    </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Soil">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -111,22 +94,21 @@
         <Parameter name="Value" type="double" value="0.20"/>
       </ParameterList>
       <ParameterList name="Intrinsic Permeability: Uniform">
-        <Parameter name="Value" type="double" value="2.350E-11"/>
+        <Parameter name="Value" type="double" value="2.350e-11"/>
       </ParameterList>
       <ParameterList name="Specific Storage: Uniform">
-	<Parameter name="Value" type="double" value="7.5E-5"/>
+        <Parameter name="Value" type="double" value="0.000075"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
-          <Parameter name="Density" type="double" value="1000"/>
+          <Parameter name="Density" type="double" value="1000.0"/>
         </ParameterList>
       </ParameterList>
       <ParameterList name="Phase Components">
@@ -135,18 +117,16 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="Initial Condition">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Linear Pressure">
-	<Parameter name="Reference Point" type="Array(double)" value="{1200,1200}"/>
-	<Parameter name="Reference Value" type="double" value="248430"/>
-	<Parameter name="Gradient Value" type="Array(double)" value="{0,0}"/>
+        <Parameter name="Reference Point" type="Array(double)" value="{1200.0, 1200.0}"/>
+        <Parameter name="Reference Value" type="double" value="248430.0"/>
+        <Parameter name="Gradient Value" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Far Field Head">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC, YLOBC, XHIBC, YHIBC}"/>
@@ -155,53 +135,48 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Sources">
     <ParameterList name="Pumping Well">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Well}"/>
       <ParameterList name="Source: Volume Weighted">
-        <Parameter name="Values" type="Array(double)" value="{-4}"/>
+        <Parameter name="Values" type="Array(double)" value="{-4.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-	<Parameter name="Values" type="Array(double)" value="{0.0,0.0864,0.4,400,500,600,5000,8000,10000,28000,35000,43000,81000,90000,100000,164000}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0, 0.0864, 0.4, 400.0, 500.0, 600.0, 5000.0, 8000.0, 10000.0, 28000.0, 35000.0, 43000.0, 81000.0, 90000.0, 100000.0, 164000.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Cycle Macros">
       <ParameterList name="Every Cycle">
-	<Parameter name="Start_Period_Stop" type="Array(int)" value="{0,1,-1}"/>
+        <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every Cycle}"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="observation.out"/>
       <ParameterList name="Pressure 01">
-	<Parameter name="Region" type="string" value="Obs_r10"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r10"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
       <ParameterList name="Pressure 02">
-	<Parameter name="Region" type="string" value="Obs_r30"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r30"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
       <ParameterList name="Pressure 03">
-	<Parameter name="Region" type="string" value="Obs_r50"/>
-	<Parameter name="Functional" type="string" value="Observation Data: Point"/>
-	<Parameter name="Variable" type="string" value="Aqueous Pressure"/>
-	<Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
+        <Parameter name="Region" type="string" value="Obs_r50"/>
+        <Parameter name="Functional" type="string" value="Observation Data: Point"/>
+        <Parameter name="Variable" type="string" value="Aqueous Pressure"/>
+        <Parameter name="Time Macros" type="Array(string)" value="{Observation Times}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>

--- a/test_suites/verification/transport/saturated/steady-state/dispersion_45_point_2d/amanzi_dispersion_45_point_2d-s.xml
+++ b/test_suites/verification/transport/saturated/steady-state/dispersion_45_point_2d/amanzi_dispersion_45_point_2d-s.xml
@@ -4,80 +4,70 @@
     <Parameter name="File Name" type="string" value=".ppfile"/>
     <Parameter name="Format" type="string" value="native"/>
   </ParameterList>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient with Static Flow">
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="End" type="double" value="1.2096e+8"/>
-        <Parameter name="Maximum Time Step Grow" type="double" value="1"/>
+        <Parameter name="Maximum Time Step Grow" type="double" value="1.0"/>
         <Parameter name="Maximum Cycle Number" type="int" value="100000"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-	  <Parameter name="cfl" type="double" value="1.0"/>
-	  <Parameter name="be_cn_theta_trac" type="double" value="1.0"/>
-	  <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
-	</ParameterList>
-	<ParameterList name="Iterative Linear Solver Control">
-	  <ParameterList name="Multigrid Algorithm">
-	    <ParameterList name="Expert Settings">
-	      <Parameter name="usecg" type="int" value="0"/>
-	      <Parameter name="v" type="int" value="0"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{2000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{16, 16, 16}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{128, 128, 128}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{6, 4}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref}"/>
-
-	  <ParameterList name="Well ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Well}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="3"/>
-	  </ParameterList>
-
-	</ParameterList>
+          <Parameter name="cfl" type="double" value="1.0"/>
+          <Parameter name="be_cn_theta_trac" type="double" value="1.0"/>
+          <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
+        </ParameterList>
+        <ParameterList name="Iterative Linear Solver Control">
+          <ParameterList name="Multigrid Algorithm">
+            <ParameterList name="Expert Settings">
+              <Parameter name="usecg" type="int" value="0"/>
+              <Parameter name="v" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{2000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{16, 16, 16}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{128, 128, 128}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{6, 4}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref}"/>
+          <ParameterList name="Well ref">
+            <Parameter name="Regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="3"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
     <Parameter name="Verbosity" type="string" value="High"/>
   </ParameterList>
-      
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{-270,-270}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{ 930, 930}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{ 128, 128}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-270.0, -270.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{930.0, 930.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{128, 128}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Well">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Upstrm210">
       <ParameterList name="Region: Point">
         <Parameter name="Coordinate" type="Array(double)" value="{-210.0, -210.0}"/>
@@ -235,41 +225,40 @@
     </ParameterList>
     <ParameterList name="Crossb060">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{240.0,60.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{240.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb090">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{210.0,90.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{210.0, 90.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb120">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{180.0,120.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{180.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb150">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{150.0,150.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{150.0, 150.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb180">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{120.0,180.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{120.0, 180.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb210">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{90.0,210.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{90.0, 210.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb240">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{60.0,240.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{60.0, 240.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Aquifers">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -286,15 +275,15 @@
       <ParameterList name="Tortuosity: Uniform">
         <Parameter name="Value" type="double" value="0.0"/>
       </ParameterList>
-      <ParameterList name="Capillary Pressure: None"/>
+      <ParameterList name="Capillary Pressure: None">
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.2"/>
@@ -307,37 +296,35 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Left">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.8634e-06}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{0.0000018634}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
         </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Bottom">
       <Parameter name="Assigned Regions" type="Array(string)" value="{YLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.8634e-06}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{0.0000018634}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -345,12 +332,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Uniform Velocity">
-        <Parameter name="Velocity Vector" type="Array(double)" value="{1.3176e-06,1.3176e-06}"/>
+        <Parameter name="Velocity Vector" type="Array(double)" value="{0.0000013176, 0.0000013176}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
@@ -365,19 +351,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Sources">
     <ParameterList name="Pumping Well">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Well}"/>
       <ParameterList name="Source: Volume Weighted">
-        <Parameter name="Values" type="Array(double)" value="{0}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0}"/>
       </ParameterList>
       <ParameterList name="Solute SOURCE">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="Source: Flow Weighted Concentration">
-                <Parameter name="Values" type="Array(double)" value="{8.1483e-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{8.1483e-8}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -385,11 +370,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{1.2096E+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{1.2096e+8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -397,16 +381,13 @@
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 1}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
       <Parameter name="File Name Base" type="string" value="run_data/chk"/>
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <ParameterList name="Point 00">
         <Parameter name="Region" type="string" value="Dnstrm000"/>

--- a/test_suites/verification/transport/saturated/steady-state/dispersion_aligned_point_2d/amanzi_dispersion_aligned_point_2d-s.xml
+++ b/test_suites/verification/transport/saturated/steady-state/dispersion_aligned_point_2d/amanzi_dispersion_aligned_point_2d-s.xml
@@ -1,269 +1,256 @@
 <ParameterList name="Main">
   <Parameter name="Amanzi Input Format Version" type="string" value="1.2.2"/>
-
   <ParameterList name="Execution Control">
     <Parameter name="Flow Model" type="string" value="Single Phase"/>
     <Parameter name="Transport Model" type="string" value="On"/>
     <Parameter name="Chemistry Model" type="string" value="Off"/>
-
     <ParameterList name="Time Integration Mode">
       <ParameterList name="Transient with Static Flow">
         <Parameter name="Start" type="double" value="0.0"/>
         <Parameter name="End" type="double" value="1.2096e+8"/>
         <Parameter name="Maximum Cycle Number" type="int" value="50000"/>
-        <Parameter name="Maximum Time Step Grow" type="double" value="1"/>
+        <Parameter name="Maximum Time Step Grow" type="double" value="1.0"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Numerical Control Parameters">
       <ParameterList name="Structured Algorithm">
         <ParameterList name="Expert Settings">
-	  <Parameter name="cfl" type="double" value="1"/>
-	  <Parameter name="visc_tol" type="double" value="1.e-10"/>
-	  <Parameter name="be_cn_theta_trac" type="double" value="1.0"/>
-	  <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
-	</ParameterList>
-	<ParameterList name="Iterative Linear Solver Control">
-	  <ParameterList name="Multigrid Algorithm">
-	    <ParameterList name="Expert Settings">
-	      <Parameter name="usecg" type="int" value="0"/>
-	      <Parameter name="v" type="int" value="0"/>
-	    </ParameterList>
-	  </ParameterList>
-	</ParameterList>
-
-	<ParameterList name="Adaptive Mesh Refinement Control">
-	  <Parameter name="Number Of AMR Levels" type="int" value="3"/>
-	  <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
-	  <Parameter name="Regrid Interval" type="Array(int)" value="{2000}"/>
-	  <Parameter name="Blocking Factor" type="Array(int)" value="{16, 16, 16}"/>
-	  <Parameter name="Maximum Grid Size" type="Array(int)" value="{128, 128, 128}"/>
-	  <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{6, 4}"/>
-	  <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref}"/>
-
-	  <ParameterList name="Well ref">
-	    <Parameter name="Regions" type="Array(string)" value="{Well}"/>
-	    <Parameter name="Inside Region" type="bool" value="TRUE"/>
-	    <Parameter name="Maximum Refinement Level" type="int" value="4"/>
-	  </ParameterList>
-
-	  <ParameterList name="Expert Settings">
-	    <Parameter name="v" type="int" value="1"/>
-	  </ParameterList>
-
-	</ParameterList>
+          <Parameter name="cfl" type="double" value="1.0"/>
+          <Parameter name="visc_tol" type="double" value="1e-10"/>
+          <Parameter name="be_cn_theta_trac" type="double" value="1.0"/>
+          <Parameter name="max_n_subcycle_transport" type="int" value="1"/>
+        </ParameterList>
+        <ParameterList name="Iterative Linear Solver Control">
+          <ParameterList name="Multigrid Algorithm">
+            <ParameterList name="Expert Settings">
+              <Parameter name="usecg" type="int" value="0"/>
+              <Parameter name="v" type="int" value="0"/>
+            </ParameterList>
+          </ParameterList>
+        </ParameterList>
+        <ParameterList name="Adaptive Mesh Refinement Control">
+          <Parameter name="Number Of AMR Levels" type="int" value="3"/>
+          <Parameter name="Refinement Ratio" type="Array(int)" value="{4, 4}"/>
+          <Parameter name="Regrid Interval" type="Array(int)" value="{2000}"/>
+          <Parameter name="Blocking Factor" type="Array(int)" value="{16, 16, 16}"/>
+          <Parameter name="Maximum Grid Size" type="Array(int)" value="{128, 128, 128}"/>
+          <Parameter name="Number Error Buffer Cells" type="Array(int)" value="{6, 4}"/>
+          <Parameter name="Refinement Indicators" type="Array(string)" value="{Well ref}"/>
+          <ParameterList name="Well ref">
+            <Parameter name="Regions" type="Array(string)" value="{Well}"/>
+            <Parameter name="Inside Region" type="bool" value="true"/>
+            <Parameter name="Maximum Refinement Level" type="int" value="4"/>
+          </ParameterList>
+          <ParameterList name="Expert Settings">
+            <Parameter name="v" type="int" value="1"/>
+          </ParameterList>
+        </ParameterList>
       </ParameterList>
     </ParameterList>
-
     <Parameter name="Verbosity" type="string" value="High"/>
   </ParameterList>
-      
   <ParameterList name="Domain">
     <Parameter name="Spatial Dimension" type="int" value="2"/>
   </ParameterList>
-
   <ParameterList name="Mesh">
     <ParameterList name="Structured">
-      <Parameter name="Domain Low Coordinate"  type="Array(double)" value="{-270,-300}"/>
-      <Parameter name="Domain High Coordinate" type="Array(double)" value="{ 930, 300}"/>
-      <Parameter name="Number of Cells"    type="Array(int)"    value="{ 128,  64}"/>
+      <Parameter name="Domain Low Coordinate" type="Array(double)" value="{-270.0, -300.0}"/>
+      <Parameter name="Domain High Coordinate" type="Array(double)" value="{930.0, 300.0}"/>
+      <Parameter name="Number of Cells" type="Array(int)" value="{128, 64}"/>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Regions">
     <ParameterList name="Well">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0,0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Upstrm210">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-210.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-210.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Upstrm150">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-150.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-150.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Upstrm090">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-90.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-90.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Upstrm030">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{-30.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{-30.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm030">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{30.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{30.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Origin">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm090">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{90.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{90.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm150">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{150.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{150.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm210">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{210.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{210.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm270">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{270.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{270.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm330">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{330.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{330.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm390">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{390.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{390.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm450">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{450.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{450.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm510">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{510.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{510.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm570">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{570.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{570.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm630">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{630.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{630.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm690">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{690.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{690.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm750">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{750.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{750.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm810">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{810.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{810.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm870">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{870.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{870.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Dnstrm930">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{930.0,0.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{930.0, 0.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0030">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,30.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 30.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0060">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,60.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0090">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,90.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 90.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0120">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,120.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0150">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,150.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 150.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0180">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,180.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 180.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0210">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,210.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 210.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cross0240">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{0.0,240.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{0.0, 240.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb030">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,30.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 30.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb060">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,60.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 60.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb090">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,90.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 90.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb120">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,120.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 120.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb150">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,150.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 150.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb180">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,180.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 180.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb210">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,210.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 210.0}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Crossb240">
       <ParameterList name="Region: Point">
-        <Parameter name="Coordinate" type="Array(double)" value="{424.0,240.0}"/>
+        <Parameter name="Coordinate" type="Array(double)" value="{424.0, 240.0}"/>
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Material Properties">
     <ParameterList name="Aquifers">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
@@ -280,15 +267,15 @@
       <ParameterList name="Tortuosity: Uniform">
         <Parameter name="Value" type="double" value="0.0"/>
       </ParameterList>
-      <ParameterList name="Capillary Pressure: None"/>
+      <ParameterList name="Capillary Pressure: None">
+      </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Phase Definitions">
     <ParameterList name="Aqueous">
       <ParameterList name="Phase Properties">
         <ParameterList name="Viscosity: Uniform">
-          <Parameter name="Viscosity" type="double" value="1.002e-3"/>
+          <Parameter name="Viscosity" type="double" value="0.001002"/>
         </ParameterList>
         <ParameterList name="Density: Uniform">
           <Parameter name="Density" type="double" value="998.2"/>
@@ -301,19 +288,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Boundary Conditions">
     <ParameterList name="Left">
       <Parameter name="Assigned Regions" type="Array(string)" value="{XLOBC}"/>
       <ParameterList name="BC: Flux">
-        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{1.8634e-06}"/>
+        <Parameter name="Inward Volumetric Flux" type="Array(double)" value="{0.0000018634}"/>
       </ParameterList>
       <ParameterList name="Solute BC">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="BC: Uniform Concentration">
-                <Parameter name="Values" type="Array(double)" value="{0}"/>
+                <Parameter name="Values" type="Array(double)" value="{0.0}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -321,12 +307,11 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Initial Conditions">
     <ParameterList name="All">
       <Parameter name="Assigned Regions" type="Array(string)" value="{All}"/>
       <ParameterList name="IC: Uniform Velocity">
-        <Parameter name="Velocity Vector" type="Array(double)" value="{1.8634e-06,0.0}"/>
+        <Parameter name="Velocity Vector" type="Array(double)" value="{0.0000018634, 0.0}"/>
       </ParameterList>
       <ParameterList name="Solute IC">
         <ParameterList name="Aqueous">
@@ -341,19 +326,18 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Sources">
     <ParameterList name="Pumping Well">
       <Parameter name="Assigned Regions" type="Array(string)" value="{Well}"/>
       <ParameterList name="Source: Volume Weighted">
-        <Parameter name="Values" type="Array(double)" value="{0}"/>
+        <Parameter name="Values" type="Array(double)" value="{0.0}"/>
       </ParameterList>
       <ParameterList name="Solute SOURCE">
         <ParameterList name="Aqueous">
           <ParameterList name="Water">
             <ParameterList name="Tc-99">
               <ParameterList name="Source: Flow Weighted Concentration">
-                <Parameter name="Values" type="Array(double)" value="{8.1483e-08}"/>
+                <Parameter name="Values" type="Array(double)" value="{8.1483e-8}"/>
               </ParameterList>
             </ParameterList>
           </ParameterList>
@@ -361,11 +345,10 @@
       </ParameterList>
     </ParameterList>
   </ParameterList>
-
   <ParameterList name="Output">
     <ParameterList name="Time Macros">
       <ParameterList name="Observation Times">
-        <Parameter name="Values" type="Array(double)" value="{1.2096E+08}"/>
+        <Parameter name="Values" type="Array(double)" value="{1.2096e+8}"/>
       </ParameterList>
     </ParameterList>
     <ParameterList name="Cycle Macros">
@@ -373,16 +356,13 @@
         <Parameter name="Start_Period_Stop" type="Array(int)" value="{0, 1, -1}"/>
       </ParameterList>
     </ParameterList>
-
     <ParameterList name="Visualization Data">
       <Parameter name="File Name Base" type="string" value="run_data/plt"/>
       <Parameter name="File Name Digits" type="int" value="5"/>
       <Parameter name="Cycle Macros" type="Array(string)" value="{Every 1}"/>
     </ParameterList>
-
     <ParameterList name="Checkpoint Data">
     </ParameterList>
-
     <ParameterList name="Observation Data">
       <Parameter name="Observation Output Filename" type="string" value="obs5_2_1_r5.out"/>
       <ParameterList name="Point 00">
@@ -610,4 +590,3 @@
     </ParameterList>
   </ParameterList>
 </ParameterList>
-

--- a/tools/amanzi_xml/amanzi_xml/common/parameter.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter.py
@@ -1,74 +1,121 @@
 from . import base
+from decimal import Decimal
 import amanzi_xml.utils.io as io
 
 _valid_parameter_types = ['double', 'int', 'string', 'bool']
-def _valid_parameter_from_string(ptype, value):
-    # ensure types
-    retval = None
+def _validValueFromString(ptype, value):
+    """Given a string, return a ptype-typed value."""
+    assert isinstance(value, str)
+    value = value.strip()
 
-    if ptype == "double":
+    if ptype == 'double':
+        if '.' not in value and 'e' not in value.lower():
+            value = value + '.0'
+
         try:
-            retval = float(value)
+            retval = Decimal(value)
         except ValueError:
-            raise RuntimeError("Parameter of type double with invalid value \"%s\""%str(value))
+            raise ValueError("Parameter of type double with invalid value \"%s\""%str(value))
 
-    elif ptype == "int":
+    elif ptype == 'int':
         try:
             retval = int(value)
         except ValueError:
-            raise RuntimeError("Parameter of type int with invalid value \"%s\""%str(value))
+            raise ValueError("Parameter of type int with invalid value \"%s\""%str(value))
 
-    elif ptype == "bool":
-        if value is True:
-            retval = value
-        elif value is False:
-            retval = value
-        elif value == "true":
+    elif ptype == 'bool':
+        if value.lower() == 'true':
             retval = True
-        elif value == "True":
-            retval = True
-        elif value == "TRUE":
-            retval = True
-        elif value == "false":
-            retval = False
-        elif value == "False":
-            retval = False
-        elif value == "FALSE":
+        elif value.lower() == 'false':
             retval = False
         else:
-            raise RuntimeError("Parameter of type bool with invalid value \"%s\""%str(value))
+            raise ValueError("Parameter of type bool with invalid value \"%s\""%str(value))
 
-    elif ptype == "string":
-        try:
-            assert type(value) is str
-        except AssertionError:
-            raise RuntimeError("Parameter of type string with invalid value \"%s\""%str(value))
-        else:
-            retval = str(value)
+    elif ptype == 'string':
+        retval = value
+
+    else:
+        raise ValueError(f"Invalid ptype {ptype}")
+
     return retval
 
 
-def _valid_parameter_from_type(ptype, value):
-    # null string is valid
-    if type(value) == str and len(value) == 0:
-        return ''
+def _validValueFromType(ptype, value):
+    """Given a typed value, convert it to ptype."""
+    if ptype == 'string':
+        if not isinstance(value, str):
+            raise ValueError("Parameter of type string given non-string value.")
+        return value
+
+    elif ptype == 'bool':
+        if not isinstance(value, bool):
+            raise ValueError("Parameter of type bool given non-bool value.")
+        return value
+
+    elif ptype == 'int':
+        if not isinstance(value, int):
+            try:
+                int_val = np.round(value)
+            except ValueError:
+                raise ValueError("Parameter of type int given non-int-convertible value.")
+
+            if abs(int_val - val) > 1.e-10:
+                raise ValueError("Parameter of type int given non-int-convertible value.")
+            value = int(int_val)
+        return int(value)
+
+    elif ptype == 'double':
+        if not isinstance(value, Decimal):
+            try:
+                value = Decimal(value)
+            except ValueError:
+                raise ValueError("Parameter of type float given non-Decimal-convertible value.")
+
+        if '.' not in str(d) and 'e' not in str(d).lower():
+            return Decimal(str(d)+'.0')
+        return d
+
+    else:
+        raise ValueError(f"Invalid ptype {ptype}")
+
+
+def _validValue(ptype, value):
+    """Valid typed value from string or typed value."""
+    if ptype != 'string' and isinstance(value, str):
+        return _validValueFromString(ptype, value)
+    else:
+        return _validValueFromType(ptype, value)
     
-    # ensure types
+
+def _checkType(ptype, value):
+    """Simply asserts that value is the right type."""
+    if ptype == 'string':
+        assert isinstance(value, str)
+    elif ptype == 'bool':
+        assert isinstance(value, bool)
+    elif ptype == 'int':
+        assert isinstance(value, int)
+    elif ptype == 'double':
+        assert isinstance(value, Decimal)
+    else:
+        assert(False)
+
+    
+def _convertTypeToString(ptype, value):
+    """Given a type, write it to a string."""
+    _checkType(ptype, value)
+    
     retval = None
-    if ptype == "double":
-        # note, it is very useful to "pick" a value here, but too
-        # small and we can cut off some user-provided but arbitrarily
-        # highly precise numbers.  Unfortunately too low of a value
-        # then allows tests to break.  This may need rethinking?
-        retval = ('%2.14g'%float(value)).strip()
-    elif ptype == "int":
-        retval = str(int(value)).strip()
-    elif ptype == "bool":
+    if ptype == 'bool':
         if value is True:
             retval = "true"
         elif value is False:
             retval = "false"
-    elif ptype == "string":
+    elif ptype == 'double':
+        retval = f'{value:g}'
+        if '.' not in retval and 'e' not in retval.lower():
+            retval = retval + '.0'
+    else:
         retval = str(value).strip()
     return retval
 
@@ -100,8 +147,8 @@ class Parameter(base.TeuchosBaseXML):
         try:
             this.setType(mytype) #validation
             this.setValue(myval) #validation
-        except RuntimeError as err:
-            raise RuntimeError(str(err)+"\n from xml entry: \"%s\""%str(elem.attrib))
+        except ValueError as err:
+            raise ValueError(str(err)+f"\n from xml entry: \"{str(elem.attrib)}\"")
         return this
 
     def __str__(self):
@@ -129,56 +176,46 @@ class Parameter(base.TeuchosBaseXML):
             self.set('type', ptype)
             self._basetype = ptype
             self._isarray = False
-        elif ptype in ["Array(%s)"%lcv for lcv in _valid_parameter_types]:
+        elif ptype in [f'Array({t})' for t in _valid_parameter_types]:
             self.set('type', ptype)
             self._basetype = ptype[6:-1]
-            self._isarray = True
-        elif ptype in ["Array %s"%lcv for lcv in _valid_parameter_types]:
-            self._basetype = ptype.split()[1]
-            self.set('type', "Array(%s)"%self._basetype)
             self._isarray = True
         else:
             raise RuntimeError("Unknown Parameter type %s"%ptype)
 
-        self.set('value', None)
-
-    def setValue(self, value):
-        """Set the value.  This checks it can be cast to the correct type."""
-        if self._isarray:
-            if type(value) is str:
-                vals = value.strip().strip('{').strip('}').split(',')
-                if len(vals) == 1 and vals[0] == '':
-                    self.value = ['',]
-                else:
-                    self.value = [self._checkSingleValueFromString(val.strip()) for val in vals]
-            elif type(value) is list:
-                if len(value) == 1 and value[0] == '':
-                    self.value = ['',]
-                else:
-                    self.value = [self._checkSingleValueFromString(val.strip()) for val in value]
-
-            self.set("value", "{" + ", ".join([self._checkSingleValueFromType(val) for val in self.value]) + "}")
-        else:
-            self.value = self._checkSingleValueFromString(value)
-            self.set("value", self._checkSingleValueFromType(self.value))
-
     def getValue(self):
         """Gets the value, cast to the correct type. Note this is here for API consistency only."""
         return self.value
+    
+    def setValue(self, value):
+        """Set the value given either string or a typed value.
 
-    def _checkSingleValueFromString(self, value):
-        retval = _valid_parameter_from_string(self._basetype, value)
-        assert retval is not None
-        return retval
+        This checks it can be cast to the correct type. Note that
+        setType() must already have been called.
 
-    def _checkSingleValueFromType(self, value):
-        retval = _valid_parameter_from_type(self._basetype, value)
-        assert retval is not None
-        return retval
+        Note this must handle both strings and typed values.
+        """
+        if self._isarray:
+            if type(value) is str:
+                value = value.strip().strip('{').strip('}').split(',')
+                if len(value) == 1 and value[0] == '':
+                    value = []
 
+            try:
+                vals = [i for i in value]
+            except TypeError:
+                raise ValueError(f'Cannot convert "{value}" to list for an array-typed parameter.')
+
+            self.value = [_validValue(self._basetype, val) for val in vals]
+            self.set("value", "{" + ", ".join([_convertTypeToString(self._basetype, val) for val in self.value]) + "}")
+
+        else:
+            self.value = _validValue(self.getType(), value)
+            self.set("value", _convertTypeToString(self.getType(), self.value))
+            
     def __copy__(self):
         return Parameter(self.getName(), self.getType(), self.getValue())
-
+    
     def __deepcopy__(self, memo):
         cp = self.__copy__()
         memo[id(self)] = cp

--- a/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter_list.py
@@ -132,8 +132,6 @@ class ParameterList(base.TeuchosBaseXML):
 
     def indent(self, ntabs, doublespace=False, doublespace_two=False):
         """Properly indent this list (and its Parameters/sublists) with [ntabs] tabs."""
-        self.sort()
-
         doublespace_sublists = self.get("name") in _doublespace
         doublespace_sublists_two_deep = self.get("name") in _doublespace_two
         postspace = doublespace or self.get("name") in _postspace

--- a/tools/amanzi_xml/amanzi_xml/utils/io.py
+++ b/tools/amanzi_xml/amanzi_xml/utils/io.py
@@ -1,10 +1,72 @@
 from . import parser, errors
 import xml.etree.ElementTree as etree
 
-etree_parser = etree.XMLParser(target=etree.TreeBuilder(insert_comments=True))
+
+def _serialize_amanzi_xml(write, elem, qnames, namespaces,
+                          short_empty_elements, **kwargs):
+    """This is a serializer, based on etree._serialize_xml(), that
+    canonicalizes according to how Teuchos::XMLObject writes XML.
+
+    This allows reading/writing with Teuchos and reading/writing with
+    amanzi_xml to result in the same output.
+    """
+    tag = elem.tag
+    text = elem.text
+    if tag is etree.Comment:
+        write("<!--%s-->" % text)
+    elif tag is etree.ProcessingInstruction:
+        write("<?%s?>" % text)
+    else:
+        tag = qnames[tag]
+        if tag is None:
+            if text:
+                write(etree._escape_cdata(text))
+            for e in elem:
+                _serialize_amanzi_xml(write, e, qnames, None,
+                                      short_empty_elements=short_empty_elements)
+        else:
+            write("<" + tag)
+            items = list(elem.items())
+            if items or namespaces:
+                if namespaces:
+                    for v, k in sorted(namespaces.items(),
+                                       key=lambda x: x[1]):  # sort on prefix
+                        if k:
+                            k = ":" + k
+                        write(" xmlns%s=\"%s\"" % (
+                            k,
+                            etree._escape_attrib(v)
+                            ))
+                for k, v in items:
+                    if isinstance(k, etree.QName):
+                        k = k.text
+                    if isinstance(v, etree.QName):
+                        v = qnames[v.text]
+                    else:
+                        v = etree._escape_attrib(v)
+                    write(" %s=\"%s\"" % (qnames[k], v))
+            if text or len(elem) or not short_empty_elements:
+                write(">")
+                if text:
+                    write(etree._escape_cdata(text))
+                for e in elem:
+                    _serialize_amanzi_xml(write, e, qnames, None,
+                                          short_empty_elements=short_empty_elements)
+                write("</" + tag + ">")
+            else:
+                # NOTE: this is the only current change relative to _serialize_xml()
+                # write(" />")  # serialize_xml versions
+                write("/>") # Teuchos version
+    if elem.tail:
+        write(etree._escape_cdata(elem.tail))
+
+
+etree._serialize['amanzi_xml'] = _serialize_amanzi_xml
+
 
 def fromFile(file_or_filename, ensure_is_plistable=False):
     """Reads a amanzi-xml hierarchy from a file or file handle"""
+    etree_parser = etree.XMLParser(target=etree.TreeBuilder(insert_comments=True))
     elem = etree.parse(file_or_filename, etree_parser)
 
     if ensure_is_plistable:
@@ -21,20 +83,24 @@ def fromFile(file_or_filename, ensure_is_plistable=False):
 
 def fromString(string):
     """Reads a amanzi-xml hierarchy from a string"""
+    etree_parser = etree.XMLParser(target=etree.TreeBuilder(insert_comments=True))
     elem = etree.fromstring(string, etree_parser)
     return parser.fromElement(elem)
+
 
 def toString(plist):
     """Writes a amanzi-xml hierarchy to a string"""
     plist.indent(0)
-    return etree.tostring(plist, encoding='unicode')
+    return etree.tostring(plist, encoding='unicode', method='amanzi_xml')
+
 
 def toFile(plist, file_or_filename):
     """Writes a amanzi-xml hierarchy to a file"""
     plist.indent(0)
     tree = etree.ElementTree(plist)
-    tree.write(file_or_filename)
+    tree.write(file_or_filename, method='amanzi_xml')
 
+    
 def extractDoxygenXML(filename, example_header="Native Spec Example"):
     """Extremely simple parser to pull out an xml example from source."""
     with open(filename,'r') as fid:

--- a/tools/amanzi_xml/amanzi_xml/utils/parser.py
+++ b/tools/amanzi_xml/amanzi_xml/utils/parser.py
@@ -19,9 +19,9 @@ class ValidationLevel(dict):
             self.none = False
 
 
-
 def _parameterFromElement(elem):
     return objects[elem.get("type")].from_Element(elem)
+
 
 def _listObjectFromElement(elem):
     # see if this is a new-style elem, whose Lists have Types
@@ -37,13 +37,12 @@ def _listObjectFromElement(elem):
         else:
             return obj.from_Element(elem)
 
-    # else try to guess the type from the List name
     cname = elem.get('name')
-    try:
+    if cname in objects:
+        # a typed list
         return objects[cname].from_Element(elem)
-
-    # else just create a generic ParameterList
-    except KeyError:
+    else:
+        # a genericl parameter list
         return objects["ParameterList"].from_Element(elem)
 
 

--- a/tools/amanzi_xml/null_op.py
+++ b/tools/amanzi_xml/null_op.py
@@ -1,0 +1,34 @@
+import sys,os
+import xml.etree.ElementTree as etree
+from amanzi_xml.utils import io as aio
+
+def fromFile(file_or_filename):
+    etree_parser = etree.XMLParser(target=etree.TreeBuilder(insert_comments=True))
+    return etree.parse(file_or_filename, etree_parser)
+
+def toFile(xml, file_or_filename):
+    xml.write(file_or_filename, method='amanzi_xml')
+
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("infile", help="input filename")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-i", "--inplace", action="store_true", help="fix file in place")
+    group.add_argument("-o", "--outfile", help="output filename")
+
+    args = parser.parse_args()
+
+    # check for orig file
+    print("Converting file: %s"%args.infile)
+    xml = fromFile(args.infile)
+
+    if args.inplace:
+        toFile(xml, args.infile)
+    else:
+        toFile(xml, args.outfile)
+    sys.exit(0)
+


### PR DESCRIPTION
Future changes to Chemistry will require changes to a significant number of xml files.  These changes will be done through a script that uses amanzi_xml.

However, currently most xml files are formatted differently from how amanzi_xml formats.  This means that after the above changes are made, there will be many many formatting differences that hide the actual changes.

This PR does two things:

1. It changes amanzi_xml's formatting to act as much like Teuchos::XMLObject's writers as possible.
2. It runs a "null op" read and write of all Amanzi xml files.  These make no actual changes, but do reformat things to a standard formatting approach, e.g. same whitespace conventions and same scientific notation on floats.

