### PR TITLE
Major refactor of Chemistry_PK, Alquimia_PK

### DIFF
--- a/demos/phase3/tank/Tank-alq_v2.xml
+++ b/demos/phase3/tank/Tank-alq_v2.xml
@@ -43,9 +43,9 @@
       <density>998.2</density>
       <dissolved_components>
 	<solutes>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Tracer</solute>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Sr90</solute>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Cs137</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Tracer</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Sr90</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Cs137</solute>
 	</solutes>
       </dissolved_components>
     </liquid_phase>

--- a/doc/input_spec/AmanziInputSpec-s.rst
+++ b/doc/input_spec/AmanziInputSpec-s.rst
@@ -990,7 +990,7 @@ The subelement ``primaries`` is used for specifying reactive and non-reactive pr
 
     * ``coefficient_of_diffusion`` = "exponential", this is an optional attribute
 
-    * ``first_order_decay_constant`` = "exponential", this is an optional attribute
+    * ``first_order_decay_rate_constant`` = "exponential", this is an optional attribute
 
     * ``forward_rate`` = "exponential", this is a required attribute when being used with non-reactive primaries/solutes and automatically generating the chemistry engine input file
 

--- a/doc/input_spec/AmanziInputSpec-u.rst
+++ b/doc/input_spec/AmanziInputSpec-u.rst
@@ -1477,7 +1477,7 @@ The subelement ``primaries`` is used for specifying reactive and non-reactive pr
 
     * ``coefficient_of_diffusion`` = "double", this is an optional attribute
 
-    * ``first_order_decay_constant`` = "double", this is an optional attribute
+    * ``first_order_decay_rate_constant`` = "double", this is an optional attribute
 
     * ``forward_rate`` = "double", this is a required attribute when being used with non-reactive primaries/solutes and automatically generating the chemistry engine input file
 

--- a/doc/input_spec/schema/amanzi.xsd
+++ b/doc/input_spec/schema/amanzi.xsd
@@ -1591,7 +1591,7 @@ TODO Can we do validation on known names plus allow unrecognised ones.  Well I t
 	<xs:simpleContent>
 	<xs:extension base="xs:string">
 		<xs:attribute name="coefficient_of_diffusion" type="typedef_exponential"/>
-		<xs:attribute name="first_order_decay_constant" type="typedef_exponential"/>	
+		<xs:attribute name="first_order_decay_rate_constant" type="typedef_exponential"/>	
 		<xs:attribute name="forward_rate" type="typedef_exponential" />
 		<xs:attribute name="backward_rate" type="typedef_exponential" />
 		<xs:attribute name="molar_mass" type="typedef_exponential" />

--- a/doc/input_spec/schema/example.xml
+++ b/doc/input_spec/schema/example.xml
@@ -77,7 +77,7 @@
             <density>exp</density> <!-- REQUIRED -->
             <dissolved_components> 
                 <primaries>
-                    <primary coefficient_of_diffusion="exp" first_order_decay_constant="exp" forward_rate="exp" backward_rate="exp">primary_name_string</primary>
+                    <primary coefficient_of_diffusion="exp" first_order_decay_rate_constant="exp" forward_rate="exp" backward_rate="exp">primary_name_string</primary>
 		    <!-- primary name must match the name in the engine database file -->
 		    <!-- NOTE: if primary is a non-reactive species/solute, 
 			 include the forward and backward rates.  Dummy values of 0 are acceptable -->

--- a/doc/user_guide/input/input_schema.rst
+++ b/doc/user_guide/input/input_schema.rst
@@ -1073,7 +1073,7 @@ The ``liquid_phase`` element is required to produce a valid input file.  If prim
      <density> Exponential </density>
      <dissolved_components> 
        <primaries>
-         <primary coefficient_of_diffusion="Exponential" first_order_decay_constant="Exponential"> PrimaryName </primary>
+         <primary coefficient_of_diffusion="Exponential" first_order_decay_rate_constant="Exponential"> PrimaryName </primary>
        </primaries> 
        <secondaries>
          <secondary>SecondaryName</secondary>
@@ -1117,7 +1117,7 @@ An example ``phases`` element looks like the following.
       <density>998.2</density>
       <dissolved_components> 
         <primaries>
-          <primary coefficient_of_diffusion="1.0e-9" first_order_decay_constant="1.0e-9">Tc-99</primary>
+          <primary coefficient_of_diffusion="1.0e-9" first_order_decay_rate_constant="1.0e-9">Tc-99</primary>
         </primaries>
       </dissolved_components>
     </liquid_phase>

--- a/src/common/interface_platform/InputConverter.cc
+++ b/src/common/interface_platform/InputConverter.cc
@@ -1464,8 +1464,8 @@ InputConverter::CreateINFile_(std::string& filename, int rank)
       primaries << "    " << name << "\n";
       element = static_cast<DOMElement*>(inode);
 
-      if (element->hasAttribute(mm.transcode("first_order_decay_constant"))) {
-        double decay = GetAttributeValueD_(element, "first_order_decay_constant");
+      if (element->hasAttribute(mm.transcode("first_order_decay_rate_constant"))) {
+        double decay = GetAttributeValueD_(element, "first_order_decay_rate_constant");
         name = TrimString_(mm.transcode(inode->getTextContent()));
         decayrates << "    REACTION " << name << " <-> \n";
         decayrates << "    RATE_CONSTANT " << decay << "\n";

--- a/src/common/interface_platform/InputConverter.cc
+++ b/src/common/interface_platform/InputConverter.cc
@@ -408,7 +408,7 @@ InputConverter::GetUniqueElementByTagsString_(const DOMNode* node1,
 ****************************************************************** */
 DOMElement*
 InputConverter::GetUniqueChildByAttribute_(xercesc::DOMNode* node,
-                                           const char* attr_name,
+                                           const std::string& attr_name,
                                            const std::string& attr_value,
                                            bool& flag,
                                            bool exception)
@@ -427,8 +427,8 @@ InputConverter::GetUniqueChildByAttribute_(xercesc::DOMNode* node,
     if (inode->getNodeType() != DOMNode::ELEMENT_NODE) continue;
 
     DOMElement* element = static_cast<DOMElement*>(inode);
-    if (element->hasAttribute(mm.transcode(attr_name))) {
-      char* text = mm.transcode(element->getAttribute(mm.transcode(attr_name)));
+    if (element->hasAttribute(mm.transcode(attr_name.c_str()))) {
+      char* text = mm.transcode(element->getAttribute(mm.transcode(attr_name.c_str())));
       if (strcmp(text, attr_value.c_str()) == 0) {
         child = element;
         n++;
@@ -584,10 +584,10 @@ InputConverter::GetSameChildNodes_(DOMNode* node, std::string& name, bool& flag,
 * Verifies existance
 ****************************************************************** */
 bool
-InputConverter::HasAttribute_(DOMElement* elem, const char* attr_name)
+InputConverter::HasAttribute_(DOMElement* elem, const std::string& attr_name)
 {
   MemoryManager mm;
-  return elem->hasAttribute(mm.transcode(attr_name));
+  return elem->hasAttribute(mm.transcode(attr_name.c_str()));
 }
 
 
@@ -596,7 +596,7 @@ InputConverter::HasAttribute_(DOMElement* elem, const char* attr_name)
 ****************************************************************** */
 double
 InputConverter::GetAttributeValueD_(DOMElement* elem,
-                                    const char* attr_name,
+                                    const std::string& attr_name,
                                     const std::string& type,
                                     double valmin,
                                     double valmax,
@@ -610,8 +610,8 @@ InputConverter::GetAttributeValueD_(DOMElement* elem,
   Errors::Message msg;
   std::string text, parsed, found_type, unit_in;
 
-  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name))) {
-    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name)));
+  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name.c_str()))) {
+    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name.c_str())));
     if (text.size() == 0) {
       msg << "Attribute \"" << attr_name << "\" cannot be empty.\n";
       Exceptions::amanzi_throw(msg);
@@ -668,7 +668,7 @@ InputConverter::GetAttributeValueD_(DOMElement* elem,
 ****************************************************************** */
 int
 InputConverter::GetAttributeValueL_(DOMElement* elem,
-                                    const char* attr_name,
+                                    const std::string& attr_name,
                                     const std::string& type,
                                     int valmin,
                                     int valmax,
@@ -679,8 +679,8 @@ InputConverter::GetAttributeValueL_(DOMElement* elem,
   MemoryManager mm;
 
   std::string text, parsed, found_type;
-  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name))) {
-    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name)));
+  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name.c_str()))) {
+    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name.c_str())));
 
     // process constants
     found_type = GetConstantType_(text, parsed);
@@ -718,7 +718,7 @@ InputConverter::GetAttributeValueL_(DOMElement* elem,
 ****************************************************************** */
 std::string
 InputConverter::GetAttributeValueS_(DOMElement* elem,
-                                    const char* attr_name,
+                                    const std::string& attr_name,
                                     const std::string& type,
                                     bool exception,
                                     std::string default_val)
@@ -727,8 +727,8 @@ InputConverter::GetAttributeValueS_(DOMElement* elem,
   MemoryManager mm;
 
   std::string text, found_type;
-  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name))) {
-    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name)));
+  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name.c_str()))) {
+    text = mm.transcode(elem->getAttribute(mm.transcode(attr_name.c_str())));
     trim(text);
 
     // check the list of global constants
@@ -760,7 +760,7 @@ InputConverter::GetAttributeValueS_(DOMElement* elem,
 ****************************************************************** */
 std::vector<double>
 InputConverter::GetAttributeVectorD_(DOMElement* elem,
-                                     const char* attr_name,
+                                     const std::string& attr_name,
                                      int length,
                                      std::string unit,
                                      bool exception,
@@ -769,9 +769,9 @@ InputConverter::GetAttributeVectorD_(DOMElement* elem,
   std::vector<double> val;
   MemoryManager mm;
 
-  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name))) {
+  if (elem != NULL && elem->hasAttribute(mm.transcode(attr_name.c_str()))) {
     std::vector<std::string> unit_in;
-    char* text_content = mm.transcode(elem->getAttribute(mm.transcode(attr_name)));
+    char* text_content = mm.transcode(elem->getAttribute(mm.transcode(attr_name.c_str())));
     val = MakeVector_(text_content, unit_in, mol_mass);
 
     for (int i = 0; i < unit_in.size(); ++i) {
@@ -805,13 +805,13 @@ InputConverter::GetAttributeVectorD_(DOMElement* elem,
 * Extract attribute of type vector<string>.
 ****************************************************************** */
 std::vector<std::string>
-InputConverter::GetAttributeVectorS_(DOMElement* elem, const char* attr_name, bool exception)
+InputConverter::GetAttributeVectorS_(DOMElement* elem, const std::string& attr_name, bool exception)
 {
   std::vector<std::string> val, tmp;
   MemoryManager mm;
 
-  if (elem->hasAttribute(mm.transcode(attr_name))) {
-    char* text_content = mm.transcode(elem->getAttribute(mm.transcode(attr_name)));
+  if (elem->hasAttribute(mm.transcode(attr_name.c_str()))) {
+    char* text_content = mm.transcode(elem->getAttribute(mm.transcode(attr_name.c_str())));
     tmp = CharToStrings_(text_content);
     for (int i = 0; i < tmp.size(); ++i) {
       std::string parsed_val;
@@ -900,7 +900,7 @@ InputConverter::GetChildVectorS_(DOMNode* node,
 * Extract atribute of type std::string.
 ****************************************************************** */
 std::string
-InputConverter::GetAttributeValueS_(DOMNode* node, const char* attr_name, const char* options)
+InputConverter::GetAttributeValueS_(DOMNode* node, const std::string& attr_name, const char* options)
 {
   DOMElement* element = static_cast<DOMElement*>(node);
 

--- a/src/common/interface_platform/InputConverter.hh
+++ b/src/common/interface_platform/InputConverter.hh
@@ -147,7 +147,7 @@ class InputConverter {
 
   // -- extract child with the given attribute
   xercesc::DOMElement* GetUniqueChildByAttribute_(xercesc::DOMNode* node,
-                                                  const char* attr_name,
+                                                  const std::string& attr_name,
                                                   const std::string& attr_value,
                                                   bool& flag,
                                                   bool exception = false);
@@ -161,7 +161,7 @@ class InputConverter {
   // ----------------
   //   Attributes
   // ----------------
-  bool HasAttribute_(DOMElement* elem, const char* attr_name);
+  bool HasAttribute_(DOMElement* elem, const std::string& attr_name);
 
   // -- extract and verify children
   // -- extract existing attribute value and verify it optionally against expected units
@@ -181,7 +181,7 @@ class InputConverter {
   //                if true, throw an exception.
   //    default_val = defult value
   int GetAttributeValueL_(xercesc::DOMElement* elem,
-                          const char* attr_name,
+                          const std::string& attr_name,
                           const std::string& type = TYPE_NUMERICAL,
                           int valmin = INT_MIN,
                           int valmax = INT_MAX,
@@ -189,7 +189,7 @@ class InputConverter {
                           int defaul_val = 0);
   double GetAttributeValueD_( // supports units except for ppbm
     xercesc::DOMElement* elem,
-    const char* attr_name,
+    const std::string& attr_name,
     const std::string& type = TYPE_NUMERICAL,
     double valmin = DVAL_MIN,
     double valmax = DVAL_MAX,
@@ -197,23 +197,23 @@ class InputConverter {
     bool exception = true,
     double default_val = 0.0);
   std::string GetAttributeValueS_(xercesc::DOMElement* elem,
-                                  const char* attr_name,
+                                  const std::string& attr_name,
                                   const std::string& type = TYPE_NUMERICAL,
                                   bool exception = true,
                                   std::string default_val = "");
   std::vector<double> GetAttributeVectorD_( // supports units except ppbm
     xercesc::DOMElement* elem,
-    const char* attr_name,
+    const std::string& attr_name,
     int length = -1,
     std::string unit = "",
     bool exception = true,
     double mol_mass = -1.0);
   std::vector<std::string>
-  GetAttributeVectorS_(xercesc::DOMElement* elem, const char* attr_name, bool exception = true);
+  GetAttributeVectorS_(xercesc::DOMElement* elem, const std::string& attr_name, bool exception = true);
 
   // -- node is used more often then element
   int GetAttributeValueL_(xercesc::DOMNode* node,
-                          const char* attr_name,
+                          const std::string& attr_name,
                           const std::string& type = TYPE_NUMERICAL,
                           int valmin = INT_MIN,
                           int valmax = INT_MAX,
@@ -225,7 +225,7 @@ class InputConverter {
   }
   double GetAttributeValueD_( // supports units except for ppbm
     xercesc::DOMNode* node,
-    const char* attr_name,
+    const std::string& attr_name,
     const std::string& type = TYPE_NUMERICAL,
     double valmin = DVAL_MIN,
     double valmax = DVAL_MAX,
@@ -237,7 +237,7 @@ class InputConverter {
     return GetAttributeValueD_(element, attr_name, type, valmin, valmax, unit, exception, val);
   }
   std::string GetAttributeValueS_(xercesc::DOMNode* node,
-                                  const char* attr_name,
+                                  const std::string& attr_name,
                                   const std::string& type = TYPE_NUMERICAL,
                                   bool exception = true,
                                   std::string val = "")
@@ -247,7 +247,7 @@ class InputConverter {
   }
   std::vector<double> GetAttributeVectorD_( // supports units except ppbm
     xercesc::DOMNode* node,
-    const char* attr_name,
+    const std::string& attr_name,
     int length = -1,
     std::string unit = "",
     bool exception = true,
@@ -257,7 +257,7 @@ class InputConverter {
     return GetAttributeVectorD_(element, attr_name, length, unit, exception, mol_mass);
   }
   std::vector<std::string>
-  GetAttributeVectorS_(xercesc::DOMNode* node, const char* attr_name, bool exception = true)
+  GetAttributeVectorS_(xercesc::DOMNode* node, const std::string& attr_name, bool exception = true)
   {
     xercesc::DOMElement* element = static_cast<xercesc::DOMElement*>(node);
     return GetAttributeVectorS_(element, attr_name, exception);
@@ -265,7 +265,7 @@ class InputConverter {
 
   // -- extract existing attribute value and verify it
   std::string
-  GetAttributeValueS_(xercesc::DOMNode* node, const char* attr_name, const char* options);
+  GetAttributeValueS_(xercesc::DOMNode* node, const std::string& attr_name, const char* options);
 
 
   // --------------

--- a/src/common/interface_platform/InputConverterU_Chemistry.cc
+++ b/src/common/interface_platform/InputConverterU_Chemistry.cc
@@ -452,16 +452,34 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     out_list.set<std::string>("Pitzer database file", pitzer_database);
   out_list.set<int>("maximum Newton iterations", max_itrs);
   out_list.set<double>("tolerance", tol);
-  out_list.set<double>("max timestep (s)", dt_max);
-  out_list.set<double>("min timestep (s)", dt_min);
-  out_list.set<double>("initial timestep (s)", dt_init);
-  out_list.set<int>("timestep cut threshold", cut_threshold);
-  out_list.set<double>("timestep cut factor", dt_cut);
-  out_list.set<int>("timestep increase threshold", increase_threshold);
-  out_list.set<double>("timestep increase factor", dt_increase);
-  out_list.set<std::string>("timestep control method", dt_method);
   out_list.set<bool>("log formulation", log_form);
   out_list.set<std::string>("convergence criterion", conv_criterion);
+
+  // timestep controller
+  if (dt_method == "simple") {
+    out_list.sublist("timestep controller").set<std::string>("timestep controller type", "standard");
+    Teuchos::ParameterList& tsc_list =
+      out_list.sublist("timestep controller").sublist("timestep controller standard parameters");
+    tsc_list.set<double>("max timestep [s]", dt_max);
+    tsc_list.set<double>("min timestep [s]", dt_min);
+    tsc_list.set<double>("initial timestep [s]", dt_init);
+    tsc_list.set<int>("max iterations", cut_threshold);
+    tsc_list.set<double>("timestep reduction factor", dt_cut);
+    tsc_list.set<int>("min iterations", increase_threshold);
+    tsc_list.set<double>("timestep increase factor", dt_increase);
+
+  } else if (dt_method == "fixed") {
+    out_list.sublist("timestep controller").set<std::string>("timestep controller type", "fixed");
+    Teuchos::ParameterList& tsc_list =
+      out_list.sublist("timestep controller").sublist("timestep controller fixed parameters");
+    tsc_list.set<double>("timestep [s]", dt_init);
+
+  } else {
+    Errors::Message msg;
+    msg << "Unknown chemistry time_step_control_method \"" << dt_method << "\" -- valid are \"fixed\" and \"simple\".";
+    Exceptions::amanzi_throw(msg);
+  }
+
   if (aux_data.size() > 0) out_list.set<Teuchos::Array<std::string>>("auxiliary data", aux_data);
   if (sorption_sites.size() > 0)
     out_list.set<Teuchos::Array<std::string>>("sorption sites", sorption_sites);

--- a/src/common/interface_platform/InputConverterU_Chemistry.cc
+++ b/src/common/interface_platform/InputConverterU_Chemistry.cc
@@ -464,7 +464,7 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     tsc_list.set<double>("min timestep [s]", dt_min);
     tsc_list.set<double>("initial timestep [s]", dt_init);
     tsc_list.set<int>("max iterations", cut_threshold);
-    tsc_list.set<double>("timestep reduction factor", dt_cut);
+    tsc_list.set<double>("timestep reduction factor", 1./dt_cut);
     tsc_list.set<int>("min iterations", increase_threshold);
     tsc_list.set<double>("timestep increase factor", dt_increase);
 

--- a/src/common/interface_platform/InputConverterU_Chemistry.cc
+++ b/src/common/interface_platform/InputConverterU_Chemistry.cc
@@ -151,7 +151,7 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
 
       double krate(-99.9);
       krate = GetAttributeValueD_(
-        inode, "first_order_decay_constant", TYPE_NUMERICAL, DVAL_MIN, DVAL_MAX, "", false, -99.9);
+        inode, "first_order_decay_rate_constant", TYPE_NUMERICAL, DVAL_MIN, DVAL_MAX, "", false, -99.9);
 
       if (krate != -99.9) {
         kin_rate_cnst.push_back(krate);
@@ -186,8 +186,7 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     if (aqueous_reactions.size() > 0) {
       out_list.set<Teuchos::Array<std::string>>("aqueous_reactions", aqueous_reactions);
 
-      std::string decay_constant_name = engine == "amanzi" ? "first_order_decay_constant" :
-        "aqueous_kinetic_rate_constant";
+      std::string decay_constant_name = "first_order_decay_rate_constant";
       Teuchos::ParameterList& rate = ic_list.sublist(decay_constant_name);
 
       for (std::vector<std::string>::const_iterator it = regions.begin(); it != regions.end();
@@ -284,8 +283,7 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     // ion exchange
     node = GetUniqueElementByTagsString_(inode, "ion_exchange, cations", flag);
     if (flag) {
-      std::string field_name = engine == "amanzi" ? "ion_exchange_sites" :
-        "cation_exchange_capacity";
+      std::string field_name = "cation_exchange_capacity";
       Teuchos::ParameterList& sites = ic_list.sublist(field_name);
       double cec = GetAttributeValueD_(node, "cec", TYPE_NUMERICAL, DVAL_MIN, DVAL_MAX, "mol/m^3");
 
@@ -373,8 +371,7 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
 
         sorption_sites.clear();
 
-      std::string field_name = engine == "amanzi" ? "sorption_sites" :
-        "sorption_site_density";
+      std::string field_name = "surface_site_density";
         Teuchos::ParameterList& complexation = ic_list.sublist(field_name);
         Teuchos::ParameterList& tmp_list =
           complexation.sublist("function")

--- a/src/common/interface_platform/InputConverterU_Chemistry.cc
+++ b/src/common/interface_platform/InputConverterU_Chemistry.cc
@@ -186,7 +186,9 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     if (aqueous_reactions.size() > 0) {
       out_list.set<Teuchos::Array<std::string>>("aqueous_reactions", aqueous_reactions);
 
-      Teuchos::ParameterList& rate = ic_list.sublist("first_order_decay_constant");
+      std::string decay_constant_name = engine == "amanzi" ? "first_order_decay_constant" :
+        "aqueous_kinetic_rate_constant";
+      Teuchos::ParameterList& rate = ic_list.sublist(decay_constant_name);
 
       for (std::vector<std::string>::const_iterator it = regions.begin(); it != regions.end();
            it++) {
@@ -282,7 +284,9 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
     // ion exchange
     node = GetUniqueElementByTagsString_(inode, "ion_exchange, cations", flag);
     if (flag) {
-      Teuchos::ParameterList& sites = ic_list.sublist("ion_exchange_sites");
+      std::string field_name = engine == "amanzi" ? "ion_exchange_sites" :
+        "cation_exchange_capacity";
+      Teuchos::ParameterList& sites = ic_list.sublist(field_name);
       double cec = GetAttributeValueD_(node, "cec", TYPE_NUMERICAL, DVAL_MIN, DVAL_MAX, "mol/m^3");
 
       for (auto it = regions.begin(); it != regions.end(); ++it) {
@@ -369,7 +373,9 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
 
         sorption_sites.clear();
 
-        Teuchos::ParameterList& complexation = ic_list.sublist("sorption_sites");
+      std::string field_name = engine == "amanzi" ? "sorption_sites" :
+        "sorption_site_density";
+        Teuchos::ParameterList& complexation = ic_list.sublist(field_name);
         Teuchos::ParameterList& tmp_list =
           complexation.sublist("function")
             .sublist(site_str.str())
@@ -393,8 +399,8 @@ InputConverterU::TranslateChemistry_(const std::string& domain)
   }
 
   // general parameters
-  int max_itrs(100), cut_threshold(8), increase_threshold(4);
-  double tol(1e-12), dt_max(1e+10), dt_min(1e+10), dt_init(1e+7), dt_cut(2.0), dt_increase(1.2);
+  int max_itrs(100), cut_threshold(20), increase_threshold(8);
+  double tol(1e-12), dt_max(1e+10), dt_min(1e-10), dt_init(1e+10), dt_cut(2.0), dt_increase(1.2);
 
   double ion_value;
   bool ion_guess(false), log_form(true);

--- a/src/common/interface_platform/test/converter_s_input.xml
+++ b/src/common/interface_platform/test/converter_s_input.xml
@@ -36,9 +36,9 @@
       <density>998.2</density>
       <dissolved_components>
 	<solutes>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Tracer</solute>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Sr90</solute>
-	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_constant="0">Cs137</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Tracer</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Sr90</solute>
+	  <solute coefficient_of_diffusion="5.e-12" first_order_decay_rate_constant="0">Cs137</solute>
 	</solutes>
       </dissolved_components>
     </liquid_phase>

--- a/src/common/interface_platform/test/converter_u_test04.xml
+++ b/src/common/interface_platform/test/converter_u_test04.xml
@@ -40,7 +40,7 @@
           <primary coefficient_of_diffusion="1.0E-9">Na+</primary>
           <primary coefficient_of_diffusion="1.0E-9">SiO2(aq)</primary>
           <primary coefficient_of_diffusion="1.0E-9">SO4--</primary>
-          <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09 ">Tritium</primary>
+          <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09 ">Tritium</primary>
           <primary coefficient_of_diffusion="1.0E-9">NO3-</primary>
           <primary coefficient_of_diffusion="1.0E-9">UO2++</primary>
         </primaries>

--- a/src/common/interface_platform/test/converter_u_validate04.xml
+++ b/src/common/interface_platform/test/converter_u_validate04.xml
@@ -780,14 +780,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-10"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.2"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="sorption sites" type="Array(string)" value="{&gt;davis_OH}"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="14"/>
@@ -799,6 +791,13 @@
 
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="1.0e+7"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/common/interface_platform/test/converter_u_validate04.xml
+++ b/src/common/interface_platform/test/converter_u_validate04.xml
@@ -279,7 +279,7 @@
         <Parameter name="value" type="double" value="101325.0"/>
       </ParameterList>
 
-      <ParameterList name="first_order_decay_constant">
+      <ParameterList name="first_order_decay_rate_constant">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="region" type="string" value="All"/>
@@ -456,7 +456,7 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="ion_exchange_sites">
+      <ParameterList name="cation_exchange_capacity">
         <ParameterList name="function">
           <ParameterList name="All">
             <Parameter name="region" type="string" value="All"/>
@@ -470,7 +470,7 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="sorption_sites">
+      <ParameterList name="surface_site_density">
         <ParameterList name="function">
           <ParameterList name="MESH BLOCK 1">
             <Parameter name="regions" type="Array(string)" value="{All}"/>

--- a/src/common/interface_platform/test/converter_u_validate06.xml
+++ b/src/common/interface_platform/test/converter_u_validate06.xml
@@ -744,7 +744,7 @@
       <ParameterList name="timestep controller" type="ParameterList">
         <Parameter name="timestep controller type" type="string" value="fixed"/>
         <ParameterList name="timestep controller fixed parameters" type="ParameterList">
-          <Parameter name="timestep [s]" type="double" value="1.0e+7"/>
+          <Parameter name="timestep [s]" type="double" value="1.0e+10"/>
         </ParameterList>
       </ParameterList>
 
@@ -771,7 +771,7 @@
       <ParameterList name="timestep controller" type="ParameterList">
         <Parameter name="timestep controller type" type="string" value="fixed"/>
         <ParameterList name="timestep controller fixed parameters" type="ParameterList">
-          <Parameter name="timestep [s]" type="double" value="1.0e+7"/>
+          <Parameter name="timestep [s]" type="double" value="1.0e+10"/>
         </ParameterList>
       </ParameterList>
 

--- a/src/common/interface_platform/test/converter_u_validate06.xml
+++ b/src/common/interface_platform/test/converter_u_validate06.xml
@@ -729,14 +729,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.2"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="false"/>
@@ -747,6 +739,13 @@
 
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="1.0e+7"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>
@@ -757,14 +756,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+7"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.2"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="false"/>
@@ -775,6 +766,13 @@
 
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="1.0e+7"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/interoperability/test/interoperability_flow_transport.xml
+++ b/src/interoperability/test/interoperability_flow_transport.xml
@@ -643,7 +643,7 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="ion_exchange_sites">
+      <ParameterList name="cation_exchange_capacity">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
             <Parameter name="region" type="string" value="Soil_1"/>

--- a/src/interoperability/test/interoperability_flow_transport.xml
+++ b/src/interoperability/test/interoperability_flow_transport.xml
@@ -253,6 +253,12 @@
       <Parameter name="minerals" type="Array(string)" value="{Halite}"/>
       <Parameter name="number of component concentrations" type="int" value="4"/>
       <Parameter name="log formulation" type="bool" value="true"/>
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="10000000000000000.0"/>
+        </ParameterList>
+      </ParameterList>
 
     </ParameterList>
 

--- a/src/mpc/CycleDriver.cc
+++ b/src/mpc/CycleDriver.cc
@@ -1083,6 +1083,7 @@ CycleDriver::ResetDriver(int time_pr_id)
 
   // Initialize the process kernels and verify
   pk_->Initialize();
+  pk_->CommitStep(S_->get_time(), S_->get_time(), Tags::DEFAULT);
   S_->CheckAllFieldsInitialized();
 
   S_->GetMeshPartition("materials");

--- a/src/mpc/FlexibleObservations.cc
+++ b/src/mpc/FlexibleObservations.cc
@@ -48,7 +48,7 @@ FlexibleObservations::FlexibleObservations(Teuchos::RCP<Teuchos::ParameterList> 
 
   Teuchos::ParameterList tmp_list;
   tmp_list.set<std::string>("verbosity level", "high");
-  vo_ = new VerboseObject("Observations", tmp_list);
+  vo_ = Teuchos::rcp(new VerboseObject("Observations", tmp_list));
 
   // loop over the sublists and create an observation for each
   for (auto i = obs_list_->begin(); i != obs_list_->end(); i++) {
@@ -103,7 +103,7 @@ FlexibleObservations::FlexibleObservations(Teuchos::RCP<Teuchos::ParameterList> 
       // loop over all variables listed and create an observable for each
       std::string var = observable_plist.get<std::string>("variable");
       Key domain_name = observable_plist.get<std::string>("domain name", "domain");
-      observations.insert(std::pair<std::string, Teuchos::RCP<Observable>>(
+      observations.insert(std::pair<std::string, Teuchos::RCP<ObservableAmanzi>>(
         obs_list_->name(i),
         CreateObservable(
           *coordinator_list, observable_plist, *units_list, S->GetMesh(domain_name))));
@@ -125,7 +125,7 @@ FlexibleObservations::MakeObservations(State& S)
   std::string unit;
 
   // loop over all observables
-  for (std::map<std::string, Teuchos::RCP<Observable>>::iterator i = observations.begin();
+  for (std::map<std::string, Teuchos::RCP<ObservableAmanzi>>::iterator i = observations.begin();
        i != observations.end();
        i++) {
     if ((i->second)->DumpRequested(S.get_time()) || (i->second)->DumpRequested(S.get_cycle())) {
@@ -207,7 +207,7 @@ bool
 FlexibleObservations::DumpRequested(const double time)
 {
   bool result = false;
-  for (std::map<std::string, Teuchos::RCP<Observable>>::iterator i = observations.begin();
+  for (std::map<std::string, Teuchos::RCP<ObservableAmanzi>>::iterator i = observations.begin();
        i != observations.end();
        i++) {
     result = result || (i->second)->DumpRequested(time);
@@ -220,7 +220,7 @@ bool
 FlexibleObservations::DumpRequested(const int cycle)
 {
   bool result = false;
-  for (std::map<std::string, Teuchos::RCP<Observable>>::iterator i = observations.begin();
+  for (std::map<std::string, Teuchos::RCP<ObservableAmanzi>>::iterator i = observations.begin();
        i != observations.end();
        i++) {
     result = result || (i->second)->DumpRequested(cycle);
@@ -243,7 +243,7 @@ FlexibleObservations::DumpRequested(const int cycle, const double time)
 void
 FlexibleObservations::RegisterWithTimeStepManager(Utils::TimeStepManager& tsm)
 {
-  for (std::map<std::string, Teuchos::RCP<Observable>>::iterator i = observations.begin();
+  for (std::map<std::string, Teuchos::RCP<ObservableAmanzi>>::iterator i = observations.begin();
        i != observations.end();
        i++) {
     (i->second)->RegisterWithTimeStepManager(tsm);

--- a/src/mpc/FlexibleObservations.hh
+++ b/src/mpc/FlexibleObservations.hh
@@ -194,11 +194,6 @@ class FlexibleObservations {
                        Amanzi::ObservationData& observation_data,
                        Teuchos::RCP<const State> S);
 
-  ~FlexibleObservations()
-  {
-    if (vo_ != NULL) delete vo_;
-  }
-
   void RegisterComponentNames(std::vector<std::string>& comp_names,
                               std::vector<double>& comp_mol_masses,
                               int num_liquid)
@@ -223,14 +218,14 @@ class FlexibleObservations {
   double CalculateWaterTable_(State& S, AmanziMesh::Entity_ID_View& ids);
 
  protected:
-  VerboseObject* vo_;
+  Teuchos::RCP<VerboseObject> vo_;
 
  private:
   int rank_;
   Teuchos::RCP<Teuchos::ParameterList> obs_list_;
   Teuchos::RCP<Teuchos::ParameterList> coordinator_list_;
   Amanzi::ObservationData& observation_data_;
-  std::map<std::string, Teuchos::RCP<Observable>> observations;
+  std::map<std::string, Teuchos::RCP<ObservableAmanzi>> observations;
 
   std::vector<std::string> comp_names_;
   std::vector<double> comp_mol_masses_;

--- a/src/mpc/ObservableAmanzi.hh
+++ b/src/mpc/ObservableAmanzi.hh
@@ -16,8 +16,7 @@
   Virtual base class.
 */
 
-#ifndef AMANZI_OBSERVABLE_HH
-#define AMANZI_OBSERVABLE_HH
+#pragma once
 
 #include "Teuchos_Array.hpp"
 #include "Teuchos_ParameterList.hpp"
@@ -30,9 +29,9 @@
 
 namespace Amanzi {
 
-class Observable : public Utils::IOEvent {
+class ObservableAmanzi : public Utils::IOEvent {
  public:
-  Observable(std::string variable,
+  ObservableAmanzi(std::string variable,
              std::string region,
              std::string functional,
              Teuchos::ParameterList& plist,
@@ -60,6 +59,8 @@ class Observable : public Utils::IOEvent {
     }
   }
 
+  virtual ~ObservableAmanzi() = default;
+
   virtual void
   ComputeObservation(State& S, double* value, double* volume, std::string& unit, double dt) = 0;
   virtual int ComputeRegionSize() { return region_size_; }
@@ -82,4 +83,4 @@ class Observable : public Utils::IOEvent {
 
 } // namespace Amanzi
 
-#endif
+

--- a/src/mpc/ObservableAqueous.cc
+++ b/src/mpc/ObservableAqueous.cc
@@ -35,7 +35,7 @@ ObservableAqueous::ObservableAqueous(std::string variable,
                                      Teuchos::ParameterList& plist,
                                      Teuchos::ParameterList& units_plist,
                                      Teuchos::RCP<const AmanziMesh::Mesh> mesh)
-  : Observable(variable, region, functional, plist, units_plist, mesh){};
+  : ObservableAmanzi(variable, region, functional, plist, units_plist, mesh){};
 
 
 /* ******************************************************************

--- a/src/mpc/ObservableAqueous.hh
+++ b/src/mpc/ObservableAqueous.hh
@@ -23,7 +23,7 @@
 
 namespace Amanzi {
 
-class ObservableAqueous : public virtual Observable {
+class ObservableAqueous : public virtual ObservableAmanzi {
  public:
   ObservableAqueous(std::string variable,
                     std::string region,

--- a/src/mpc/ObservableFactory.cc
+++ b/src/mpc/ObservableFactory.cc
@@ -37,13 +37,13 @@
 
 namespace Amanzi {
 
-Teuchos::RCP<Observable>
+Teuchos::RCP<ObservableAmanzi>
 CreateObservable(Teuchos::ParameterList& coord_plist,
                  Teuchos::ParameterList& observable_plist,
                  Teuchos::ParameterList& units_plist,
                  Teuchos::RCP<const AmanziMesh::Mesh> mesh)
 {
-  Teuchos::RCP<Observable> observe;
+  Teuchos::RCP<ObservableAmanzi> observe;
   std::string var = observable_plist.get<std::string>("variable");
   std::string func = observable_plist.get<std::string>("functional");
   std::string region = observable_plist.get<std::string>("region");

--- a/src/mpc/ObservableFactory.hh
+++ b/src/mpc/ObservableFactory.hh
@@ -21,9 +21,9 @@
 
 namespace Amanzi {
 
-class Observable;
+class ObservableAmanzi;
 
-Teuchos::RCP<Observable>
+Teuchos::RCP<ObservableAmanzi>
 CreateObservable(Teuchos::ParameterList& coord_plist,
                  Teuchos::ParameterList& observable_plist,
                  Teuchos::ParameterList& units_plist,

--- a/src/mpc/ObservableLineSegment.hh
+++ b/src/mpc/ObservableLineSegment.hh
@@ -18,7 +18,7 @@
 
 namespace Amanzi {
 
-class ObservableLineSegment : public virtual Observable {
+class ObservableLineSegment : public virtual ObservableAmanzi {
  public:
   ObservableLineSegment(std::string variable,
                         std::string region,
@@ -41,13 +41,14 @@ class ObservableLineSegment : public virtual Observable {
 };
 
 
+inline
 ObservableLineSegment::ObservableLineSegment(std::string variable,
                                              std::string region,
                                              std::string functional,
                                              Teuchos::ParameterList& plist,
                                              Teuchos::ParameterList& units_plist,
                                              Teuchos::RCP<const AmanziMesh::Mesh> mesh)
-  : Observable(variable, region, functional, plist, units_plist, mesh)
+  : ObservableAmanzi(variable, region, functional, plist, units_plist, mesh)
 {
   interpolation_ = plist.get<std::string>("interpolation", "linear");
   weighting_ = plist.get<std::string>("weighting", "none");
@@ -55,7 +56,7 @@ ObservableLineSegment::ObservableLineSegment(std::string variable,
 };
 
 
-int
+inline int
 ObservableLineSegment::ComputeRegionSize()
 {
   //int mesh_block_size;
@@ -87,7 +88,7 @@ ObservableLineSegment::ComputeRegionSize()
 }
 
 
-void
+inline void
 ObservableLineSegment::ComputeObservation(State& S,
                                           double* value,
                                           double* volume,
@@ -100,7 +101,7 @@ ObservableLineSegment::ComputeObservation(State& S,
 }
 
 
-void
+inline void
 ObservableLineSegment::ComputeInterpolationPoints(
   Teuchos::RCP<const AmanziGeometry::Region> reg_ptr)
 {

--- a/src/mpc/ObservableLineSegmentAqueous.hh
+++ b/src/mpc/ObservableLineSegmentAqueous.hh
@@ -41,6 +41,7 @@ class ObservableLineSegmentAqueous : public ObservableAqueous, public Observable
 };
 
 
+inline
 ObservableLineSegmentAqueous::ObservableLineSegmentAqueous(
   std::string variable,
   std::string region,
@@ -48,19 +49,19 @@ ObservableLineSegmentAqueous::ObservableLineSegmentAqueous(
   Teuchos::ParameterList& plist,
   Teuchos::ParameterList& units_plist,
   Teuchos::RCP<const AmanziMesh::Mesh> mesh)
-  : Observable(variable, region, functional, plist, units_plist, mesh),
+  : ObservableAmanzi(variable, region, functional, plist, units_plist, mesh),
     ObservableAqueous(variable, region, functional, plist, units_plist, mesh),
     ObservableLineSegment(variable, region, functional, plist, units_plist, mesh){};
 
 
-int
+inline int
 ObservableLineSegmentAqueous::ComputeRegionSize()
 {
   return ObservableLineSegment::ComputeRegionSize();
 }
 
 
-void
+inline void
 ObservableLineSegmentAqueous::ComputeObservation(State& S,
                                                  double* value,
                                                  double* volume,
@@ -102,7 +103,7 @@ ObservableLineSegmentAqueous::ComputeObservation(State& S,
 }
 
 
-void
+inline void
 ObservableLineSegmentAqueous::InterpolatedValues(State& S,
                                                  std::string& var,
                                                  std::string& interpolation,

--- a/src/mpc/ObservableLineSegmentSolute.hh
+++ b/src/mpc/ObservableLineSegmentSolute.hh
@@ -43,7 +43,7 @@ ObservableLineSegmentSolute::ObservableLineSegmentSolute(std::string variable,
                                                          Teuchos::ParameterList& plist,
                                                          Teuchos::ParameterList& units_plist,
                                                          Teuchos::RCP<const AmanziMesh::Mesh> mesh)
-  : Observable(variable, region, functional, plist, units_plist, mesh),
+  : ObservableAmanzi(variable, region, functional, plist, units_plist, mesh),
     ObservableSolute(variable, region, functional, plist, units_plist, mesh),
     ObservableLineSegment(variable, region, functional, plist, units_plist, mesh){};
 

--- a/src/mpc/ObservableSolute.cc
+++ b/src/mpc/ObservableSolute.cc
@@ -31,7 +31,7 @@ ObservableSolute::ObservableSolute(std::string variable,
                                    Teuchos::ParameterList& plist,
                                    Teuchos::ParameterList& units_plist,
                                    Teuchos::RCP<const AmanziMesh::Mesh> mesh)
-  : Observable(variable, region, functional, plist, units_plist, mesh){};
+  : ObservableAmanzi(variable, region, functional, plist, units_plist, mesh){};
 
 
 /* ******************************************************************

--- a/src/mpc/ObservableSolute.hh
+++ b/src/mpc/ObservableSolute.hh
@@ -22,7 +22,7 @@
 
 namespace Amanzi {
 
-class ObservableSolute : public virtual Observable {
+class ObservableSolute : public virtual ObservableAmanzi {
  public:
   ObservableSolute(std::string variable,
                    std::string region,

--- a/src/mpc/test/mpc_alquimia_transport.xml
+++ b/src/mpc/test/mpc_alquimia_transport.xml
@@ -386,17 +386,16 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="1.0e+5"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="1.0e+5"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow_reactive_transport.xml
+++ b/src/mpc/test/mpc_coupled_flow_reactive_transport.xml
@@ -1296,14 +1296,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="10000000.0000000000"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -1313,6 +1305,13 @@
 
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="10000000.0000000000"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>
@@ -1323,14 +1322,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="10000000.0000000000"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -1340,6 +1331,13 @@
 
       <ParameterList name="physical models and assumptions">
         <Parameter name="eos lookup table" type="string" value="false"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="10000000.0000000000"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/mpc/test/mpc_coupled_reactive_transport.xml
+++ b/src/mpc/test/mpc_coupled_reactive_transport.xml
@@ -598,14 +598,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+6"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+5"/>
-      <Parameter name="initial timestep (s)" type="double" value="2.0e+5"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.20"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0e-17"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -617,6 +609,13 @@
 
       </ParameterList>
 
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="2.0e+5"/>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="chemistry fracture">
@@ -625,14 +624,6 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="1.0e-12"/>
-      <Parameter name="max timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+4"/>
-      <Parameter name="initial timestep (s)" type="double" value="2.0e+5"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.2"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -642,6 +633,13 @@
 
       <ParameterList name="initial conditions">
 
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="2.0e+5"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/mpc/test/mpc_flow_reactive_transport.xml
+++ b/src/mpc/test/mpc_flow_reactive_transport.xml
@@ -218,6 +218,13 @@
         <Parameter name="verbosity level" type="string" value="high"/>
       </ParameterList>
 
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="10000000000000000.0"/>
+        </ParameterList>
+      </ParameterList>
+
     </ParameterList>
 
     <ParameterList name="transport">

--- a/src/mpc/test/mpc_flow_reactive_transport.xml
+++ b/src/mpc/test/mpc_flow_reactive_transport.xml
@@ -544,7 +544,7 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="ion_exchange_sites">
+      <ParameterList name="cation_exchange_capacity">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
             <Parameter name="region" type="string" value="Soil_1"/>

--- a/src/mpc/test/mpc_reactive_transport.xml
+++ b/src/mpc/test/mpc_reactive_transport.xml
@@ -99,7 +99,6 @@
     <ParameterList name="chemistry">
       <Parameter name="PK type" type="string" value="chemistry pk"/>
       <Parameter name="component names" type="Array(string)" value="{Na+, Ca++, Mg++, Cl-}"/>
-      <Parameter name="initial timestep (s)" type="double" value="20.0"/>
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="50"/>
       <Parameter name="log formulation" type="bool" value="true"/>
@@ -131,6 +130,13 @@
       <Parameter name="number of component concentrations" type="int" value="4"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="20.0"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/mpc/test/mpc_reactive_transport.xml
+++ b/src/mpc/test/mpc_reactive_transport.xml
@@ -112,7 +112,7 @@
           <Parameter name="function" type="string" value="list was moved to state"/>
         </ParameterList>
 
-        <ParameterList name="ion_exchange_sites">
+        <ParameterList name="cation_exchange_capacity">
           <Parameter name="function" type="string" value="list was moved to state"/>
         </ParameterList>
 
@@ -483,7 +483,7 @@
         </ParameterList>
       </ParameterList>
 
-      <ParameterList name="ion_exchange_sites">
+      <ParameterList name="cation_exchange_capacity">
         <ParameterList name="function">
           <ParameterList name="Soil_1">
             <Parameter name="region" type="string" value="Soil_1"/>

--- a/src/pks/PK_Physical.cc
+++ b/src/pks/PK_Physical.cc
@@ -26,7 +26,7 @@ namespace Amanzi {
 void
 PK_Physical::State_to_Solution(const Tag& tag, TreeVector& solution)
 {
-  solution.SetData(S_->GetPtrW<CompositeVector>(key_, tag, name()));
+  solution.SetData(S_->GetPtrW<CompositeVector>(key_, tag, passwd_));
 }
 
 

--- a/src/pks/PK_Physical.hh
+++ b/src/pks/PK_Physical.hh
@@ -40,6 +40,7 @@ class PK_Physical : virtual public PK {
   {
     domain_ = Keys::readDomain(*plist_, "domain", "domain");
     mesh_ = S_->GetMesh(domain_);
+    passwd_ = name();
   };
 
   // Virtual destructor
@@ -60,7 +61,8 @@ class PK_Physical : virtual public PK {
   Key domain_;
 
   // solution and evaluator
-  std::string key_;
+  Key key_;
+  std::string passwd_;
 
   // debugger for dumping vectors
   Teuchos::RCP<Debugger> db_;

--- a/src/pks/PK_Physical_Default.cc
+++ b/src/pks/PK_Physical_Default.cc
@@ -25,7 +25,11 @@ namespace Amanzi {
 void
 PK_Physical_Default::parseParameterList()
 {
-  key_ = Keys::readKey(*plist_, domain_, "primary variable");
+  if (key_.empty()) {
+    key_ = Keys::readKey(*plist_, domain_, "primary variable");
+  } else {
+    key_ = Keys::readKey(*plist_, domain_, "primary variable", key_);
+  }
   passwd_ = plist_->get<std::string>("primary variable password", name());
 
   // require primary variable evaluators

--- a/src/pks/PK_Physical_Default.hh
+++ b/src/pks/PK_Physical_Default.hh
@@ -48,9 +48,6 @@ class PK_Physical_Default : public PK_Physical {
 
   void ChangedSolutionPK(const Tag& tag) override;
 
- protected:
-  // solution and evaluator
-  Key passwd_;
 };
 
 

--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -473,8 +473,9 @@ Alquimia_PK::updateSubstate()
 
   // internal things
   if (operator_split_) {
-    // OPERATOR SPLITTING -- TCC old is NEXT here!
-    substate_.tcc_old = &*S_->Get<CompositeVector>(key_, tag_next_).ViewComponent("cell", false);
+    // operator splitting -- that tag used here depends upon the code.  In
+    // Amanzi, this is COPY, in ATS, this is NEXT
+    substate_.tcc_old = &*S_->Get<CompositeVector>(key_, operator_split_tag_).ViewComponent("cell", false);
   } else {
     // stand-alone chemistry -- TCC is CURRENT here!
     substate_.tcc_old = &*S_->Get<CompositeVector>(key_, tag_current_).ViewComponent("cell", false);

--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -489,6 +489,11 @@ Alquimia_PK::updateSubstate()
     substate_.mineral_specific_surface_area_new = &*S_->GetW<CompositeVector>(mineral_specific_surface_area_key_, tag_next_, passwd_).ViewComponent("cell", false);
   }
 
+  if (number_sorption_sites_ > 0) {
+    substate_.sorption_site_density_old = &*S_->Get<CompositeVector>(sorp_site_density_key_, tag_current_).ViewComponent("cell", false);
+    substate_.sorption_site_density_new = &*S_->GetW<CompositeVector>(sorp_site_density_key_, tag_next_, passwd_).ViewComponent("cell", false);
+  }
+
   if (!total_sorbed_key_.empty()) {
     substate_.total_sorbed_old = &*S_->Get<CompositeVector>(total_sorbed_key_, tag_current_).ViewComponent("cell", false);
     substate_.total_sorbed_new = &*S_->GetW<CompositeVector>(total_sorbed_key_, tag_next_, passwd_).ViewComponent("cell", false);
@@ -496,7 +501,7 @@ Alquimia_PK::updateSubstate()
 
   if (number_ion_exchange_sites_ > 0) {
     substate_.cation_exchange_capacity_old = &*S_->Get<CompositeVector>(cation_exchange_capacity_key_, tag_current_).ViewComponent("cell", false);
-    substate_.cation_exchange_capacity_old = &*S_->GetW<CompositeVector>(cation_exchange_capacity_key_, tag_next_, passwd_).ViewComponent("cell", false);
+    substate_.cation_exchange_capacity_new = &*S_->GetW<CompositeVector>(cation_exchange_capacity_key_, tag_next_, passwd_).ViewComponent("cell", false);
   }
 
   // aux data
@@ -643,6 +648,7 @@ Alquimia_PK::XMLParameters()
     Teuchos::ParameterList& geochem_conditions =
       initial_conditions->sublist("geochemical conditions");
     ParseChemicalConditionRegions_(geochem_conditions, chem_initial_conditions_);
+
     if (chem_initial_conditions_.empty()) {
       if (plist_->isSublist("initial conditions")) {
         msg << "Alquimia_PK::XMLParameters(): No geochemical conditions were found in "

--- a/src/pks/chemistry/Alquimia_PK.hh
+++ b/src/pks/chemistry/Alquimia_PK.hh
@@ -68,6 +68,129 @@ Most details are provided in the trimmed PFloTran file *1d-tritium-trim.in*.
 namespace Amanzi {
 namespace AmanziChemistry {
 
+namespace Impl {
+
+//
+// This struct is used to avoid doing State->Get<>() calls within the inner
+// (cell-based) loop.
+//
+// NOTE: ATS at least needs both old and new values of these vectors, under the
+// possiblity where chemistry succeeds but something else fails afterwards
+// (e.g. transport fails due to invalid timestep size), and we therefore need
+// to recover the old chemistry values.
+//
+// It may be worth looking into whether this can actually happen in our
+// assorted coupling schemes.  In particular, I think it is possible that this
+// cannot happen if transport+chemistry is subcycled relative to flow (but it
+// probably can if they are not subcycled) relative to flow.
+//
+// If it can't happen, then we don't need to be able to back up, and so we
+// don't need to store duplicate copies in memory.
+//
+// We'll support it for now under the assumption it is possible, and then can
+// always construct both the const and non-const versions of these pointers
+// with the same vector/tag.  --ETC
+//
+// NOTE: names here match names in Amanzi, not in Alquimia.  Translation
+// between Amanzi and Alquimia happens in the Copy{To,From}Alquimia() methods.
+//
+struct AlquimiaSubstate {
+  // alquimia state
+  Epetra_MultiVector const * mass_density_liquid;  // [kg m^-3]
+  Epetra_MultiVector const * porosity; // [-]
+  Epetra_MultiVector const * temperature; // [K]
+
+  Epetra_MultiVector const * tcc_old; // [mol L^-1]
+  Epetra_MultiVector * tcc_new;
+
+  Epetra_MultiVector const * total_sorbed_old; // [mol m^-3 (bulk)]
+  Epetra_MultiVector * total_sorbed_new;
+
+  Epetra_MultiVector const * mineral_volume_fraction_old; // [-]
+  Epetra_MultiVector * mineral_volume_fraction_new;
+  Epetra_MultiVector const * mineral_specific_surface_area_old; // [m^2 (mineral) m^-3 (bulk)]
+  Epetra_MultiVector * mineral_specific_surface_area_new;
+
+  Epetra_MultiVector const * sorption_site_density_old; // [mol m^-3 (bulk)]
+  Epetra_MultiVector * sorption_site_density_new;
+
+  Epetra_MultiVector const * cation_exchange_capacity_old; // [mol m^-3 (bulk)]
+  Epetra_MultiVector * cation_exchange_capacity_new; // [mol m^-3 (bulk)]
+
+  // alquimia properties -- input only, so only at old time
+  Epetra_MultiVector const * saturation_liquid; // [-]
+
+  Epetra_MultiVector const * isotherm_kd; // [kg H2O m^-3 (bulk)]
+  Epetra_MultiVector const * isotherm_freundlich_n; // [-]
+  Epetra_MultiVector const * isotherm_langmuir_b; // [-]
+
+  Epetra_MultiVector const * mineral_rate_constant; // [mol m^-2 s^-1]
+  Epetra_MultiVector const * aqueous_kinetic_rate_constant; // [s^-1]
+
+  // aux data
+  Epetra_MultiVector const * aux_data_old;
+  Epetra_MultiVector * aux_data_new;
+
+  // aux output -- note, no need for "old" variants of these, output only
+  Epetra_MultiVector * pH; // [-]
+  Epetra_MultiVector * mineral_saturation_index; // [mol s^-1 m^-3]
+  Epetra_MultiVector * mineral_reaction_rate; // [mol s^-1 m^-3 (bulk)]
+  Epetra_MultiVector * aqueous_kinetic_rate; // [??]
+  Epetra_MultiVector * primary_free_ion_concentration; // [mol L^-1]
+  Epetra_MultiVector * primary_activity_coefficient; // [-]
+  Epetra_MultiVector * secondary_free_ion_concentration; // [mol L^-1]
+  Epetra_MultiVector * secondary_activity_coefficient; // [-]
+  // Epetra_MultiVector * gas_partial_pressure; // [-]
+
+  AlquimiaSubstate()
+    : mass_density_liquid(nullptr),
+      porosity(nullptr),
+      temperature(nullptr),
+      tcc_old(nullptr),
+      tcc_new(nullptr),
+      total_sorbed_new(nullptr),
+      total_sorbed_old(nullptr),
+      mineral_volume_fraction_old(nullptr),
+      mineral_volume_fraction_new(nullptr),
+      mineral_specific_surface_area_old(nullptr),
+      mineral_specific_surface_area_new(nullptr),
+      sorption_site_density_old(nullptr),
+      sorption_site_density_new(nullptr),
+      cation_exchange_capacity_old(nullptr),
+      cation_exchange_capacity_new(nullptr),
+      saturation_liquid(nullptr),
+      isotherm_kd(nullptr),
+      isotherm_freundlich_n(nullptr),
+      isotherm_langmuir_b(nullptr),
+      mineral_rate_constant(nullptr),
+      aqueous_kinetic_rate_constant(nullptr),
+      aux_data_old(nullptr),
+      aux_data_new(nullptr),
+      pH(nullptr),
+      mineral_saturation_index(nullptr),
+      mineral_reaction_rate(nullptr),
+      aqueous_kinetic_rate(nullptr),
+      primary_free_ion_concentration(nullptr),
+      primary_activity_coefficient(nullptr),
+      secondary_free_ion_concentration(nullptr),
+      secondary_activity_coefficient(nullptr) {}
+};
+
+} // namespace Impl
+
+
+//
+// This is just shorthand for passing all four Alquimia data structures
+//
+struct AlquimiaBeaker {
+  AlquimiaState state;
+  AlquimiaProperties properties;
+  AlquimiaAuxiliaryData aux_data;
+  AlquimiaAuxiliaryOutputData aux_output;
+};
+
+
+
 #ifdef ALQUIMIA_ENABLED
 class Alquimia_PK : public Chemistry_PK {
  public:
@@ -83,87 +206,91 @@ class Alquimia_PK : public Chemistry_PK {
   virtual void Setup() override final;
   virtual void Initialize() override final;
 
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) override final;
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag) override final;
-  virtual void CalculateDiagnostics(const Tag& tag) override final { extra_chemistry_output_data(); }
+  Teuchos::RCP<AmanziChemistry::ChemistryEngine> getChemEngine() {
+    return chem_engine_;
+  }
+  void copyToAlquimia(int cell, AlquimiaBeaker& beaker);
+  void updateSubstate() override;
 
-  // Ben: the following routine provides the interface for
-  // output of auxillary cellwise data from chemistry
-  Teuchos::RCP<Epetra_MultiVector> extra_chemistry_output_data() override final;
-
-  // Copies the chemistry state in the given cell to the given Alquimia containers.
-  void CopyToAlquimia(int cell_id,
-                      AlquimiaProperties& mat_props,
-                      AlquimiaState& state,
-                      AlquimiaAuxiliaryData& aux_data,
-                      const Tag& water_tag = Tags::DEFAULT);
-
- private:
-  // Copy cell state to the given Alquimia containers taking
-  // the aqueous components from the given multivector.
-  void CopyToAlquimia(int cell_id,
-                      Teuchos::RCP<const Epetra_MultiVector> aqueous_components,
-                      AlquimiaProperties& mat_props,
-                      AlquimiaState& state,
-                      AlquimiaAuxiliaryData& aux_data,
-                      const Tag& water_tag = Tags::DEFAULT);
-
-  // Copy the data in the given Alquimia containers to the given cell state.
-  // The aqueous components are placed into the given multivector.
-  void CopyFromAlquimia(const int cell,
-                        const AlquimiaProperties& mat_props,
-                        const AlquimiaState& state,
-                        const AlquimiaAuxiliaryData& aux_data,
-                        const AlquimiaAuxiliaryOutputData& aux_output,
-                        Teuchos::RCP<Epetra_MultiVector> aqueous_components);
-
-  int InitializeSingleCell(int cell, const std::string& condition);
-  int AdvanceSingleCell(double dt, Teuchos::RCP<Epetra_MultiVector>& aquesous_components, int cell);
-
-  void ParseChemicalConditionRegions(const Teuchos::ParameterList& param_list,
-                                     std::map<std::string, std::string>& conditions);
+ protected:
   void XMLParameters();
 
-  void CopyAlquimiaStateToAmanzi(const int cell,
-                                 const AlquimiaProperties& mat_props,
-                                 const AlquimiaState& state,
-                                 const AlquimiaAuxiliaryData& aux_data,
-                                 const AlquimiaAuxiliaryOutputData& aux_output,
-                                 Teuchos::RCP<Epetra_MultiVector> aquesous_components);
+  // Copies the chemistry state to or from the given cell to the Alquimia containers.
+  void copyFromAlquimia_(int cell);
 
-  void ComputeNextTimeStep();
+  // customization implementations
+  void copyFields_(const Tag& tag_dest, const Tag& tag_source) override;
+  int advanceSingleCell_(int cell, double dt) override;
 
-  // maps
-  void InitializeAuxNamesMap_();
+  // initialize the cell using a given condition
+  int initializeSingleCell_(int cell, const std::string& condition);
+
+  void ParseChemicalConditionRegions_(const Teuchos::ParameterList& param_list,
+          std::map<std::string, std::string>& conditions);
+
 
  private:
-  // Time stepping controls. Some parameters are defined in the base class
-  std::string dt_control_method_;
+  // Amanzi variable names:
+  // -- water state
+  Key dens_key_;
+  Key poro_key_;
+  Key temp_key_;
+  Key sat_key_;
 
+  // -- internal chemistry state
+  Key total_sorbed_key_;
+  Key mineral_volume_fraction_key_;
+  Key mineral_specific_surface_area_key_;
+  Key sorp_site_density_key_;
+  Key cation_exchange_capacity_key_;
+  Key aux_data_key_;
+
+  // -- chemistry parameters
+  Key isotherm_kd_key_;
+  Key isotherm_freundlich_n_key_;
+  Key isotherm_langmuir_b_key_;
+  Key mineral_rate_constant_key_;
+  Key aqueous_kinetic_rate_constant_key_;
+
+  // -- aux output (diagnostics)
+  Key pH_key_;
+  Key mineral_sat_index_key_;
+  Key mineral_reaction_rate_key_;
+  Key aqueous_kinetic_rate_key_;
+  Key primary_ion_conc_key_;
+  Key primary_activity_coef_key_;
+  Key secondary_ion_conc_key_;
+  Key secondary_activity_coef_key_;
+  // Key gas_partial_pressure_key_;
+
+  // sizes and metadata
+  int number_aqueous_kinetics_;
+  std::vector<std::string> aqueous_kinetics_names_;
+
+  int number_sorption_sites_;
+  std::vector<std::string> sorption_site_names_;
+
+  int number_ion_exchange_sites_;
+  std::vector<std::string> ion_exchange_site_names_;
+
+  int number_isotherm_species_;
+  int number_aux_data_;
+
+  std::map<std::string, Key> aux_out_names_;
+  std::vector<std::vector<std::string> > aux_out_subfield_names_;
+
+  Impl::AlquimiaSubstate substate_;
+
+  // Alquimia data structures
+  AlquimiaBeaker beaker_;
+  Teuchos::RCP<AmanziChemistry::ChemistryEngine> chem_engine_;
   bool chem_initialized_;
 
-  // Alquimia data structures for interface with Amanzi.
-  AlquimiaState alq_state_;
-  AlquimiaProperties alq_mat_props_;
-  AlquimiaAuxiliaryData alq_aux_data_;
-  AlquimiaAuxiliaryOutputData alq_aux_output_;
 
   // Mapping of region names to geochemical condition names. A region is identified
   // by a string, and all cells within a region will have all geochemical
   // conditions in the corresponding condition vector applied to them.
   std::map<std::string, std::string> chem_initial_conditions_;
-
-  double current_time_;
-  double saved_time_;
-
-  // Auxiliary output data, requested by and stored within Amanzi.
-  std::vector<std::string> aux_names_;
-  std::vector<std::vector<std::string>> aux_subfield_names_;
-  Teuchos::RCP<Epetra_MultiVector> aux_output_;
-  Teuchos::RCP<Epetra_MultiVector> aux_data_;
-
-  std::vector<std::vector<int>> map_;
-  std::vector<std::string> mineral_names_, primary_names_;
 
  private:
   // factory registration

--- a/src/pks/chemistry/Alquimia_PK.hh
+++ b/src/pks/chemistry/Alquimia_PK.hh
@@ -111,8 +111,8 @@ struct AlquimiaSubstate {
   Epetra_MultiVector const * mineral_specific_surface_area_old; // [m^2 (mineral) m^-3 (bulk)]
   Epetra_MultiVector * mineral_specific_surface_area_new;
 
-  Epetra_MultiVector const * sorption_site_density_old; // [mol m^-3 (bulk)]
-  Epetra_MultiVector * sorption_site_density_new;
+  Epetra_MultiVector const * surface_site_density_old; // [mol m^-3 (bulk)]
+  Epetra_MultiVector * surface_site_density_new;
 
   Epetra_MultiVector const * cation_exchange_capacity_old; // [mol m^-3 (bulk)]
   Epetra_MultiVector * cation_exchange_capacity_new; // [mol m^-3 (bulk)]
@@ -125,7 +125,7 @@ struct AlquimiaSubstate {
   Epetra_MultiVector const * isotherm_langmuir_b; // [-]
 
   Epetra_MultiVector const * mineral_rate_constant; // [mol m^-2 s^-1]
-  Epetra_MultiVector const * aqueous_kinetic_rate_constant; // [s^-1]
+  Epetra_MultiVector const * first_order_decay_rate_constant; // [s^-1]
 
   // aux data
   Epetra_MultiVector const * aux_data_old;
@@ -154,8 +154,8 @@ struct AlquimiaSubstate {
       mineral_volume_fraction_new(nullptr),
       mineral_specific_surface_area_old(nullptr),
       mineral_specific_surface_area_new(nullptr),
-      sorption_site_density_old(nullptr),
-      sorption_site_density_new(nullptr),
+      surface_site_density_old(nullptr),
+      surface_site_density_new(nullptr),
       cation_exchange_capacity_old(nullptr),
       cation_exchange_capacity_new(nullptr),
       saturation_liquid(nullptr),
@@ -163,7 +163,7 @@ struct AlquimiaSubstate {
       isotherm_freundlich_n(nullptr),
       isotherm_langmuir_b(nullptr),
       mineral_rate_constant(nullptr),
-      aqueous_kinetic_rate_constant(nullptr),
+      first_order_decay_rate_constant(nullptr),
       aux_data_old(nullptr),
       aux_data_new(nullptr),
       pH(nullptr),
@@ -241,7 +241,7 @@ class Alquimia_PK : public Chemistry_PK {
   Key total_sorbed_key_;
   Key mineral_volume_fraction_key_;
   Key mineral_specific_surface_area_key_;
-  Key sorp_site_density_key_;
+  Key surface_site_density_key_;
   Key cation_exchange_capacity_key_;
   Key aux_data_key_;
 
@@ -250,7 +250,7 @@ class Alquimia_PK : public Chemistry_PK {
   Key isotherm_freundlich_n_key_;
   Key isotherm_langmuir_b_key_;
   Key mineral_rate_constant_key_;
-  Key aqueous_kinetic_rate_constant_key_;
+  Key first_order_decay_rate_constant_key_;
 
   // -- aux output (diagnostics)
   Key pH_key_;

--- a/src/pks/chemistry/Alquimia_PK.hh
+++ b/src/pks/chemistry/Alquimia_PK.hh
@@ -277,7 +277,7 @@ class Alquimia_PK : public Chemistry_PK {
   int number_aux_data_;
 
   std::map<std::string, Key> aux_out_names_;
-  std::vector<std::vector<std::string> > aux_out_subfield_names_;
+  std::map<std::string, std::vector<std::string> > aux_out_subfield_names_;
 
   Impl::AlquimiaSubstate substate_;
 

--- a/src/pks/chemistry/Amanzi_PK.cc
+++ b/src/pks/chemistry/Amanzi_PK.cc
@@ -33,7 +33,9 @@
 #include "Mesh.hh"
 #include "Beaker.hh"
 #include "errors.hh"
+#include "PK_Helpers.hh"
 #include "exceptions.hh"
+#include "message.hh"
 #include "SimpleThermoDatabase.hh"
 #include "VerboseObject.hh"
 
@@ -54,8 +56,19 @@ Amanzi_PK::Amanzi_PK(Teuchos::ParameterList& pk_tree,
                      const Teuchos::RCP<Teuchos::ParameterList>& glist,
                      const Teuchos::RCP<State>& S,
                      const Teuchos::RCP<TreeVector>& soln)
-  : PK(pk_tree, glist, S, soln), Chemistry_PK(pk_tree, glist, S, soln), chem_(NULL), dt_global_(0.0)
+  : PK(pk_tree, glist, S, soln),
+    Chemistry_PK(pk_tree, glist, S, soln),
+    chem_(NULL),
+    dt_global_(0.0),
+    glist_(glist)
+{}
+
+
+void
+Amanzi_PK::parseParameterList()
 {
+  Chemistry_PK::parseParameterList();
+
   // obtain key of fields
   tcc_key_ = Keys::getKey(domain_, "total_component_concentration");
   poro_key_ = plist_->get<std::string>("porosity key", Keys::getKey(domain_, "porosity"));
@@ -91,15 +104,15 @@ Amanzi_PK::Amanzi_PK(Teuchos::ParameterList& pk_tree,
   InitializeSorptionSites(plist_, S_->ICList());
 
   // grab the component names
-  comp_names_.clear();
-  Teuchos::RCP<Teuchos::ParameterList> cd_list = Teuchos::sublist(glist, "cycle driver", true);
+  aqueous_comp_names_.clear();
+  Teuchos::RCP<Teuchos::ParameterList> cd_list = Teuchos::sublist(glist_, "cycle driver", true);
   if (cd_list->isParameter("component names")) {
-    comp_names_ = cd_list->get<Teuchos::Array<std::string>>("component names").toVector();
+    aqueous_comp_names_ = cd_list->get<Teuchos::Array<std::string>>("component names").toVector();
   } else {
     Errors::Message msg("Amanzi_PK: Cycle Driver has no input parameter component names.");
     Exceptions::amanzi_throw(msg);
   }
-  number_aqueous_components_ = comp_names_.size();
+  number_aqueous_components_ = aqueous_comp_names_.size();
   number_free_ion_ = number_aqueous_components_;
   number_total_sorbed_ = number_aqueous_components_;
 
@@ -130,6 +143,131 @@ void
 Amanzi_PK::Setup()
 {
   Chemistry_PK::Setup();
+
+  bool amanzi_physics = plist_->isSublist("physical models and assumptions");
+
+  // require flow fields
+  S_->Require<CV_t, CVS_t>(poro_key_, Tags::DEFAULT, poro_key_)
+    .SetMesh(mesh_)
+    ->SetGhosted(false)
+    ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+  S_->RequireEvaluator(poro_key_, Tags::DEFAULT);
+
+  if (!S_->HasRecord(saturation_key_, Tags::DEFAULT)) {
+    S_->Require<CV_t, CVS_t>(saturation_key_, Tags::DEFAULT, saturation_key_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+    S_->RequireEvaluator(saturation_key_, Tags::DEFAULT);
+  }
+  // REMOVE after #646 is fixed
+  // meanwhile we check for the physics module via presence of a particular sublist
+  if (!S_->HasRecord(saturation_key_, Tags::CURRENT) && !amanzi_physics) {
+    S_->Require<CV_t, CVS_t>(saturation_key_, Tags::CURRENT, saturation_key_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+    S_->RequireEvaluator(saturation_key_, Tags::CURRENT);
+  }
+
+  S_->Require<CV_t, CVS_t>(fluid_den_key_, Tags::DEFAULT, fluid_den_key_)
+    .SetMesh(mesh_)
+    ->SetGhosted(false)
+    ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+  S_->RequireEvaluator(fluid_den_key_, Tags::DEFAULT);
+
+  // require transport fields
+  std::vector<std::string>::const_iterator it;
+  S_->Require<CV_t, CVS_t>(tcc_key_, tag_next_, passwd_, aqueous_comp_names_)
+    .SetMesh(mesh_)
+    ->SetGhosted(true)
+    ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+
+  // require minerals
+  if (number_mineral_components_ > 0) {
+    S_->Require<CV_t, CVS_t>(min_vol_frac_key_, tag_next_, passwd_, mineral_comp_names_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_mineral_components_);
+
+    S_->Require<CV_t, CVS_t>(min_ssa_key_, tag_next_, passwd_, mineral_comp_names_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_mineral_components_);
+
+    S_->Require<CV_t, CVS_t>(mineral_rate_constant_key_, tag_next_, passwd_, mineral_comp_names_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_mineral_components_);
+  }
+
+  // require sorption sites
+  if (number_sorption_sites_ > 0) {
+    std::vector<std::string> ss_names_cv, scfsc_names_cv;
+    for (it = sorption_site_names_.begin(); it != sorption_site_names_.end(); ++it) {
+      ss_names_cv.push_back(*it + std::string(" sorption site"));
+      scfsc_names_cv.push_back(*it + std::string(" surface complex free site conc"));
+    }
+
+    // -- register two fields
+    S_->Require<CV_t, CVS_t>(sorp_sites_key_, tag_next_, passwd_, ss_names_cv)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_sorption_sites_);
+    S_->Require<CV_t, CVS_t>(surf_cfsc_key_, tag_next_, passwd_, scfsc_names_cv)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_sorption_sites_);
+  }
+
+  if (using_sorption_) {
+    S_->Require<CV_t, CVS_t>(total_sorbed_key_, tag_next_, passwd_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+
+    if (using_sorption_isotherms_) {
+      S_->Require<CV_t, CVS_t>(isotherm_kd_key_, tag_next_, passwd_)
+        .SetMesh(mesh_)
+        ->SetGhosted(false)
+        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+
+      S_->Require<CV_t, CVS_t>(isotherm_freundlich_n_key_, tag_next_, passwd_)
+        .SetMesh(mesh_)
+        ->SetGhosted(false)
+        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+
+      S_->Require<CV_t, CVS_t>(isotherm_langmuir_b_key_, tag_next_, passwd_)
+        .SetMesh(mesh_)
+        ->SetGhosted(false)
+        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+    }
+  }
+
+  // ion
+  if (number_aqueous_components_ > 0) {
+    S_->Require<CV_t, CVS_t>(free_ion_species_key_, tag_next_, passwd_, aqueous_comp_names_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+
+    S_->Require<CV_t, CVS_t>(primary_activity_coeff_key_, tag_next_, passwd_, aqueous_comp_names_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
+  }
+
+  if (number_ion_exchange_sites_ > 0) {
+    S_->Require<CV_t, CVS_t>(ion_exchange_sites_key_, tag_next_, passwd_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_ion_exchange_sites_);
+
+    S_->Require<CV_t, CVS_t>(ion_exchange_ref_cation_conc_key_, tag_next_, passwd_)
+      .SetMesh(mesh_)
+      ->SetGhosted(false)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_ion_exchange_sites_);
+  }
 
   if (!S_->HasRecord(prev_saturation_key_)) {
     S_->Require<CV_t, CVS_t>(prev_saturation_key_, Tags::DEFAULT, passwd_)
@@ -174,7 +312,54 @@ Amanzi_PK::Initialize()
   // initialization using base class
   Chemistry_PK::Initialize();
 
+  // Aqueous species
+  if (number_aqueous_components_ > 0) {
+    if (!S_->GetRecordW(tcc_key_, passwd_).initialized()) {
+      InitializeCVField(S_, *vo_, tcc_key_, tag_next_, passwd_, 0.0);
+    }
+    set_aqueous_components(
+      S_->GetPtrW<CompositeVector>(tcc_key_, tag_next_, passwd_)->ViewComponent("cell", false));
+
+    InitializeCVField(S_, *vo_, primary_activity_coeff_key_, tag_next_, passwd_, 1.0);
+    InitializeCVField(S_, *vo_, free_ion_species_key_, tag_next_, passwd_, 1.0e-9);
+
+    // Sorption sites: all will have a site density, but we can default to zero
+    if (using_sorption_) {
+      InitializeCVField(S_, *vo_, total_sorbed_key_, tag_next_, passwd_, 0.0);
+    }
+
+    // Sorption isotherms: Kd required, Langmuir and Freundlich optional
+    if (using_sorption_isotherms_) {
+      InitializeCVField(S_, *vo_, isotherm_kd_key_, tag_next_, passwd_, -1.0);
+      InitializeCVField(S_, *vo_, isotherm_freundlich_n_key_, tag_next_, passwd_, 1.0);
+      InitializeCVField(S_, *vo_, isotherm_langmuir_b_key_, tag_next_, passwd_, 1.0);
+    }
+  }
+
+  // Minerals: vol frac and surface areas
+  if (number_mineral_components_ > 0) {
+    InitializeCVField(S_, *vo_, min_vol_frac_key_, tag_next_, passwd_, 0.0);
+    InitializeCVField(S_, *vo_, min_ssa_key_, tag_next_, passwd_, 1.0);
+  }
+
+  // Ion exchange sites: default to 1
+  if (number_ion_exchange_sites_ > 0) {
+    InitializeCVField(S_, *vo_, ion_exchange_sites_key_, tag_next_, passwd_, 1.0);
+    InitializeCVField(S_, *vo_, ion_exchange_ref_cation_conc_key_, tag_next_, passwd_, 1.0);
+  }
+
+  if (number_sorption_sites_ > 0) {
+    InitializeCVField(S_, *vo_, sorp_sites_key_, tag_next_, passwd_, 1.0);
+    InitializeCVField(S_, *vo_, surf_cfsc_key_, tag_next_, passwd_, 1.0);
+  }
+
+  // auxiliary fields
+  InitializeCVField(S_, *vo_, alquimia_aux_data_key_, tag_next_, passwd_, 0.0);
   InitializeCVFieldFromCVField(S_, *vo_, prev_saturation_key_, saturation_key_, passwd_);
+
+  // miscaleneous controls
+  initial_conditions_time_ = plist_->get<double>("initial conditions time", S_->get_time());
+
 
   auto tcc = S_->GetPtrW<CV_t>(tcc_key_, Tags::DEFAULT, passwd_)->ViewComponent("cell", true);
 
@@ -204,12 +389,12 @@ Amanzi_PK::Initialize()
 
   // check names of primary species
   int nprimary = chem_->primary_species().size();
-  if (nprimary == comp_names_.size()) {
+  if (nprimary == aqueous_comp_names_.size()) {
     for (int i = 0; i < nprimary; ++i) {
       std::string species_name = chem_->primary_species().at(i).name();
-      if (comp_names_[i] != species_name) {
+      if (aqueous_comp_names_[i] != species_name) {
         Errors::Message msg;
-        msg << "Amanzi PK: mismatch of name: \"" << comp_names_[i] << "\" and \"" << species_name
+        msg << "Amanzi PK: mismatch of name: \"" << aqueous_comp_names_[i] << "\" and \"" << species_name
             << "\". Compare XML and BGD lists.";
         Exceptions::amanzi_throw(msg);
       }
@@ -236,7 +421,7 @@ Amanzi_PK::Initialize()
   }
 
   // print statistics
-  try {
+  // try {
     vo_->Write(Teuchos::VERB_HIGH, "Initializing chemistry in cell 0...\n");
     chem_->Display();
     vo_->Write(Teuchos::VERB_HIGH, "Initial speciation calculations in cell 0...\n");
@@ -248,10 +433,10 @@ Amanzi_PK::Initialize()
       vo_->Write(Teuchos::VERB_HIGH, "\nTest solution of initial conditions in cell 0:\n");
       chem_->DisplayResults();
     }
-  } catch (Exceptions::Amanzi_exception& geochem_err) {
-    ierr = 1;
-    internal_msg = geochem_err.what();
-  }
+  // } catch (Exceptions::Amanzi_exception& geochem_err) {
+  //   ierr = 1;
+  //   internal_msg = geochem_err.what();
+  // }
 
   ErrorAnalysis(ierr, internal_msg);
 
@@ -366,20 +551,81 @@ Amanzi_PK::XMLParameters()
       }
     }
   }
-
-  // misc other chemistry flags
-  dt_control_method_ = plist_->get<std::string>("timestep control method", "fixed");
-  dt_max_ = plist_->get<double>("max timestep (s)", 9.9e+9);
-  dt_next_ = plist_->get<double>("initial timestep (s)", dt_max_);
-  dt_cut_factor_ = plist_->get<double>("timestep cut factor", 2.0);
-  dt_increase_factor_ = plist_->get<double>("timestep increase factor", 1.2);
-
-  dt_cut_threshold_ = plist_->get<int>("timestep cut threshold", 8);
-  dt_increase_threshold_ = plist_->get<int>("timestep increase threshold", 4);
-
-  num_successful_steps_ = 0;
 }
 
+
+/* ******************************************************************
+* Process names of materials
+******************************************************************* */
+void
+Amanzi_PK::InitializeMinerals(Teuchos::RCP<Teuchos::ParameterList> plist)
+{
+  mineral_comp_names_.clear();
+  if (plist->isParameter("minerals")) {
+    mineral_comp_names_ = plist->get<Teuchos::Array<std::string>>("minerals").toVector();
+  }
+
+  number_mineral_components_ = mineral_comp_names_.size();
+}
+
+
+/* ******************************************************************
+* Process names of sorption sites
+* NOTE: Do we need to worry about sorption sites?
+******************************************************************* */
+void
+Amanzi_PK::InitializeSorptionSites(Teuchos::RCP<Teuchos::ParameterList> plist,
+                                      Teuchos::ParameterList& ic_list)
+{
+  sorption_site_names_.clear();
+  if (plist->isParameter("sorption sites")) {
+    sorption_site_names_ = plist->get<Teuchos::Array<std::string>>("sorption sites").toVector();
+  }
+
+  number_sorption_sites_ = sorption_site_names_.size();
+  using_sorption_ = (number_sorption_sites_ > 0);
+
+  // check if there is an initial condition for ion_exchange_sites
+  number_ion_exchange_sites_ = 0;
+  using_sorption_isotherms_ = false;
+
+  if (ic_list.isSublist(ion_exchange_sites_key_)) {
+    // there is currently only at most one site...
+    using_sorption_ = true;
+    number_ion_exchange_sites_ = 1;
+  }
+
+  if (ic_list.isSublist(isotherm_kd_key_)) {
+    using_sorption_ = true;
+    using_sorption_isotherms_ = true;
+  }
+
+  KeyTriple split;
+  bool is_ds = Keys::splitDomainSet(isotherm_kd_key_, split);
+  if (is_ds) {
+    Key lifted_key = Keys::getKey(std::get<0>(split), "*", std::get<2>(split));
+
+    if (ic_list.isSublist(lifted_key)) {
+      using_sorption_ = true;
+      using_sorption_isotherms_ = true;
+    }
+  }
+
+  if (ic_list.isSublist(sorp_sites_key_)) { using_sorption_ = true; }
+
+  // in the old version, this was only in the Block sublist... may need work?
+  if (plist->isParameter("Cation Exchange Capacity")) {
+    using_sorption_ = true;
+    number_ion_exchange_sites_ = 1;
+  }
+
+  // surely this doesn't need to be in the global plist?
+  if (glist_->isSublist("thermodynamic database")) {
+    if (glist_->sublist("thermodynamic database").isSublist("isotherms")) {
+      using_sorption_ = true;
+    }
+  }
+}
 
 /* *******************************************************************
 * Requires that Beaker::Setup() has already been called!
@@ -447,8 +693,8 @@ Amanzi_PK::CopyCellStateToBeakerState(int c, Teuchos::RCP<Epetra_MultiVector> aq
   }
 
   // minerals
-  if (number_minerals_ > 0) {
-    for (int i = 0; i < number_minerals_; ++i) {
+  if (number_mineral_components_ > 0) {
+    for (int i = 0; i < number_mineral_components_; ++i) {
       beaker_state_.mineral_volume_fraction[i] = (*bf_.mineral_vf)[i][c];
       beaker_state_.mineral_specific_surface_area.at(i) = (*bf_.mineral_ssa)[i][c];
     }
@@ -532,8 +778,8 @@ Amanzi_PK::CopyBeakerStructuresToCellState(int c,
   }
 
   // minerals
-  if (number_minerals_ > 0) {
-    for (int i = 0; i < number_minerals_; ++i) {
+  if (number_mineral_components_ > 0) {
+    for (int i = 0; i < number_mineral_components_; ++i) {
       (*bf_.mineral_vf)[i][c] = beaker_state_.mineral_volume_fraction.at(i);
       (*bf_.mineral_ssa)[i][c] = beaker_state_.mineral_specific_surface_area.at(i);
     }
@@ -583,98 +829,29 @@ Amanzi_PK::CopyBeakerStructuresToCellState(int c,
 }
 
 
-/* ******************************************************************
-* This function advances concentrations in the auxialiry vector
-* aqueous_components_ (defined in the base class). This vector must
-* be set up using routine set_aqueous_components(). Tipically, it
-* contains values advected by the transport PK.
-******************************************************************* */
-bool
-Amanzi_PK::AdvanceStep(double t_old, double t_new, bool reinit)
+int
+Amanzi_PK::advanceSingleCell_(int cell, double dt)
 {
-  bool failed(false);
-  std::string internal_msg;
+  CopyCellStateToBeakerState(cell, aqueous_components_);
 
-  dt_ = t_new - t_old;
+  int num_itrs = 0;
+  if (beaker_state_.saturation > saturation_tolerance_) {
+    try {
+      // create a backup copy of the components
+      chem_->CopyState(beaker_state_, &beaker_state_copy_);
 
-  // this assumes that initial and final are flow times FIXME
-  dt_global_ = S_->final_time() - S_->initial_time();
-  dt_int_ = t_new - S_->initial_time();
+      // chemistry computations for this cell
+      num_itrs = chem_->ReactionStep(&beaker_state_, beaker_parameters_, dt);
 
-  int num_itrs, max_itrs(0), min_itrs(10000000), avg_itrs(0);
-  int cmax(-1), ierr(0);
-
-  // Ensure dependencies are filled
-  S_->GetEvaluator(poro_key_).Update(*S_, name_);
-  S_->GetEvaluator(fluid_den_key_).Update(*S_, name_);
-  S_->GetEvaluator(saturation_key_).Update(*S_, name_);
-
-  const auto& sat_vec = *S_->Get<CV_t>(saturation_key_).ViewComponent("cell");
-
-  for (int c = 0; c < ncells_owned_; ++c) {
-    if (sat_vec[0][c] > saturation_tolerance_) {
-      CopyCellStateToBeakerState(c, aqueous_components_);
-      try {
-        // create a backup copy of the components
-        chem_->CopyState(beaker_state_, &beaker_state_copy_);
-
-        // chemistry computations for this cell
-        num_itrs = chem_->ReactionStep(&beaker_state_, beaker_parameters_, dt_);
-
-        if (max_itrs < num_itrs) {
-          max_itrs = num_itrs;
-          cmax = c;
-        }
-        if (min_itrs > num_itrs) { min_itrs = num_itrs; }
-        avg_itrs += num_itrs;
-      } catch (Exceptions::Amanzi_exception& geochem_err) {
-        ierr = 1;
-        internal_msg = geochem_err.what();
-        // chem_->DisplayComponents(beaker_state_);
-        break;
-      } catch (...) {
-        ierr = 1;
-        internal_msg = "unknown error";
-        break;
-      }
-
-      if (ierr == 0) CopyBeakerStructuresToCellState(c, aqueous_components_);
-      // TODO: was porosity etc changed? copy some place
+    } catch (Exceptions::Amanzi_exception& geochem_err) {
+      num_itrs = -1;
+    } catch (...) {
+      num_itrs = -1;
     }
+
+    if (num_itrs >= 0) CopyBeakerStructuresToCellState(cell, aqueous_components_);
   }
-
-  ErrorAnalysis(ierr, internal_msg);
-
-  int tmp0(min_itrs), tmp1(max_itrs), tmp2(avg_itrs), tmp3(ncells_owned_), ncells_total;
-  mesh_->getComm()->MinAll(&tmp0, &min_itrs, 1);
-  mesh_->getComm()->MaxAll(&tmp1, &max_itrs, 1);
-  mesh_->getComm()->SumAll(&tmp2, &avg_itrs, 1);
-  mesh_->getComm()->SumAll(&tmp3, &ncells_total, 1);
-
-  std::stringstream ss;
-  ss << "Newton itrs: " << min_itrs << "/" << max_itrs << "/" << avg_itrs / ncells_total
-     << ", maximum in gid=" << mesh_->getEntityGID(AmanziMesh::CELL, cmax) 
-     << ", dt=" << dt_ << std::endl;
-  vo_->Write(Teuchos::VERB_HIGH, ss.str());
-
-  // update time control parameters
-  num_successful_steps_++;
-  num_iterations_ = max_itrs;
-
-  if (!failed) EstimateNextTimeStep_(t_old, t_new);
-  return failed;
-}
-
-
-/* ******************************************************************
-* The MPC will call this function to signal to the process kernel
-* that it has accepted the state update, thus, the PK should update
-* possible auxilary state variables here
-******************************************************************* */
-void
-Amanzi_PK::CommitStep(double t_old, double t_new, const Tag& tag)
-{
-  EstimateNextTimeStep_(t_old, t_new);
+  return num_itrs;
 }
 
 
@@ -710,7 +887,7 @@ Amanzi_PK::InitializeBeakerFields_()
       S_->GetW<CV_t>(ion_exchange_ref_cation_conc_key_, tag, passwd_).ViewComponent("cell");
   }
 
-  if (number_minerals_ > 0) {
+  if (number_mineral_components_ > 0) {
     bf_.mineral_vf = S_->GetW<CV_t>(min_vol_frac_key_, tag, passwd_).ViewComponent("cell");
     bf_.mineral_ssa = S_->GetW<CV_t>(min_ssa_key_, tag, passwd_).ViewComponent("cell");
   }
@@ -733,41 +910,6 @@ Amanzi_PK::InitializeBeakerFields_()
 
   if (beaker_state_.surface_complex_free_site_conc.size() > 0) {
     bf_.surface_complex = S_->GetW<CV_t>(surf_cfsc_key_, tag, passwd_).ViewComponent("cell");
-  }
-}
-
-
-/* ******************************************************************
-* We estimate stable timestep and report it to CD via get_dt()
-******************************************************************* */
-void
-Amanzi_PK::EstimateNextTimeStep_(double t_old, double t_new)
-{
-  if (dt_control_method_ == "simple") {
-    double dt_next_tmp(dt_next_);
-
-    if ((num_successful_steps_ == 0) || (num_iterations_ >= dt_cut_threshold_)) {
-      dt_next_ /= dt_cut_factor_;
-    } else if (num_successful_steps_ >= dt_increase_threshold_) {
-      dt_next_ *= dt_increase_factor_;
-      num_successful_steps_ = 1;
-    }
-
-    dt_next_ = std::min(dt_next_, dt_max_);
-
-    // synchronize processors since update of control parameters was
-    // made in many places.
-    double tmp(dt_next_);
-    mesh_->getComm()->MinAll(&tmp, &dt_next_, 1);
-
-    if (dt_next_tmp != dt_next_ && vo_->getVerbLevel() >= Teuchos::VERB_EXTREME) {
-      Teuchos::OSTab tab = vo_->getOSTab();
-      *vo_->os() << "controller changed dt_next to " << dt_next_ << std::endl;
-    }
-  } else if (dt_control_method_ == "fixed") {
-    // dt_next could be reduced by the base PK. To avoid small timestep, we reset it here.
-    dt_next_ = std::max(dt_, t_new - t_old); // due to subcycling
-    dt_next_ = std::min(dt_next_, dt_max_);
   }
 }
 
@@ -810,6 +952,37 @@ Amanzi_PK::set_chemistry_output_names(std::vector<std::string>* names)
     names->push_back(*name);
   }
 }
+
+
+/* *******************************************************************
+* I/O or error messages
+******************************************************************* */
+void
+Amanzi_PK::ErrorAnalysis(int ierr, std::string& internal_msg)
+{
+  int tmp_out[2], tmp_in[2] = { ierr, (int)internal_msg.size() };
+  mesh_->getComm()->MaxAll(tmp_in, tmp_out, 2);
+
+  if (tmp_out[0] != 0) {
+    // update time control parameters
+    num_successful_steps_ = 0;
+
+    // get at least one error message
+    int n = tmp_out[1];
+    int msg_out[n + 1], msg_in[n + 1], m(mesh_->getComm()->MyPID());
+    internal_msg.resize(n);
+
+    Errors::encode_string(internal_msg, n, m, msg_in);
+    mesh_->getComm()->MaxAll(msg_in, msg_out, n + 1);
+    Errors::decode_string(msg_out, n, internal_msg);
+
+    vo_->Write(Teuchos::VERB_HIGH, internal_msg);
+
+    Errors::Message msg(internal_msg);
+    Exceptions::amanzi_throw(msg);
+  }
+}
+
 
 } // namespace AmanziChemistry
 } // namespace Amanzi

--- a/src/pks/chemistry/Amanzi_PK.hh
+++ b/src/pks/chemistry/Amanzi_PK.hh
@@ -100,12 +100,8 @@ class Amanzi_PK : public Chemistry_PK {
   Teuchos::RCP<Epetra_MultiVector> extra_chemistry_output_data();
   void set_chemistry_output_names(std::vector<std::string>* names);
 
-  // -- get/set auxiliary tcc vector that now contains only aqueous components.
-  Teuchos::RCP<Epetra_MultiVector> aqueous_components() { return aqueous_components_; }
-  void set_aqueous_components(Teuchos::RCP<Epetra_MultiVector> tcc) { aqueous_components_ = tcc; }
-
   // functions used in Transport PK
-  void CopyCellStateToBeakerState(int c, Teuchos::RCP<Epetra_MultiVector> aqueous_components);
+  void CopyCellStateToBeakerState(int c);
 
   // access
   std::shared_ptr<Beaker> get_engine() { return chem_; }
@@ -127,7 +123,7 @@ class Amanzi_PK : public Chemistry_PK {
 
   void InitializeBeakerFields_();
 
-  void CopyBeakerStructuresToCellState(int c, Teuchos::RCP<Epetra_MultiVector> aqueous_components);
+  void CopyBeakerStructuresToCellState(int c);
   virtual int advanceSingleCell_(int cell, double dt) override;
   virtual void copyFields_(const Tag& tag_dest, const Tag& tag_source) override {}
 

--- a/src/pks/chemistry/Amanzi_PK.hh
+++ b/src/pks/chemistry/Amanzi_PK.hh
@@ -135,7 +135,7 @@ class Amanzi_PK : public Chemistry_PK {
   Key temperature_key_;
   Key min_vol_frac_key_;
   Key min_ssa_key_;
-  Key sorp_sites_key_;
+  Key surface_site_density_key_;
   Key surf_cfsc_key_;
   Key total_sorbed_key_;
   Key isotherm_kd_key_;
@@ -143,12 +143,12 @@ class Amanzi_PK : public Chemistry_PK {
   Key isotherm_langmuir_b_key_;
   Key free_ion_species_key_;
   Key primary_activity_coeff_key_;
-  Key ion_exchange_sites_key_;
+  Key cation_exchange_capacity_key_;
   Key ion_exchange_ref_cation_conc_key_;
   Key secondary_activity_coeff_key_;
   Key alquimia_aux_data_key_;
   Key mineral_rate_constant_key_;
-  Key first_order_decay_constant_key_;
+  Key first_order_decay_rate_constant_key_;
 
  private:
   std::shared_ptr<Beaker> chem_;

--- a/src/pks/chemistry/Amanzi_PK.hh
+++ b/src/pks/chemistry/Amanzi_PK.hh
@@ -89,27 +89,35 @@ class Amanzi_PK : public Chemistry_PK {
             const Teuchos::RCP<TreeVector>& soln);
 
   // members required by PK interface
-  virtual void Setup() final;
-  virtual void Initialize() final;
+  virtual void parseParameterList() override;
+  virtual void Setup() override final;
+  virtual void Initialize() override final;
 
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) final;
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag) final;
-  virtual void CalculateDiagnostics(const Tag& tag) final { extra_chemistry_output_data(); }
-
-  virtual std::string name() { return "chemistry amanzi"; }
+  virtual void CalculateDiagnostics(const Tag& tag) override final { extra_chemistry_output_data(); }
 
   // The following two routines provide the interface for
   // output of auxillary cellwise data from chemistry
   Teuchos::RCP<Epetra_MultiVector> extra_chemistry_output_data();
   void set_chemistry_output_names(std::vector<std::string>* names);
 
-  // functions used in Rransport PK
+  // -- get/set auxiliary tcc vector that now contains only aqueous components.
+  Teuchos::RCP<Epetra_MultiVector> aqueous_components() { return aqueous_components_; }
+  void set_aqueous_components(Teuchos::RCP<Epetra_MultiVector> tcc) { aqueous_components_ = tcc; }
+
+  // functions used in Transport PK
   void CopyCellStateToBeakerState(int c, Teuchos::RCP<Epetra_MultiVector> aqueous_components);
 
   // access
   std::shared_ptr<Beaker> get_engine() { return chem_; }
   const BeakerParameters& beaker_parameters() const { return beaker_parameters_; }
   BeakerState beaker_state() { return beaker_state_; }
+
+  void InitializeMinerals(Teuchos::RCP<Teuchos::ParameterList> plist);
+  void InitializeSorptionSites(Teuchos::RCP<Teuchos::ParameterList> plist, Teuchos::ParameterList& ic_list);
+
+  void ErrorAnalysis(int ierr, std::string& internal_msg);
+
+  virtual void updateSubstate() override {}
 
  private:
   void AllocateAdditionalChemistryStorage_();
@@ -120,11 +128,31 @@ class Amanzi_PK : public Chemistry_PK {
   void InitializeBeakerFields_();
 
   void CopyBeakerStructuresToCellState(int c, Teuchos::RCP<Epetra_MultiVector> aqueous_components);
-
-  void EstimateNextTimeStep_(double t_old, double t_new);
+  virtual int advanceSingleCell_(int cell, double dt) override;
+  virtual void copyFields_(const Tag& tag_dest, const Tag& tag_source) override {}
 
  protected:
-  Teuchos::RCP<TreeVector> soln_;
+  Key tcc_key_;
+  Key poro_key_;
+  Key saturation_key_;
+  Key fluid_den_key_;
+  Key temperature_key_;
+  Key min_vol_frac_key_;
+  Key min_ssa_key_;
+  Key sorp_sites_key_;
+  Key surf_cfsc_key_;
+  Key total_sorbed_key_;
+  Key isotherm_kd_key_;
+  Key isotherm_freundlich_n_key_;
+  Key isotherm_langmuir_b_key_;
+  Key free_ion_species_key_;
+  Key primary_activity_coeff_key_;
+  Key ion_exchange_sites_key_;
+  Key ion_exchange_ref_cation_conc_key_;
+  Key secondary_activity_coeff_key_;
+  Key alquimia_aux_data_key_;
+  Key mineral_rate_constant_key_;
+  Key first_order_decay_constant_key_;
 
  private:
   std::shared_ptr<Beaker> chem_;
@@ -134,14 +162,24 @@ class Amanzi_PK : public Chemistry_PK {
 
   Key prev_saturation_key_; // move to base class ???
 
-  std::string dt_control_method_;
   double dt_int_, dt_global_; // interpolation and global times
 
+  bool using_sorption_;
+  bool using_sorption_isotherms_;
+  int number_free_ion_, number_total_sorbed_;
+  int number_ion_exchange_sites_, number_sorption_sites_;
+  int number_aqueous_kinetics_;
+  std::vector<std::string> sorption_site_names_;
+  std::vector<std::string> aqueous_kinetics_names_;
+
+  Teuchos::RCP<Teuchos::ParameterList> glist_;
   std::vector<std::string> aux_names_;
   std::vector<int> aux_index_;
   Teuchos::RCP<Epetra_MultiVector> aux_data_;
 
   int ncells_owned_;
+
+  Teuchos::RCP<Epetra_MultiVector> aqueous_components_;
 
  private:
   // factory registration

--- a/src/pks/chemistry/BeakerFields.hh
+++ b/src/pks/chemistry/BeakerFields.hh
@@ -36,6 +36,9 @@ struct BeakerFields {
   Teuchos::RCP<Epetra_MultiVector> surface_complex;
 
   Teuchos::RCP<Epetra_MultiVector> ion_exchange_sites, ion_exchange_ref_cation_conc;
+
+  Teuchos::RCP<const Epetra_MultiVector> tcc_old;
+  Teuchos::RCP<Epetra_MultiVector> tcc_new;
 };
 
 } // namespace AmanziChemistry

--- a/src/pks/chemistry/BeakerFields.hh
+++ b/src/pks/chemistry/BeakerFields.hh
@@ -32,10 +32,10 @@ struct BeakerFields {
   Teuchos::RCP<Epetra_MultiVector> sorbed;
   Teuchos::RCP<Epetra_MultiVector> isotherm_kd, isotherm_freundlich_n, isotherm_langmuir_b;
 
-  Teuchos::RCP<Epetra_MultiVector> sorption_sites;
+  Teuchos::RCP<Epetra_MultiVector> surface_site_density;
   Teuchos::RCP<Epetra_MultiVector> surface_complex;
 
-  Teuchos::RCP<Epetra_MultiVector> ion_exchange_sites, ion_exchange_ref_cation_conc;
+  Teuchos::RCP<Epetra_MultiVector> cation_exchange_capacity, ion_exchange_ref_cation_conc;
 
   Teuchos::RCP<const Epetra_MultiVector> tcc_old;
   Teuchos::RCP<Epetra_MultiVector> tcc_new;

--- a/src/pks/chemistry/CMakeLists.txt
+++ b/src/pks/chemistry/CMakeLists.txt
@@ -69,7 +69,7 @@ add_install_include_file(${chem_inc_files})
 add_amanzi_library(chemistry_pk
                    SOURCE ${chem_src_files}
                    HEADERS ${chem_inc_files}
-                   LINK_LIBS ${GEOCHEM_LIBS} pks ${Epetra_LIBRARIES}
+                   LINK_LIBS ${GEOCHEM_LIBS} pks time_integration ${Epetra_LIBRARIES}
                              ${XERCES_LIBRARIES} ${XERCES_ICU_LIBRARIES})
 
 if (BUILD_TESTS AND ENABLE_Unstructured)
@@ -89,10 +89,11 @@ if (BUILD_TESTS AND ENABLE_Unstructured)
         file(COPY ${DataFiles} DESTINATION ${CHEMPK_BINARY_DIR}/test/)
     endif()
 
+
     add_amanzi_test(chemistry_amanzi_pk chemistry_amanzi_pk
                     KIND int
                     SOURCE test/Main.cc test/chemistry_amanzi_pk.cc
-                    LINK_LIBS chemistry_pk state pks data_structures operators
+                    LINK_LIBS chemistry_pk time_integration state pks data_structures operators
                               mesh_functions mesh mesh_factory error_handling
                               ${UnitTest_LIBRARIES} ${Teuchos_LIBRARIES} ${Epetra_LIBRARIES}
                               ${XERCES_LIBRARIES} ${XERCES_ICU_LIBRARIES} ${NOX_LIBRARIES}
@@ -102,7 +103,7 @@ if (BUILD_TESTS AND ENABLE_Unstructured)
       add_amanzi_test(chemistry_alquimia_pk chemistry_alquimia_pk
                       KIND int
                       SOURCE test/Main.cc test/chemistry_alquimia_pk.cc
-                      LINK_LIBS chemistry_pk state pks data_structures operators
+                      LINK_LIBS chemistry_pk time_integration state pks data_structures operators
                                 mesh_functions mesh mesh_factory error_handling
                                 ${UnitTest_LIBRARIES} ${Teuchos_LIBRARIES} ${Epetra_LIBRARIES}
                                 ${HDF5_LIBRARIES} ${XERCESC_LIBRARIES} ${XERCES_ICU_LIBRARIES}
@@ -117,7 +118,7 @@ if (BUILD_TESTS AND ENABLE_Unstructured)
       add_amanzi_test(chemistry_benchmarks_1d chemistry_benchmarks_1d
                       KIND int
                       SOURCE test/chemistry_benchmarks_1d.cc
-                      LINK_LIBS chemistry_pk state pks data_structures operators
+                      LINK_LIBS chemistry_pk time_integration state pks data_structures operators
                               mesh_functions mesh mesh_factory error_handling
                               ${UnitTest_LIBRARIES} ${Teuchos_LIBRARIES} ${Epetra_LIBRARIES}
                               ${HDF5_LIBRARIES} ${XERCESC_LIBRARIES} ${XERCES_ICU_LIBRARIES}

--- a/src/pks/chemistry/Chemistry_PK.cc
+++ b/src/pks/chemistry/Chemistry_PK.cc
@@ -11,50 +11,49 @@
   Chemistry PK
 
   Base class for chemical process kernels.
+
+  Handles timestep control, and generic advancing by cell.
 */
 
-#include "message.hh"
-
 // Chemistry
+#include "message.hh"
+#include "Reductions.hh"
+#include "PK_Helpers.hh"
+#include "TimestepControllerFactory.hh"
 #include "Chemistry_PK.hh"
 
 namespace Amanzi {
 namespace AmanziChemistry {
 
-using CV_t = CompositeVector;
-using CVS_t = CompositeVectorSpace;
-
 /* ******************************************************************
-* Default constructor that initializes all pointers to NULL
+* Standard PK constructor
 ****************************************************************** */
-Chemistry_PK::Chemistry_PK()
-  : passwd_("state"),
-    number_minerals_(0),
-    number_aqueous_kinetics_(0),
-    number_sorption_sites_(0),
-    using_sorption_(false),
-    using_sorption_isotherms_(false),
-    number_ion_exchange_sites_(0),
-    dt_(9.9e+9),
-    dt_max_(9.9e9){};
-
-
 Chemistry_PK::Chemistry_PK(Teuchos::ParameterList& pk_tree,
                            const Teuchos::RCP<Teuchos::ParameterList>& glist,
                            const Teuchos::RCP<State>& S,
                            const Teuchos::RCP<TreeVector>& soln)
-  : PK(pk_tree, glist, S, soln),
-    PK_Physical(pk_tree, glist, S, soln),
-    passwd_("state"),
-    glist_(glist),
-    number_minerals_(0),
-    number_aqueous_kinetics_(0),
-    number_sorption_sites_(0),
-    using_sorption_(false),
-    using_sorption_isotherms_(false),
-    number_ion_exchange_sites_(0),
-    dt_(9.9e+9),
-    dt_max_(9.9e9){};
+  : PK_Physical_Default(pk_tree, glist, S, soln),
+    PK(pk_tree, glist, S, soln),
+    number_aqueous_components_(0),
+    number_gaseous_components_(0),
+    number_mineral_components_(0),
+    dt_next_(-1.),
+    operator_split_(false)
+{
+  // note, we pass in null to the factory here to make sure there is no error
+  // control used, which doesn't make sense for this application.
+  timestep_controller_ = createTimestepController<TreeVector>(name_,
+          plist_->sublist("timestep controller"), S_, Teuchos::null, Teuchos::null);
+};
+
+
+double
+Chemistry_PK::get_dt()
+{
+  if (dt_next_ < 0.) dt_next_ = timestep_controller_->getInitialTimestep();
+  return dt_next_;
+}
+
 
 
 /* ******************************************************************
@@ -63,351 +62,116 @@ Chemistry_PK::Chemistry_PK(Teuchos::ParameterList& pk_tree,
 void
 Chemistry_PK::parseParameterList()
 {
+  // set the default primary variable.  Note this will be mangled with the
+  // domain.
+  key_ = "total_component_concentration";
+
+  PK_Physical_Default::parseParameterList();
+
+  // other parameters
   saturation_tolerance_ = plist_->get<double>("saturation tolerance", 1e-14);
+  operator_split_ = plist_->get<bool>("operator split", false);
 }
 
 
-/* ******************************************************************
-* Register fields and evaluators with the State
-******************************************************************* */
-void
-Chemistry_PK::Setup()
-{
-  bool amanzi_physics = plist_->isSublist("physical models and assumptions");
-
-  // require flow fields
-  S_->Require<CV_t, CVS_t>(poro_key_, Tags::DEFAULT, poro_key_)
-    .SetMesh(mesh_)
-    ->SetGhosted(false)
-    ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
-  S_->RequireEvaluator(poro_key_, Tags::DEFAULT);
-
-  if (!S_->HasRecord(saturation_key_, Tags::DEFAULT)) {
-    S_->Require<CV_t, CVS_t>(saturation_key_, Tags::DEFAULT, saturation_key_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
-    S_->RequireEvaluator(saturation_key_, Tags::DEFAULT);
-  }
-  // REMOVE after #646 is fixed
-  // meanwhile we check for the physics module via presence of a particular sublist
-  if (!S_->HasRecord(saturation_key_, Tags::CURRENT) && !amanzi_physics) {
-    S_->Require<CV_t, CVS_t>(saturation_key_, Tags::CURRENT, saturation_key_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
-    S_->RequireEvaluator(saturation_key_, Tags::CURRENT);
-  }
-
-  S_->Require<CV_t, CVS_t>(fluid_den_key_, Tags::DEFAULT, fluid_den_key_)
-    .SetMesh(mesh_)
-    ->SetGhosted(false)
-    ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
-  S_->RequireEvaluator(fluid_den_key_, Tags::DEFAULT);
-
-  // require transport fields
-  std::vector<std::string>::const_iterator it;
-  if (!S_->HasRecord(tcc_key_)) {
-    S_->Require<CV_t, CVS_t>(tcc_key_, tag_next_, passwd_, comp_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(true)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-  }
-
-  // require minerals
-  if (number_minerals_ > 0) {
-    S_->Require<CV_t, CVS_t>(min_vol_frac_key_, tag_next_, passwd_, mineral_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_minerals_);
-
-    S_->Require<CV_t, CVS_t>(min_ssa_key_, tag_next_, passwd_, mineral_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_minerals_);
-
-    S_->Require<CV_t, CVS_t>(mineral_rate_constant_key_, tag_next_, passwd_, mineral_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_minerals_);
-  }
-
-  // require aqueous kinetics
-  if (number_aqueous_kinetics_ > 0) {
-    std::vector<std::string> subfield_names;
-
-    for (it = aqueous_kinetics_names_.begin(); it != aqueous_kinetics_names_.end(); ++it) {
-      subfield_names.push_back(*it + std::string(" aq kin rate cnst"));
-    }
-
-    // -- register field
-    S_->Require<CV_t, CVS_t>(first_order_decay_constant_key_, tag_next_, passwd_, subfield_names)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_kinetics_);
-  }
-
-  // require sorption sites
-  if (number_sorption_sites_ > 0) {
-    std::vector<std::string> ss_names_cv, scfsc_names_cv;
-    for (it = sorption_site_names_.begin(); it != sorption_site_names_.end(); ++it) {
-      ss_names_cv.push_back(*it + std::string(" sorption site"));
-      scfsc_names_cv.push_back(*it + std::string(" surface complex free site conc"));
-    }
-
-    // -- register two fields
-    S_->Require<CV_t, CVS_t>(sorp_sites_key_, tag_next_, passwd_, ss_names_cv)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_sorption_sites_);
-    S_->Require<CV_t, CVS_t>(surf_cfsc_key_, tag_next_, passwd_, scfsc_names_cv)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_sorption_sites_);
-  }
-
-  if (using_sorption_) {
-    S_->Require<CV_t, CVS_t>(total_sorbed_key_, tag_next_, passwd_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-
-    if (using_sorption_isotherms_) {
-      S_->Require<CV_t, CVS_t>(isotherm_kd_key_, tag_next_, passwd_)
-        .SetMesh(mesh_)
-        ->SetGhosted(false)
-        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-
-      S_->Require<CV_t, CVS_t>(isotherm_freundlich_n_key_, tag_next_, passwd_)
-        .SetMesh(mesh_)
-        ->SetGhosted(false)
-        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-
-      S_->Require<CV_t, CVS_t>(isotherm_langmuir_b_key_, tag_next_, passwd_)
-        .SetMesh(mesh_)
-        ->SetGhosted(false)
-        ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-    }
-  }
-
-  // ion
-  if (number_aqueous_components_ > 0) {
-    S_->Require<CV_t, CVS_t>(free_ion_species_key_, tag_next_, passwd_, comp_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-
-    S_->Require<CV_t, CVS_t>(primary_activity_coeff_key_, tag_next_, passwd_, comp_names_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_aqueous_components_);
-  }
-
-  if (number_ion_exchange_sites_ > 0) {
-    S_->Require<CV_t, CVS_t>(ion_exchange_sites_key_, tag_next_, passwd_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_ion_exchange_sites_);
-
-    S_->Require<CV_t, CVS_t>(ion_exchange_ref_cation_conc_key_, tag_next_, passwd_)
-      .SetMesh(mesh_)
-      ->SetGhosted(false)
-      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, number_ion_exchange_sites_);
-  }
-}
-
-
-/* ******************************************************************
-* Most things are initialized through State, but State can only manage that
-* if they are always initialized.  If sane defaults are available, or they
-* can be derived from other initialized quantities, they are initialized
-* here, where we can manage that logic.
-******************************************************************* */
 void
 Chemistry_PK::Initialize()
 {
-  // Aqueous species
-  if (number_aqueous_components_ > 0) {
-    if (!S_->GetRecordW(tcc_key_, passwd_).initialized()) {
-      InitializeCVField(S_, *vo_, tcc_key_, tag_next_, passwd_, 0.0);
-    }
-    set_aqueous_components(
-      S_->GetPtrW<CompositeVector>(tcc_key_, tag_next_, passwd_)->ViewComponent("cell", false));
+  PK_Physical_Default::Initialize();
 
-    InitializeCVField(S_, *vo_, primary_activity_coeff_key_, tag_next_, passwd_, 1.0);
-    InitializeCVField(S_, *vo_, free_ion_species_key_, tag_next_, passwd_, 1.0e-9);
-
-    // Sorption sites: all will have a site density, but we can default to zero
-    if (using_sorption_) {
-      InitializeCVField(S_, *vo_, total_sorbed_key_, tag_next_, passwd_, 0.0);
-    }
-
-    // Sorption isotherms: Kd required, Langmuir and Freundlich optional
-    if (using_sorption_isotherms_) {
-      InitializeCVField(S_, *vo_, isotherm_kd_key_, tag_next_, passwd_, -1.0);
-      InitializeCVField(S_, *vo_, isotherm_freundlich_n_key_, tag_next_, passwd_, 1.0);
-      InitializeCVField(S_, *vo_, isotherm_langmuir_b_key_, tag_next_, passwd_, 1.0);
-    }
-  }
-
-  // Minerals: vol frac and surface areas
-  if (number_minerals_ > 0) {
-    InitializeCVField(S_, *vo_, min_vol_frac_key_, tag_next_, passwd_, 0.0);
-    InitializeCVField(S_, *vo_, min_ssa_key_, tag_next_, passwd_, 1.0);
-  }
-
-  // Aqueous kinetics
-  if (number_aqueous_kinetics_ > 0) {
-    InitializeCVField(S_, *vo_, first_order_decay_constant_key_, tag_next_, passwd_, 0.0);
-  }
-
-  // Ion exchange sites: default to 1
-  if (number_ion_exchange_sites_ > 0) {
-    InitializeCVField(S_, *vo_, ion_exchange_sites_key_, tag_next_, passwd_, 1.0);
-    InitializeCVField(S_, *vo_, ion_exchange_ref_cation_conc_key_, tag_next_, passwd_, 1.0);
-  }
-
-  if (number_sorption_sites_ > 0) {
-    InitializeCVField(S_, *vo_, sorp_sites_key_, tag_next_, passwd_, 1.0);
-    InitializeCVField(S_, *vo_, surf_cfsc_key_, tag_next_, passwd_, 1.0);
-  }
-
-  // auxiliary fields
-  InitializeCVField(S_, *vo_, alquimia_aux_data_key_, tag_next_, passwd_, 0.0);
-
-  // miscaleneous controls
+  // note, this is done here to allow the default value to be the time in state
   initial_conditions_time_ = plist_->get<double>("initial conditions time", S_->get_time());
 }
 
 
-/* ******************************************************************
-* Process names of materials
-******************************************************************* */
-void
-Chemistry_PK::InitializeMinerals(Teuchos::RCP<Teuchos::ParameterList> plist)
+/* *******************************************************************
+ * Take a timestep from t_old to t_new
+ ******************************************************************* */
+bool
+Chemistry_PK::AdvanceStep(double t_old, double t_new, bool reinit)
 {
-  mineral_names_.clear();
-  if (plist->isParameter("minerals")) {
-    mineral_names_ = plist->get<Teuchos::Array<std::string>>("minerals").toVector();
+  double dt = t_new - t_old;
+
+  Teuchos::OSTab tab = vo_->getOSTab();
+  if (vo_->os_OK(Teuchos::VERB_LOW))
+    *vo_->os() << "----------------------------------------------------------------" << std::endl
+               << "Advancing: t0 = " << t_old
+               << " t1 = " << t_new << " h = " << dt << std::endl
+               << "----------------------------------------------------------------" << std::endl;
+
+  // these assertions fail with Amanzi, does Amanzi not call State::set_time?  --ETC
+  // AMANZI_ASSERT(std::abs(S_->get_time(tag_current_) - t_old) < 1.e-4);
+  // AMANZI_ASSERT(std::abs(S_->get_time(tag_next_) - t_new) < 1.e-4);
+  State_to_Solution(Tags::NEXT, *solution_);
+
+  // Get the number of owned (non-ghost) cells for the mesh.
+  AmanziMesh::Entity_ID num_cells =
+    mesh_->getNumEntities(AmanziMesh::Entity_kind::CELL, AmanziMesh::Parallel_kind::OWNED);
+
+  // Now loop through all the cells and advance the chemistry.
+  int max_itrs(0), imax(-1);
+  int convergence_failure = 0;
+  for (AmanziMesh::Entity_ID cell = 0; cell != num_cells; ++cell) {
+    int num_itrs = advanceSingleCell_(cell, dt);
+    if (num_itrs >= 0) {
+      if (max_itrs < num_itrs) {
+        max_itrs = num_itrs;
+        imax = cell;
+      }
+    } else {
+      // Convergence failure. Compute the next timestep size.
+      convergence_failure = 1;
+      break;
+    }
   }
 
-  number_minerals_ = mineral_names_.size();
+  // broadcast and check for global failed step
+  bool failed = checkForError_(convergence_failure, max_itrs, imax);
+
+  // Compute the next global timestep.
+  dt_next_ = timestep_controller_->getTimestep(dt, max_itrs, !failed);
+  return failed;
 }
 
 
 /* ******************************************************************
-* Process names of sorption sites
-* NOTE: Do we need to worry about sorption sites?
+* Advance fields after a successful step
 ******************************************************************* */
 void
-Chemistry_PK::InitializeSorptionSites(Teuchos::RCP<Teuchos::ParameterList> plist,
-                                      Teuchos::ParameterList& ic_list)
+Chemistry_PK::CommitStep(double t_old, double t_new, const Tag& tag_next)
 {
-  sorption_site_names_.clear();
-  if (plist->isParameter("sorption sites")) {
-    sorption_site_names_ = plist->get<Teuchos::Array<std::string>>("sorption sites").toVector();
-  }
+  AMANZI_ASSERT(tag_next == tag_next_ || tag_next == Tags::NEXT);
+  Tag tag_current = tag_next == tag_next_ ? tag_current_ : Tags::CURRENT;
+  copyFields_(tag_current_, tag_next);
 
-  number_sorption_sites_ = sorption_site_names_.size();
-  using_sorption_ = (number_sorption_sites_ > 0);
-
-  // check if there is an initial condition for ion_exchange_sites
-  number_ion_exchange_sites_ = 0;
-  using_sorption_isotherms_ = false;
-
-  if (ic_list.isSublist(ion_exchange_sites_key_)) {
-    // there is currently only at most one site...
-    using_sorption_ = true;
-    number_ion_exchange_sites_ = 1;
-  }
-
-  if (ic_list.isSublist(isotherm_kd_key_)) {
-    using_sorption_ = true;
-    using_sorption_isotherms_ = true;
-  }
-
-  KeyTriple split;
-  bool is_ds = Keys::splitDomainSet(isotherm_kd_key_, split);
-  if (is_ds) {
-    Key lifted_key = Keys::getKey(std::get<0>(split), "*", std::get<2>(split));
-
-    if (ic_list.isSublist(lifted_key)) {
-      using_sorption_ = true;
-      using_sorption_isotherms_ = true;
-    }
-  }
-
-  if (ic_list.isSublist(sorp_sites_key_)) { using_sorption_ = true; }
-
-  // in the old version, this was only in the Block sublist... may need work?
-  if (plist->isParameter("Cation Exchange Capacity")) {
-    using_sorption_ = true;
-    number_ion_exchange_sites_ = 1;
-  }
-
-  // surely this doesn't need to be in the global plist?
-  if (glist_->isSublist("thermodynamic database")) {
-    if (glist_->sublist("thermodynamic database").isSublist("isotherms")) {
-      using_sorption_ = true;
-    }
-  }
+  PK_Physical_Default::CommitStep(t_old, t_new, tag_next);
 }
 
 
 /* *******************************************************************
 * I/O or error messages
 ******************************************************************* */
-void
-Chemistry_PK::ErrorAnalysis(int ierr, std::string& internal_msg)
+bool
+Chemistry_PK::checkForError_(int ierr, int max_itrs, int max_itrs_cell) const
 {
-  int tmp_out[2], tmp_in[2] = { ierr, (int)internal_msg.size() };
-  mesh_->getComm()->MaxAll(tmp_in, tmp_out, 2);
+  int ierr_l(ierr);
+  mesh_->getComm()->MaxAll(&ierr_l, &ierr, 1);
+  if (ierr) return true;
 
-  if (tmp_out[0] != 0) {
-    // update time control parameters
-    num_successful_steps_ = 0;
-    dt_next_ /= dt_cut_factor_;
+  Reductions::ValLoc itrs_l{ (double)max_itrs,
+    mesh_->getMap(AmanziMesh::Entity_kind::CELL, false).GID(max_itrs_cell) };
+  Reductions::ValLoc itrs_g;
+  ierr = Reductions::reduceAllMaxLoc(*mesh_->getComm(), itrs_l, itrs_g);
+  if (ierr) return true;
 
-    // get at least one error message
-    int n = tmp_out[1];
-    int msg_out[n + 1], msg_in[n + 1], m(mesh_->getComm()->MyPID());
-    internal_msg.resize(n);
-
-    Errors::encode_string(internal_msg, n, m, msg_in);
-    mesh_->getComm()->MaxAll(msg_in, msg_out, n + 1);
-    Errors::decode_string(msg_out, n, internal_msg);
-
-    vo_->Write(Teuchos::VERB_HIGH, internal_msg);
-
-    Errors::Message msg(internal_msg);
-    Exceptions::amanzi_throw(msg);
+  if (vo_->os_OK(Teuchos::VERB_MEDIUM)) {
+    Teuchos::OSTab tab = vo_->getOSTab();
+    *vo_->os() << "max Newton iterations: " << (int) itrs_g.value << " in cell "
+               << itrs_g.gid << std::endl;
   }
+  return false;
 }
 
-
-void
-Chemistry_PK::CopyFieldstoNewState(const Teuchos::RCP<State>& S_next)
-{
-  std::vector<std::string> fields = { min_vol_frac_key_,
-                                      min_ssa_key_,
-                                      sorp_sites_key_,
-                                      surf_cfsc_key_,
-                                      total_sorbed_key_,
-                                      isotherm_kd_key_,
-                                      isotherm_freundlich_n_key_,
-                                      isotherm_langmuir_b_key_,
-                                      free_ion_species_key_,
-                                      primary_activity_coeff_key_,
-                                      ion_exchange_sites_key_,
-                                      ion_exchange_ref_cation_conc_key_ };
-
-  for (int i = 0; i < fields.size(); ++i) {
-    if (S_->HasRecord(fields[i]) && S_next->HasRecord(fields[i])) {
-      *S_next->GetW<CompositeVector>(fields[i], tag_next_, passwd_).ViewComponent("cell") =
-        *S_->Get<CompositeVector>(fields[i]).ViewComponent("cell");
-    }
-  }
-}
 
 } // namespace AmanziChemistry
 } // namespace Amanzi

--- a/src/pks/chemistry/Chemistry_PK.cc
+++ b/src/pks/chemistry/Chemistry_PK.cc
@@ -158,11 +158,10 @@ Chemistry_PK::checkForError_(int ierr, int max_itrs, int max_itrs_cell) const
   mesh_->getComm()->MaxAll(&ierr_l, &ierr, 1);
   if (ierr) return true;
 
-  Reductions::ValLoc itrs_l{ (double)max_itrs,
+  Reductions::MaxLoc itrs_l{ (double)max_itrs,
     mesh_->getMap(AmanziMesh::Entity_kind::CELL, false).GID(max_itrs_cell) };
-  Reductions::ValLoc itrs_g;
-  ierr = Reductions::reduceAllMaxLoc(*mesh_->getComm(), itrs_l, itrs_g);
-  if (ierr) return true;
+
+  Reductions::MaxLoc itrs_g = Reductions::reduceAllMaxLoc(*mesh_->getComm(), itrs_l);
 
   if (vo_->os_OK(Teuchos::VERB_MEDIUM)) {
     Teuchos::OSTab tab = vo_->getOSTab();

--- a/src/pks/chemistry/Chemistry_PK.cc
+++ b/src/pks/chemistry/Chemistry_PK.cc
@@ -71,6 +71,9 @@ Chemistry_PK::parseParameterList()
   // other parameters
   saturation_tolerance_ = plist_->get<double>("saturation tolerance", 1e-14);
   operator_split_ = plist_->get<bool>("operator split", false);
+  if (operator_split_) {
+    operator_split_tag_ = Tag(plist_->get<std::string>("operator split tag"));
+  }
 }
 
 
@@ -103,6 +106,9 @@ Chemistry_PK::AdvanceStep(double t_old, double t_new, bool reinit)
   // AMANZI_ASSERT(std::abs(S_->get_time(tag_current_) - t_old) < 1.e-4);
   // AMANZI_ASSERT(std::abs(S_->get_time(tag_next_) - t_new) < 1.e-4);
   State_to_Solution(Tags::NEXT, *solution_);
+
+  // set up the substate for faster access
+  updateSubstate();
 
   // Get the number of owned (non-ghost) cells for the mesh.
   AmanziMesh::Entity_ID num_cells =

--- a/src/pks/chemistry/Chemistry_PK.hh
+++ b/src/pks/chemistry/Chemistry_PK.hh
@@ -79,13 +79,16 @@ The following parameters are common for all supported engines.
 #endif
 #include "Key.hh"
 #include "Mesh.hh"
-#include "PK_Physical.hh"
+#include "PK_Physical_Default.hh"
 #include "State.hh"
 
 namespace Amanzi {
+
+class TimestepController;
+
 namespace AmanziChemistry {
 
-class Chemistry_PK : public PK_Physical {
+class Chemistry_PK : public PK_Physical_Default {
  public:
   Chemistry_PK();
   Chemistry_PK(Teuchos::ParameterList& pk_tree,
@@ -96,83 +99,45 @@ class Chemistry_PK : public PK_Physical {
 
   // required members for PK interface
   virtual void parseParameterList() override;
-  virtual void Setup() override;
   virtual void Initialize() override;
 
-  virtual void set_dt(double dt) override{};
-  virtual double get_dt() override { return dt_next_; }
+  virtual bool AdvanceStep(double t_old, double t_new, bool reinit) override;
+  virtual void CommitStep(double t_old, double t_new, const Tag& tag) override;
 
-  // Required members for chemistry interface
-  // -- output of auxillary cellwise data from chemistry
-  virtual Teuchos::RCP<Epetra_MultiVector> extra_chemistry_output_data() = 0;
+  virtual void set_dt(double dt) override {};
+  virtual double get_dt() override;
 
-  // Basic capabilities
-  // -- get/set auxiliary tcc vector that now contains only aqueous components.
-  Teuchos::RCP<Epetra_MultiVector> aqueous_components() { return aqueous_components_; }
-  void set_aqueous_components(Teuchos::RCP<Epetra_MultiVector> tcc) { aqueous_components_ = tcc; }
-
-  // -- process various objects before/during setup phase
-  void InitializeMinerals(Teuchos::RCP<Teuchos::ParameterList> plist);
-  void InitializeSorptionSites(Teuchos::RCP<Teuchos::ParameterList> plist,
-                               Teuchos::ParameterList& ic_list);
-
-  virtual void CopyFieldstoNewState(const Teuchos::RCP<State>& S_next);
-  // -- access
-#ifdef ALQUIMIA_ENABLED
-  Teuchos::RCP<AmanziChemistry::ChemistryEngine> chem_engine() { return chem_engine_; }
-#endif
-
-  // -- output of error messages.
-  void ErrorAnalysis(int ierr, std::string& internal_msg);
-  int num_aqueous_components() { return number_aqueous_components_; }
+  virtual void updateSubstate() = 0;
 
  protected:
-  std::string passwd_;
-  Teuchos::RCP<Teuchos::ParameterList> glist_;
+  // error messages in Chemistry are rank-local.  This method does the
+  // AllReduce to check errors across ranks.
+  bool checkForError_(int ierr, int max_itrs, int max_itrs_cell) const;
 
+  // customization points for the beaker-level chemistry and substates
+  virtual int advanceSingleCell_(int cell, double dt) = 0;
+  virtual void copyFields_(const Tag& tag_dest, const Tag& tag_source) = 0;
+
+ protected:
   int number_aqueous_components_;
-  std::vector<std::string> comp_names_;
-  Teuchos::RCP<Epetra_MultiVector> aqueous_components_;
+  std::vector<std::string> aqueous_comp_names_;
 
-  int number_minerals_;
-  std::vector<std::string> mineral_names_;
+  int number_gaseous_components_;
+  std::vector<std::string> gaseous_comp_names_;
 
-  int number_aqueous_kinetics_;
-  std::vector<std::string> aqueous_kinetics_names_;
+  int number_mineral_components_;
+  std::vector<std::string> mineral_comp_names_;
 
-  int number_sorption_sites_, number_total_sorbed_;
-  std::vector<std::string> sorption_site_names_;
-  bool using_sorption_, using_sorption_isotherms_;
-
-  int number_free_ion_, number_ion_exchange_sites_;
   double saturation_tolerance_;
 
-  // names of state fields
-  Key tcc_key_;
-  Key poro_key_, saturation_key_, temperature_key_;
-  Key fluid_den_key_, molar_fluid_den_key_;
-  Key min_vol_frac_key_, min_ssa_key_;
-  Key sorp_sites_key_;
-  Key surf_cfsc_key_;
-  Key total_sorbed_key_;
-  Key isotherm_kd_key_, isotherm_freundlich_n_key_, isotherm_langmuir_b_key_;
-  Key free_ion_species_key_, primary_activity_coeff_key_;
-  Key ion_exchange_sites_key_, ion_exchange_ref_cation_conc_key_;
-  Key secondary_activity_coeff_key_;
-  Key alquimia_aux_data_key_;
-  Key mineral_rate_constant_key_;
-  Key first_order_decay_constant_key_;
-
-#ifdef ALQUIMIA_ENABLED
-  Teuchos::RCP<AmanziChemistry::ChemistryEngine> chem_engine_;
-#endif
-
   // time controls
-  int dt_cut_threshold_, dt_increase_threshold_;
-  double dt_, dt_min_, dt_max_, dt_prev_, dt_next_, dt_cut_factor_, dt_increase_factor_;
-
-  int num_iterations_, num_successful_steps_;
   double initial_conditions_time_;
+  Teuchos::RCP<TimestepController> timestep_controller_;
+  double dt_next_;
+  int num_iterations_, num_successful_steps_;
+
+  // discretization control
+  bool operator_split_;
 };
 
 } // namespace AmanziChemistry

--- a/src/pks/chemistry/Chemistry_PK.hh
+++ b/src/pks/chemistry/Chemistry_PK.hh
@@ -111,8 +111,9 @@ class Chemistry_PK : public PK_Physical_Default {
 
  protected:
   // error messages in Chemistry are rank-local.  This method does the
-  // AllReduce to check errors across ranks.
-  bool checkForError_(int ierr, int max_itrs, int max_itrs_cell) const;
+  // AllReduce to check errors across ranks.  Note that all three arguments are
+  // accepted by reference, and updated with their equivalent GLOBAL values.
+  void checkForError_(int& ierr, int& max_itrs, int& max_itrs_cell) const;
 
   // customization points for the beaker-level chemistry and substates
   virtual int advanceSingleCell_(int cell, double dt) = 0;
@@ -137,8 +138,8 @@ class Chemistry_PK : public PK_Physical_Default {
   int num_iterations_, num_successful_steps_;
 
   // discretization control
-  bool operator_split_;
-  Tag operator_split_tag_;
+  Tag tcc_tag_current_;
+  Tag tcc_tag_next_;
 };
 
 } // namespace AmanziChemistry

--- a/src/pks/chemistry/Chemistry_PK.hh
+++ b/src/pks/chemistry/Chemistry_PK.hh
@@ -138,6 +138,7 @@ class Chemistry_PK : public PK_Physical_Default {
 
   // discretization control
   bool operator_split_;
+  Tag operator_split_tag_;
 };
 
 } // namespace AmanziChemistry

--- a/src/pks/chemistry/test/Main.cc
+++ b/src/pks/chemistry/test/Main.cc
@@ -9,6 +9,7 @@
 
 #include <UnitTest++.h>
 #include <TestReporterStdout.h>
+#include <ThrowingTestReporter.h>
 
 #include "Teuchos_GlobalMPISession.hpp"
 
@@ -20,7 +21,11 @@ main(int argc, char* argv[])
 {
   Teuchos::GlobalMPISession mpiSession(&argc, &argv);
   Kokkos::initialize();
-  int status = UnitTest::RunAllTests();
+
+  UnitTest::TestReporterStdout base_reporter;
+  UnitTest::ThrowingTestReporter reporter(&base_reporter);
+  UnitTest::TestRunner runner(reporter);
+  int status = runner.RunTestsIf(UnitTest::Test::GetTestList(), NULL, UnitTest::True(), 0);
   Kokkos::finalize();
   return status;
 }

--- a/src/pks/chemistry/test/chemistry_alquimia_pk.xml
+++ b/src/pks/chemistry/test/chemistry_alquimia_pk.xml
@@ -214,18 +214,17 @@
       <Parameter name="activity model" type="string" value="unit"/>
       <Parameter name="maximum Newton iterations" type="int" value="100"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="15778463.0000000000"/>
-      <Parameter name="min timestep (s)" type="double" value="10000000000.0000000"/>
-      <Parameter name="initial timestep (s)" type="double" value="15778463.0000000000"/>
-      <Parameter name="timestep cut threshold" type="int" value="8"/>
-      <Parameter name="timestep cut factor" type="double" value="2.00000000000000000"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="initial conditions time" type="double" value="0e-17"/>
       <Parameter name="number of component concentrations" type="int" value="1"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="extreme"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="15778463.0000000000"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/pks/chemistry/test/chemistry_amanzi_pk.cc
+++ b/src/pks/chemistry/test/chemistry_amanzi_pk.cc
@@ -139,18 +139,14 @@ SUITE(GeochemistryTestsChemistryPK)
   {
     // make sure that we can initialize the pk and internal chemistry
     // object correctly based on the xml input....
-    try {
-      cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
-      cpk_->parseParameterList();
-      cpk_->Setup();
-      state_->Setup();
-      state_->InitializeFields();
-      state_->InitializeEvaluators();
-      cpk_->Initialize();
-    } catch (std::exception& e) {
-      std::cout << "ERROR test2 " << e.what() << std::endl;
-      throw e;
-    }
+    cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
+    cpk_->parseParameterList();
+    cpk_->Setup();
+    state_->Setup();
+    state_->InitializeFields();
+    state_->InitializeEvaluators();
+    cpk_->Initialize();
+
     // assume all is right with the world if we exited w/o an error
     CHECK_EQUAL(0, 0);
   }
@@ -158,18 +154,14 @@ SUITE(GeochemistryTestsChemistryPK)
 
   TEST_FIXTURE(ChemistryPKTest, ChemistryPK_get_chem_output_names)
   {
-    try {
-      cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
-      cpk_->parseParameterList();
-      cpk_->Setup();
-      state_->Setup();
-      state_->InitializeFields();
-      state_->InitializeEvaluators();
-      cpk_->Initialize();
-    } catch (std::exception& e) {
-      std::cout << "ERROR test3 " << e.what() << std::endl;
-      throw e;
-    }
+    cpk_ = new ac::Amanzi_PK(pk_tree_, glist_, state_, Teuchos::null);
+    cpk_->parseParameterList();
+    cpk_->Setup();
+    state_->Setup();
+    state_->InitializeFields();
+    state_->InitializeEvaluators();
+    cpk_->Initialize();
+
     std::vector<std::string> names;
     cpk_->set_chemistry_output_names(&names);
     std::cout << names.at(0) << "\n";

--- a/src/pks/chemistry/test/chemistry_amanzi_pk.xml
+++ b/src/pks/chemistry/test/chemistry_amanzi_pk.xml
@@ -94,6 +94,12 @@
       <Parameter name="maximum Newton iterations" type="int" value="150"/>
       <Parameter name="auxiliary data" type="Array(string)" value="{pH}"/>
       <Parameter name="log formulation" type="bool" value="true"/>
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="10000000000000000.0"/>
+        </ParameterList>
+      </ParameterList>
 
     </ParameterList>
 

--- a/src/pks/chemistry/test/chemistry_benchmarks_1d_b.xml
+++ b/src/pks/chemistry/test/chemistry_benchmarks_1d_b.xml
@@ -540,20 +540,19 @@
       <!--Parameter name="activity model" type="string" value="unit"/-->
       <Parameter name="maximum Newton iterations" type="int" value="50"/>
       <Parameter name="tolerance" type="double" value="9.99999999999999980e-13"/>
-      <Parameter name="max timestep (s)" type="double" value="2.20e+5"/>
-      <Parameter name="min timestep (s)" type="double" value="1.0e+10"/>
-      <Parameter name="initial timestep (s)" type="double" value="2.2e+5"/>
-      <Parameter name="timestep cut threshold" type="int" value="10"/>
-      <Parameter name="timestep cut factor" type="double" value="2.0"/>
-      <Parameter name="timestep increase threshold" type="int" value="4"/>
-      <Parameter name="timestep increase factor" type="double" value="1.19999999999999996"/>
-      <Parameter name="timestep control method" type="string" value="fixed"/>
       <Parameter name="auxiliary data" type="Array(string)" value="{pH}"/>
       <Parameter name="initial conditions time" type="double" value="0.0"/>
       <Parameter name="number of component concentrations" type="int" value="3"/>
       <Parameter name="log formulation" type="bool" value="true"/>
       <ParameterList name="verbose object">
         <Parameter name="verbosity level" type="string" value="high"/>
+      </ParameterList>
+
+      <ParameterList name="timestep controller" type="ParameterList">
+        <Parameter name="timestep controller type" type="string" value="fixed"/>
+        <ParameterList name="timestep controller fixed parameters" type="ParameterList">
+          <Parameter name="timestep [s]" type="double" value="2.2e+5"/>
+        </ParameterList>
       </ParameterList>
 
     </ParameterList>

--- a/src/pks/mpc_pk/FlowReactiveTransport_PK.cc
+++ b/src/pks/mpc_pk/FlowReactiveTransport_PK.cc
@@ -105,6 +105,7 @@ FlowReactiveTransport_PK::AdvanceStep(double t_old, double t_new, bool reinit)
       S_->set_intermediate_time(t_old + dt_done + dt_next);
       sub_pks_[slave_]->CommitStep(t_old + dt_done, t_old + dt_done + dt_next, Tags::DEFAULT);
       dt_done += dt_next;
+
       // allow dt to grow only when success
       dt_next = sub_pks_[slave_]->get_dt();
     }
@@ -116,6 +117,11 @@ FlowReactiveTransport_PK::AdvanceStep(double t_old, double t_new, bool reinit)
 
     // check for subcycling condition
     done = std::abs(t_old + dt_done - t_new) / (t_new - t_old) < 0.1 * min_dt_;
+  }
+
+  {
+    const Epetra_MultiVector& tcc = *S_->Get<CompositeVector>("total_component_concentration", tag_next_).ViewComponent("cell", false);
+    std::cout << "post FlowReactiveTransport Advance tcc = " << tcc[0][0] << std::endl;
   }
 
   // we reach this point when subcycling has been completed

--- a/src/pks/mpc_pk/PK_MPC.hh
+++ b/src/pks/mpc_pk/PK_MPC.hh
@@ -74,6 +74,8 @@ class PK_MPC : virtual public PK {
   typename std::vector<Teuchos::RCP<PK_Base>>::iterator end() { return sub_pks_.end(); }
 
  protected:
+  Teuchos::RCP<Teuchos::ParameterList> getSubPKPlist_(int i);
+
   // list of the PKs coupled by this MPC
   typedef std::vector<Teuchos::RCP<PK_Base>> SubPKList;
   SubPKList sub_pks_;
@@ -221,6 +223,17 @@ PK_MPC<PK_Base>::CalculateDiagnostics(const Tag& tag)
     (*pk)->CalculateDiagnostics(tag);
   }
 }
+
+
+template <class PK_Base>
+Teuchos::RCP<Teuchos::ParameterList>
+PK_MPC<PK_Base>::getSubPKPlist_(int i)
+{
+  Teuchos::Array<std::string> names = my_list_->get<Teuchos::Array<std::string>>("PKs order");
+  return Teuchos::sublist(Teuchos::sublist(global_list_, "PKs"), names[i]);
+}
+
+
 
 } // namespace Amanzi
 

--- a/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
@@ -47,8 +47,8 @@ ReactiveTransportMatrixFracture_PK::ReactiveTransportMatrixFracture_PK(
   // instead of current.  Also tell it to use Amanzi generic passwd
   for (const auto& chem_pk : *coupled_chemistry_pk_) {
     auto chem_pk_plist = Teuchos::sublist(Teuchos::sublist(global_list_, "PKs"), chem_pk->name());
-    chem_pk_plist->set("operator split", true);
-    chem_pk_plist->set("operator split tag", Tags::COPY.get());
+    chem_pk_plist->set("concentration tag current", Tags::COPY.get());
+    chem_pk_plist->set("concentration tag next", Tags::COPY.get());
     chem_pk_plist->set("primary variable password", "state");
   }
 }

--- a/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
@@ -39,10 +39,17 @@ ReactiveTransportMatrixFracture_PK::ReactiveTransportMatrixFracture_PK(
   coupled_chemistry_pk_ = Teuchos::rcp_dynamic_cast<ChemistryMatrixFracture_PK>(sub_pks_[0]);
 
   subcycling_ = my_list_->get<bool>("subcycle chemistry", true);
-
   AMANZI_ASSERT(master_ == 1);
 
   vo_ = Teuchos::rcp(new VerboseObject("CoupledRT_PK", *global_list));
+
+  // tell each chemistry pk it is operator split, which means it will use TCC next
+  // instead of current.  Also tell it to use Amanzi generic passwd
+  for (const auto& chem_pk : *coupled_chemistry_pk_) {
+    auto chem_pk_plist = Teuchos::sublist(Teuchos::sublist(global_list_, "PKs"), chem_pk->name());
+    chem_pk_plist->set("operator split", true);
+    chem_pk_plist->set("primary variable password", "state");
+  }
 }
 
 
@@ -96,10 +103,6 @@ ReactiveTransportMatrixFracture_PK::Setup()
       .set<std::string>("evaluator type", "independent variable");
   }
 
-  // copies
-  S_->Require<CV_t, CVS_t>(tcc_matrix_key_, Tags::COPY, "state");
-  S_->Require<CV_t, CVS_t>(tcc_fracture_key_, Tags::COPY, "state");
-
   // communicate chemistry engine to transport.
   auto ic = coupled_chemistry_pk_->begin();
 
@@ -124,16 +127,6 @@ ReactiveTransportMatrixFracture_PK::Setup()
 
 
 // -----------------------------------------------------------------------------
-// Initialization of copies requires fileds to exists
-// -----------------------------------------------------------------------------
-void
-ReactiveTransportMatrixFracture_PK::Initialize()
-{
-  Amanzi::PK_MPCSubcycled::Initialize();
-}
-
-
-// -----------------------------------------------------------------------------
 // Calculate minimum of sub PKs timestep sizes
 // -----------------------------------------------------------------------------
 double
@@ -152,17 +145,6 @@ ReactiveTransportMatrixFracture_PK::get_dt()
 
 
 // -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void
-ReactiveTransportMatrixFracture_PK::set_dt(double dt)
-{
-  sub_pks_[0]->set_dt(dt);
-  sub_pks_[1]->set_dt(dt);
-}
-
-
-// -----------------------------------------------------------------------------
 // Advance each sub-PK individually, returning a failure as soon as possible
 // -----------------------------------------------------------------------------
 bool
@@ -170,36 +152,6 @@ ReactiveTransportMatrixFracture_PK::AdvanceStep(double t_old, double t_new, bool
 {
   bool fail = sub_pks_[1]->AdvanceStep(t_old, t_new, reinit);
   if (fail) return fail;
-
-  std::vector<Teuchos::RCP<AmanziChemistry::Chemistry_PK>> subpks_chem;
-  for (auto ic = coupled_chemistry_pk_->begin(); ic != coupled_chemistry_pk_->end(); ++ic) {
-    auto ic1 = Teuchos::rcp_dynamic_cast<AmanziChemistry::Chemistry_PK>(*ic);
-    subpks_chem.push_back(ic1);
-  }
-
-  std::vector<Teuchos::RCP<Transport::Transport_PK>> subpks_tran;
-  if (sub_pks_[1]->name() == "coupled transport") {
-    auto tpk = Teuchos::rcp_dynamic_cast<TransportMatrixFracture_PK>(sub_pks_[1]);
-
-    for (auto ic = tpk->begin(); ic != tpk->end(); ++ic) {
-      auto ic1 = Teuchos::rcp_dynamic_cast<Transport::Transport_PK>(*ic);
-      subpks_tran.push_back(ic1);
-    }
-  } else if (sub_pks_[1]->name() == "coupled transport implicit") {
-    auto tpk = Teuchos::rcp_dynamic_cast<TransportMatrixFractureImplicit_PK>(sub_pks_[1]);
-
-    for (auto ic = tpk->begin(); ic != tpk->end(); ++ic) {
-      auto ic1 = Teuchos::rcp_dynamic_cast<Transport::Transport_PK>(*ic);
-      subpks_tran.push_back(ic1);
-    }
-  }
-
-  // at this moment, we have old tcc in State and new tcc in a temporary vector
-  // tell chemistry PKs to work with the temporary vector
-  for (int i = 0; i < 2; ++i) {
-    auto tcc_copy = subpks_tran[i]->total_component_concentration()->ViewComponent("cell", true);
-    subpks_chem[i]->set_aqueous_components(tcc_copy);
-  }
 
   // advance the slave, subcycling if needed
   double dTchem = sub_pks_[0]->get_dt();
@@ -218,11 +170,6 @@ ReactiveTransportMatrixFracture_PK::AdvanceStep(double t_old, double t_new, bool
 
       if (fail) {
         dt_next /= 2;
-        for (int i = 0; i < 2; ++i) {
-          auto tcc_copy =
-            subpks_tran[i]->total_component_concentration()->ViewComponent("cell", true);
-          subpks_chem[i]->set_aqueous_components(tcc_copy);
-        }
       } else {
         dt_done += dt_next;
         dt_next = sub_pks_[0]->get_dt();
@@ -236,11 +183,6 @@ ReactiveTransportMatrixFracture_PK::AdvanceStep(double t_old, double t_new, bool
       done = std::abs(t_old + dt_done - t_new) / (t_new - t_old) < 0.1 * min_dt_;
     }
 
-    *S_->GetW<CV_t>(tcc_matrix_key_, Tags::DEFAULT, "state").ViewComponent("cell", true) =
-      *subpks_chem[0]->aqueous_components();
-
-    *S_->GetW<CV_t>(tcc_fracture_key_, Tags::DEFAULT, "state").ViewComponent("cell", true) =
-      *subpks_chem[1]->aqueous_components();
   } catch (const Errors::Message& chem_error) {
     fail = true;
   } catch (...) {

--- a/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.cc
@@ -48,6 +48,7 @@ ReactiveTransportMatrixFracture_PK::ReactiveTransportMatrixFracture_PK(
   for (const auto& chem_pk : *coupled_chemistry_pk_) {
     auto chem_pk_plist = Teuchos::sublist(Teuchos::sublist(global_list_, "PKs"), chem_pk->name());
     chem_pk_plist->set("operator split", true);
+    chem_pk_plist->set("operator split tag", Tags::COPY.get());
     chem_pk_plist->set("primary variable password", "state");
   }
 }

--- a/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.hh
+++ b/src/pks/mpc_pk/ReactiveTransportMatrixFracture_PK.hh
@@ -44,10 +44,8 @@ class ReactiveTransportMatrixFracture_PK : public PK_MPCSubcycled {
   // PK methods
   // -- dt is the minimum of the sub pks
   virtual double get_dt() override;
-  virtual void set_dt(double dt) override;
 
   virtual void Setup() override;
-  virtual void Initialize() override;
 
   // -- advance each sub pk from t_old to t_new.
   virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false) override;

--- a/src/pks/mpc_pk/ReactiveTransport_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransport_PK.cc
@@ -26,9 +26,8 @@ ReactiveTransport_PK::ReactiveTransport_PK(Teuchos::ParameterList& pk_tree,
                                            const Teuchos::RCP<TreeVector>& soln)
   : Amanzi::PK_MPCAdditive<PK>(pk_tree, global_list, S, soln)
 {
-  storage_created = false;
-  chem_step_succeeded = true;
-
+  // why put chemistry before transport if you intend to solve transport before
+  // chemistry? --ETC
   transport_pk_ = Teuchos::rcp_dynamic_cast<Transport::Transport_PK>(sub_pks_[1]);
   AMANZI_ASSERT(transport_pk_ != Teuchos::null);
 
@@ -38,24 +37,10 @@ ReactiveTransport_PK::ReactiveTransport_PK(Teuchos::ParameterList& pk_tree,
   // communicate chemistry engine to transport.
   transport_pk_->SetupChemistry(chemistry_pk_);
 
-  // master_ = 1;  // Transport;
-  // slave_ = 0;  // Chemistry;
-}
-
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void
-ReactiveTransport_PK::Initialize()
-{
-  Amanzi::PK_MPCAdditive<PK>::Initialize();
-
-  if (S_->HasRecord("total_component_concentration")) {
-    total_component_concentration_stor = Teuchos::rcp(new Epetra_MultiVector(
-      *S_->Get<CompositeVector>("total_component_concentration").ViewComponent("cell", true)));
-    storage_created = true;
-  }
+  // tell chemistry it is operator split, which means it will use TCC next
+  // instead of current.  Also tell it to use Amanzi generic passwd
+  getSubPKPlist_(0)->set("operator split", true);
+  getSubPKPlist_(0)->set("primary variable password", "state");
 }
 
 
@@ -67,11 +52,7 @@ ReactiveTransport_PK::get_dt()
 {
   dTtran_ = transport_pk_->get_dt();
   dTchem_ = chemistry_pk_->get_dt();
-
-  if (!chem_step_succeeded && (dTchem_ / dTtran_ > 0.99)) { dTchem_ *= 0.5; }
-
   if (dTtran_ > dTchem_) dTtran_ = dTchem_;
-
   return dTchem_;
 }
 
@@ -84,12 +65,10 @@ ReactiveTransport_PK::set_dt(double dt)
 {
   dTtran_ = dt;
   dTchem_ = dt;
-  //dTchem_ = chemistry_pk_->get_dt();
-  //if (dTchem_ > dTtran_) dTchem_ = dTtran_;
-  //if (dTtran_ > dTchem_) dTtran_= dTchem_;
   chemistry_pk_->set_dt(dTchem_);
   transport_pk_->set_dt(dTtran_);
 }
+
 
 
 // -----------------------------------------------------------------------------
@@ -98,45 +77,19 @@ ReactiveTransport_PK::set_dt(double dt)
 bool
 ReactiveTransport_PK::AdvanceStep(double t_old, double t_new, bool reinit)
 {
+  // NOTE: this need not be implemented except that the PKs are reversed.  Is
+  // there a good reason that chemistry's Setup() is called before transport's
+  // Setup(), but transport's Advance() is called before chemistry's Advance()?
+  // --ETC
   bool fail = false;
-  chem_step_succeeded = false;
 
   // First we do a transport step.
   bool pk_fail = transport_pk_->AdvanceStep(t_old, t_new, reinit);
-
-  // Right now transport step is always succeeded.
-  if (!pk_fail) {
-    *total_component_concentration_stor =
-      *transport_pk_->total_component_concentration()->ViewComponent("cell", true);
-  } else {
-    Errors::Message message("MPC: Transport PK returned an unexpected error.");
-    Exceptions::amanzi_throw(message);
-  }
+  if (pk_fail) return pk_fail;
 
   // Second, we do a chemistry step using a copy of the tcc vector
-  try {
-    chemistry_pk_->set_aqueous_components(total_component_concentration_stor);
-
-    pk_fail = chemistry_pk_->AdvanceStep(t_old, t_new, reinit);
-    chem_step_succeeded = true;
-
-    *S_->GetW<CompositeVector>("total_component_concentration", "state")
-       .ViewComponent("cell", true) = *chemistry_pk_->aqueous_components();
-  } catch (const Errors::Message& chem_error) {
-    fail = true;
-  }
-
-  return fail;
+  pk_fail = chemistry_pk_->AdvanceStep(t_old, t_new, reinit);
+  return pk_fail;
 };
-
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void
-ReactiveTransport_PK::CommitStep(double t_old, double t_new, const Tag& tag)
-{
-  chemistry_pk_->CommitStep(t_old, t_new, tag);
-}
 
 } // namespace Amanzi

--- a/src/pks/mpc_pk/ReactiveTransport_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransport_PK.cc
@@ -40,6 +40,7 @@ ReactiveTransport_PK::ReactiveTransport_PK(Teuchos::ParameterList& pk_tree,
   // tell chemistry it is operator split, which means it will use TCC next
   // instead of current.  Also tell it to use Amanzi generic passwd
   getSubPKPlist_(0)->set("operator split", true);
+  getSubPKPlist_(0)->set("operator split tag", Tags::COPY.get());
   getSubPKPlist_(0)->set("primary variable password", "state");
 }
 

--- a/src/pks/mpc_pk/ReactiveTransport_PK.cc
+++ b/src/pks/mpc_pk/ReactiveTransport_PK.cc
@@ -39,8 +39,8 @@ ReactiveTransport_PK::ReactiveTransport_PK(Teuchos::ParameterList& pk_tree,
 
   // tell chemistry it is operator split, which means it will use TCC next
   // instead of current.  Also tell it to use Amanzi generic passwd
-  getSubPKPlist_(0)->set("operator split", true);
-  getSubPKPlist_(0)->set("operator split tag", Tags::COPY.get());
+  getSubPKPlist_(0)->set("concentration tag current", Tags::COPY.get());
+  getSubPKPlist_(0)->set("concentration tag next", "operator_split");
   getSubPKPlist_(0)->set("primary variable password", "state");
 }
 
@@ -92,5 +92,13 @@ ReactiveTransport_PK::AdvanceStep(double t_old, double t_new, bool reinit)
   pk_fail = chemistry_pk_->AdvanceStep(t_old, t_new, reinit);
   return pk_fail;
 };
+
+
+void
+ReactiveTransport_PK::CommitStep(double t_old, double t_new, const Tag& tag)
+{
+  chemistry_pk_->CommitStep(t_old, t_new, tag);
+}
+
 
 } // namespace Amanzi

--- a/src/pks/mpc_pk/ReactiveTransport_PK.hh
+++ b/src/pks/mpc_pk/ReactiveTransport_PK.hh
@@ -56,6 +56,7 @@ class ReactiveTransport_PK : public PK_MPCAdditive<PK> {
   double get_dt() override;
   void set_dt(double dt) override;
   bool AdvanceStep(double t_old, double t_new, bool reinit) override;
+  void CommitStep(double t_old, double t_new, const Tag& tag) override;
 
   std::string name() override { return "reactive transport"; }
 

--- a/src/pks/mpc_pk/ReactiveTransport_PK.hh
+++ b/src/pks/mpc_pk/ReactiveTransport_PK.hh
@@ -51,35 +51,21 @@ class ReactiveTransport_PK : public PK_MPCAdditive<PK> {
                        const Teuchos::RCP<State>& S,
                        const Teuchos::RCP<TreeVector>& soln);
 
-  ~ReactiveTransport_PK(){};
-
   // PK methods
   // -- dt is the minimum of the sub pks
-  virtual double get_dt();
-  virtual void set_dt(double dt);
+  double get_dt() override;
+  void set_dt(double dt) override;
+  bool AdvanceStep(double t_old, double t_new, bool reinit) override;
 
-  // -- advance each sub pk dt.
-  virtual bool AdvanceStep(double t_old, double t_new, bool reinit = false);
-
-  virtual void Initialize();
-
-  virtual void CommitStep(double t_old, double t_new, const Tag& tag);
-
-  std::string name() { return "reactive transport"; }
+  std::string name() override { return "reactive transport"; }
 
  protected:
   bool chem_step_succeeded;
-  bool storage_created;
   double dTtran_, dTchem_;
 
  private:
-  // storage for the component concentration intermediate values
-  Teuchos::RCP<Epetra_MultiVector> total_component_concentration_stor;
-
   Teuchos::RCP<Transport::Transport_PK> transport_pk_;
   Teuchos::RCP<AmanziChemistry::Chemistry_PK> chemistry_pk_;
-  // int master_, slave_;
-
 
   // factory registration
   static RegisteredPKFactory<ReactiveTransport_PK> reg_;

--- a/src/pks/transport/TransportBoundaryFunction_Alquimia.cc
+++ b/src/pks/transport/TransportBoundaryFunction_Alquimia.cc
@@ -31,7 +31,7 @@ TransportBoundaryFunction_Alquimia::TransportBoundaryFunction_Alquimia(
 {
   // Check arguments.
   if (chem_engine_ != Teuchos::null) {
-    chem_engine_->InitState(alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+    chem_engine_->InitState(beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
     chem_engine_->GetPrimarySpeciesNames(tcc_names_);
   } else {
     Errors::Message msg;
@@ -58,7 +58,7 @@ TransportBoundaryFunction_Alquimia::TransportBoundaryFunction_Alquimia(
 ****************************************************************** */
 TransportBoundaryFunction_Alquimia::~TransportBoundaryFunction_Alquimia()
 {
-  chem_engine_->FreeState(alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+  chem_engine_->FreeState(beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
 }
 
 
@@ -104,15 +104,15 @@ TransportBoundaryFunction_Alquimia::Compute(double t_old, double t_new)
     int cell = cell_for_face_[f];
 
     // Dump the contents of the chemistry state into our Alquimia containers.
-    alquimia_pk_->CopyToAlquimia(cell, alq_mat_props_, alq_state_, alq_aux_data_);
+    alquimia_pk_->copyToAlquimia(cell, beaker_);
 
     // Enforce the condition.
-    chem_engine_->EnforceCondition(
-      cond_name, t_new, alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+    chem_engine_->EnforceCondition(cond_name, t_new,
+            beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
 
     // Move the concentrations into place.
     std::vector<double>& values = it->second;
-    for (int i = 0; i < values.size(); i++) { values[i] = alq_state_.total_mobile.data[i]; }
+    for (int i = 0; i < values.size(); i++) { values[i] = beaker_.state.total_mobile.data[i]; }
   }
 }
 

--- a/src/pks/transport/TransportBoundaryFunction_Alquimia.hh
+++ b/src/pks/transport/TransportBoundaryFunction_Alquimia.hh
@@ -61,10 +61,7 @@ class TransportBoundaryFunction_Alquimia : public TransportDomainFunction {
   Teuchos::RCP<AmanziChemistry::ChemistryEngine> chem_engine_;
 
   // Containers for interacting with the chemistry engine.
-  AlquimiaState alq_state_;
-  AlquimiaProperties alq_mat_props_;
-  AlquimiaAuxiliaryData alq_aux_data_;
-  AlquimiaAuxiliaryOutputData alq_aux_output_;
+  AmanziChemistry::AlquimiaBeaker beaker_;
 
   // A mapping of boundary face indices to interior cells.
   std::map<int, int> cell_for_face_;

--- a/src/pks/transport/TransportBoundaryFunction_Chemistry.hh
+++ b/src/pks/transport/TransportBoundaryFunction_Chemistry.hh
@@ -55,7 +55,7 @@ class TransportBoundaryFunction_Chemistry : public TransportDomainFunction {
       AMANZI_ASSERT(cells.size() == 1);
       int c = cells[0];
 
-      amanzi_pk_->CopyCellStateToBeakerState(c, tcc->ViewComponent("cell", true));
+      amanzi_pk_->CopyCellStateToBeakerState(c);
 
       auto& values = it->second;
       chem_engine_->EnforceConstraint(&beaker_state, beaker_parameters, constraints_, values);

--- a/src/pks/transport/TransportExplicit_PK.cc
+++ b/src/pks/transport/TransportExplicit_PK.cc
@@ -186,6 +186,11 @@ TransportExplicit_PK::AdvanceStep(double t_old, double t_new, bool reinit)
   bool failed = false;
   double dt_MPC = t_new - t_old;
 
+  {
+    const Epetra_MultiVector& tcc = *S_->Get<CompositeVector>("total_component_concentration", tag_next_).ViewComponent("cell", false);
+    std::cout << "UGH tcc = " << tcc[0][0] << std::endl;
+  }
+
   // We use original tcc and make a copy of it later if needed.
   tcc = S_->GetPtrW<CV_t>(tcc_key_, Tags::DEFAULT, passwd_);
   Epetra_MultiVector& tcc_prev = *tcc->ViewComponent("cell");

--- a/src/pks/transport/TransportExplicit_PK.cc
+++ b/src/pks/transport/TransportExplicit_PK.cc
@@ -186,11 +186,6 @@ TransportExplicit_PK::AdvanceStep(double t_old, double t_new, bool reinit)
   bool failed = false;
   double dt_MPC = t_new - t_old;
 
-  {
-    const Epetra_MultiVector& tcc = *S_->Get<CompositeVector>("total_component_concentration", tag_next_).ViewComponent("cell", false);
-    std::cout << "UGH tcc = " << tcc[0][0] << std::endl;
-  }
-
   // We use original tcc and make a copy of it later if needed.
   tcc = S_->GetPtrW<CV_t>(tcc_key_, Tags::DEFAULT, passwd_);
   Epetra_MultiVector& tcc_prev = *tcc->ViewComponent("cell");

--- a/src/pks/transport/TransportSourceFunction_Alquimia.cc
+++ b/src/pks/transport/TransportSourceFunction_Alquimia.cc
@@ -31,7 +31,7 @@ TransportSourceFunction_Alquimia::TransportSourceFunction_Alquimia(
 {
   // Check arguments.
   if (chem_engine_ != Teuchos::null) {
-    chem_engine_->InitState(alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+    chem_engine_->InitState(beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
     chem_engine_->GetPrimarySpeciesNames(tcc_names_);
   } else {
     Errors::Message msg;
@@ -58,7 +58,7 @@ TransportSourceFunction_Alquimia::TransportSourceFunction_Alquimia(
 ****************************************************************** */
 TransportSourceFunction_Alquimia::~TransportSourceFunction_Alquimia()
 {
-  chem_engine_->FreeState(alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+  chem_engine_->FreeState(beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
 }
 
 
@@ -95,16 +95,16 @@ TransportSourceFunction_Alquimia::Compute(double t_old, double t_new)
     int cell = it->first;
 
     // Dump the contents of the chemistry state into our Alquimia containers.
-    alquimia_pk_->CopyToAlquimia(cell, alq_mat_props_, alq_state_, alq_aux_data_);
+    alquimia_pk_->copyToAlquimia(cell, beaker_);
 
     // Enforce the condition.
-    chem_engine_->EnforceCondition(
-      cond_name, t_new, alq_mat_props_, alq_state_, alq_aux_data_, alq_aux_output_);
+    chem_engine_->EnforceCondition(cond_name, t_new,
+      beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
 
     // Move the concentrations into place.
     std::vector<double>& values = it->second;
     for (int i = 0; i < values.size(); i++) {
-      values[i] = alq_state_.total_mobile.data[i] / domain_volume_;
+      values[i] = beaker_.state.total_mobile.data[i] / domain_volume_;
     }
   }
 }

--- a/src/pks/transport/TransportSourceFunction_Alquimia.hh
+++ b/src/pks/transport/TransportSourceFunction_Alquimia.hh
@@ -58,10 +58,7 @@ class TransportSourceFunction_Alquimia : public TransportDomainFunction {
   Teuchos::RCP<AmanziChemistry::ChemistryEngine> chem_engine_;
 
   // Containers for interacting with the chemistry engine.
-  AlquimiaState alq_state_;
-  AlquimiaProperties alq_mat_props_;
-  AlquimiaAuxiliaryData alq_aux_data_;
-  AlquimiaAuxiliaryOutputData alq_aux_output_;
+  AmanziChemistry::AlquimiaBeaker beaker_;
 };
 
 } // namespace Transport

--- a/src/pks/transport/Transport_PK.cc
+++ b/src/pks/transport/Transport_PK.cc
@@ -388,7 +388,8 @@ Transport_PK::Setup()
   }
 
   // temporary fields
-  S_->Require<CV_t, CVS_t>(tcc_key_, Tags::COPY, passwd_, component_names_);
+  S_->Require<CV_t, CVS_t>(tcc_key_, Tags::COPY, passwd_, component_names_)
+    .SetGhosted(true);
 
 #ifdef ALQUIMIA_ENABLED
   SetupAlquimia();

--- a/src/pks/transport/Transport_PK.cc
+++ b/src/pks/transport/Transport_PK.cc
@@ -150,9 +150,10 @@ void
 Transport_PK::SetupAlquimia()
 {
   if (chem_pk_ == Teuchos::null) return;
-
   alquimia_pk_ = Teuchos::rcp_dynamic_cast<AmanziChemistry::Alquimia_PK>(chem_pk_);
-  chem_engine_ = chem_pk_->chem_engine();
+  if (alquimia_pk_ != Teuchos::null) {
+    chem_engine_ = alquimia_pk_->getChemEngine();
+  }
 
   if (chem_engine_ != Teuchos::null) {
     // Retrieve the component names (primary and secondary) from the chemistry

--- a/src/state/Observable.cc
+++ b/src/state/Observable.cc
@@ -106,7 +106,7 @@ Observable::Observable(Teuchos::ParameterList& plist)
   // function modifies the values
   if (plist.isSublist("modifier")) {
     FunctionFactory fac;
-    modifier_ = fac.Create(plist.sublist("modifier"));
+    modifier_ = Teuchos::rcp(fac.Create(plist.sublist("modifier")));
 
     // convert the list to a string for printing in the file, so there is some
     // hope of tracibility

--- a/src/state/Observable.hh
+++ b/src/state/Observable.hh
@@ -129,10 +129,13 @@ class Observable {
   static const double nan;
 
   Observable(Teuchos::ParameterList& plist);
-  Observable(const Comm_ptr_type& comm, Teuchos::ParameterList& plist) : Observable(plist)
+  Observable(const Comm_ptr_type& comm, Teuchos::ParameterList& plist)
+    : Observable(plist)
   {
     set_comm(comm);
   }
+
+  virtual ~Observable() = default;
 
   const std::string& get_name() const { return name_; }
   const std::string& get_variable() const { return variable_; }
@@ -175,7 +178,7 @@ class Observable {
 
   double (*reducer_)(double a, double b, double vol);
 
-  std::unique_ptr<Function> modifier_;
+  Teuchos::RCP<Function> modifier_;
   std::string modifier_str_;
 };
 

--- a/src/utils/Key.cc
+++ b/src/utils/Key.cc
@@ -117,7 +117,7 @@ cleanName(const std::string& name, bool delimiters_ok)
 // Note, if DOMAIN == "domain" or "" this returns VARNAME
 
 bool
-validKey(const Key& key)
+isValid(const Key& key)
 {
   bool result = true;
   int deriv_del_count = std::count(key.begin(), key.end(), deriv_delimiter);
@@ -125,14 +125,14 @@ validKey(const Key& key)
     result = false;
   } else if (deriv_del_count == 1) {
     auto split_deriv = split(key, deriv_delimiter);
-    result = validKey(split_deriv.first) && validKey(split_deriv.second);
+    result = isValid(split_deriv.first) && isValid(split_deriv.second);
   } else {
     int tag_count = std::count(key.begin(), key.end(), tag_delimiter);
     if (tag_count > 1) {
       result = false;
     } else if (tag_count == 1) {
       auto split_tag = split(key, tag_delimiter);
-      result = validKey(split_tag.first) && validKey(split_tag.second);
+      result = isValid(split_tag.first) && isValid(split_tag.second);
     } else {
       int name_count = std::count(key.begin(), key.end(), name_delimiter);
       if (name_count > 1) {
@@ -144,8 +144,8 @@ validKey(const Key& key)
           result = false;
         if (std::count(domain_var.first.begin(), domain_var.first.end(), dset_delimiter) > 1)
           result = false;
-        if (std::count(domain_var.second.begin(), domain_var.second.end(), dset_delimiter))
-          result = false;
+        // if (std::count(domain_var.second.begin(), domain_var.second.end(), dset_delimiter))
+        //   result = false;
       }
     }
   }
@@ -179,7 +179,7 @@ getKey(const Key& domain, const Key& variable)
 KeyPair
 splitKey(const Key& name)
 {
-  if (!validKey(name)) {
+  if (!isValid(name)) {
     Errors::Message msg("Keys::splitKey() called with invalid argument \"");
     msg << name << "\"";
     Exceptions::amanzi_throw(msg);

--- a/src/utils/Key.hh
+++ b/src/utils/Key.hh
@@ -148,7 +148,7 @@ cleanName(const std::string& name, bool delimiters_ok = false);
 
 // is this valid?
 bool
-validKey(const Key& key);
+isValid(const Key& key);
 
 // Generate a DOMAIN-VARNAME key.
 // Note, if DOMAIN == "domain" or "" this returns VARNAME

--- a/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-crunch.xml
+++ b/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-crunch.xml
@@ -111,8 +111,6 @@
         <maximum_newton_iterations>150</maximum_newton_iterations>
         <auxiliary_data>pH</auxiliary_data>
         <initial_time_step>220000.0</initial_time_step>
-<!--        <max_time_step>220000.0</max_time_step> -->
-        <time_step_cut_threshold>5</time_step_cut_threshold>
       </unstr_chemistry_controls>
 
       <unstr_linear_solver>

--- a/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-pflo-writer.xml
+++ b/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-pflo-writer.xml
@@ -111,8 +111,6 @@
         <maximum_newton_iterations>150</maximum_newton_iterations>
         <auxiliary_data>pH</auxiliary_data>
         <initial_time_step>220000.0</initial_time_step>
-        <max_time_step>220000.0</max_time_step>
-        <time_step_cut_threshold>5</time_step_cut_threshold>
       </unstr_chemistry_controls>
 
       <unstr_linear_solver>

--- a/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/calcite_1d/amanzi-u-1d-calcite-alq-pflo.xml
@@ -106,12 +106,8 @@
       </unstr_transient_controls>
 
       <unstr_chemistry_controls>
-        <max_residual_tolerance>1.0e-12</max_residual_tolerance>
-        <maximum_newton_iterations>150</maximum_newton_iterations>
         <auxiliary_data>pH</auxiliary_data>
         <initial_time_step>220000.0</initial_time_step>
-        <max_time_step>220000.0</max_time_step>
-        <time_step_cut_threshold>5</time_step_cut_threshold>
       </unstr_chemistry_controls>
 
       <unstr_linear_solver>

--- a/test_suites/benchmarking/chemistry/calcite_1d/calcite_1d.py
+++ b/test_suites/benchmarking/chemistry/calcite_1d/calcite_1d.py
@@ -183,8 +183,9 @@ if __name__ == "__main__":
 
         native = True
 
-    except:
+    except Exception as err:
         native = False
+        print(err)
         pass    
 
 
@@ -200,7 +201,7 @@ if __name__ == "__main__":
             x_amanzi_alquimia, c_amanzi_alquimia = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
             Ca_amanzi_alquimia = Ca_amanzi_alquimia +[c_amanzi_alquimia]
 
-        comp = 'free_ion_species.H+'
+        comp = 'primary_free_ion_concentration.H+'
         pH_amanzi_alquimia = []
         for i, time in enumerate(times):
             x_amanzi_alquimia, c_amanzi_alquimia = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
@@ -214,7 +215,8 @@ if __name__ == "__main__":
 
         alq = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq = False
 
     # Amanzi U + Alquimia + PFloTran chemistry with writer
@@ -229,7 +231,7 @@ if __name__ == "__main__":
             x_amanzi_alquimia_w, c_amanzi_alquimia_w = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
             Ca_amanzi_alquimia_w = Ca_amanzi_alquimia_w +[c_amanzi_alquimia_w]
 
-        comp = 'free_ion_species.H+'
+        comp = 'primary_free_ion_concentration.H+'
         pH_amanzi_alquimia_w = []
         for i, time in enumerate(times):
             x_amanzi_alquimia_w, c_amanzi_alquimia_w = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
@@ -243,7 +245,8 @@ if __name__ == "__main__":
 
         alq_writer = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq_writer = False
         
     # Amanzi U + Alquimia + CruchFlow chemistry
@@ -258,7 +261,7 @@ if __name__ == "__main__":
             x_amanzi_alquimia_crunch, c_amanzi_alquimia_crunch = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
             Ca_amanzi_alquimia_crunch = Ca_amanzi_alquimia_crunch +[c_amanzi_alquimia_crunch]
 
-        comp = 'free_ion_species.H+'
+        comp = 'primary_free_ion_concentration.H+'
         pH_amanzi_alquimia_crunch = []
         for i, time in enumerate(times):
            x_amanzi_alquimia_crunch, c_amanzi_alquimia_crunch = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
@@ -272,7 +275,8 @@ if __name__ == "__main__":
 
         alq_crunch = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq_crunch = False
 
     

--- a/test_suites/benchmarking/chemistry/farea_1d/amanzi-u-1d-farea-full-alq-pflo-writer.xml
+++ b/test_suites/benchmarking/chemistry/farea_1d/amanzi-u-1d-farea-full-alq-pflo-writer.xml
@@ -34,7 +34,7 @@
                     <primary coefficient_of_diffusion="1.0E-9">Na+</primary>
                     <primary coefficient_of_diffusion="1.0E-9">SiO2(aq)</primary>
                     <primary coefficient_of_diffusion="1.0E-9">SO4--</primary>
-                    <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09 ">Tritium</primary>
+                    <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09 ">Tritium</primary>
                     <primary coefficient_of_diffusion="1.0E-9">NO3-</primary>
                     <primary coefficient_of_diffusion="1.0E-9">UO2++</primary>
                 </primaries>

--- a/test_suites/benchmarking/chemistry/farea_1d/amanzi-u-1d-farea-full-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/farea_1d/amanzi-u-1d-farea-full-alq-pflo.xml
@@ -35,7 +35,7 @@
                     <primary coefficient_of_diffusion="1.0E-9">Na+</primary>
                     <primary coefficient_of_diffusion="1.0E-9">SiO2(aq)</primary>
                     <primary coefficient_of_diffusion="1.0E-9">SO4--</primary>
-                    <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09 ">Tritium</primary>
+                    <primary backward_rate="0.0" coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09 ">Tritium</primary>
                     <primary coefficient_of_diffusion="1.0E-9">NO3-</primary>
                     <primary coefficient_of_diffusion="1.0E-9">UO2++</primary>
                 </primaries>

--- a/test_suites/benchmarking/chemistry/farea_1d/farea_1d.py
+++ b/test_suites/benchmarking/chemistry/farea_1d/farea_1d.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     amanzi_totc = [amanzi_totc_templ%comp for comp in components]
 
     amanzi_sorb_templ = "total_sorbed.{0}"
-    amanzi_sorb = [amanzi_sorb_templ.format(x) for x in range(len(components))]
+    amanzi_sorb = [amanzi_sorb_templ.format(x) for x in components]
 
     amanzi_vf_templ = "mineral_volume_fractions.{0}"
     amanzi_vf = [amanzi_vf_templ.format(x) for x in minerals]
@@ -130,7 +130,8 @@ if __name__ == "__main__":
 
         native = True
 
-    except:
+    except Exception as err:
+        print(err)
         native = False
 
 
@@ -165,7 +166,8 @@ if __name__ == "__main__":
 
         alq = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq = False
 
     # Amanzi + Alquimia + PFloTran chemistry with writer
@@ -199,7 +201,8 @@ if __name__ == "__main__":
 
         alq_writer = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq_writer = False
         
     # initialize subplots

--- a/test_suites/benchmarking/chemistry/ion_exchange_1d/ion_exchange_1d.py
+++ b/test_suites/benchmarking/chemistry/ion_exchange_1d/ion_exchange_1d.py
@@ -105,10 +105,10 @@ if __name__ == "__main__":
                          'total_component_concentration.Ca++', \
                          'total_component_concentration.Mg++', \
                          'total_component_concentration.Cl-']
-    amanzi_sorbed     = ['total_sorbed.0', \
-                         'total_sorbed.1', \
-                         'total_sorbed.2', \
-                         'total_sorbed.3']
+    amanzi_sorbed     = ['total_sorbed.Na+', \
+                         'total_sorbed.Ca++', \
+                         'total_sorbed.Mg++', \
+                         'total_sorbed.Cl-']
 
     amanzi_compS      = ['Na+_water_Concentration', \
                          'Ca++_water_Concentration', \
@@ -369,8 +369,8 @@ if __name__ == "__main__":
         bx[i].yaxis.set_label_position("right")
 
     # Set axes to be shared + only have ticks on the bottom row
-    ax[0].get_shared_x_axes().join(*[ax[i] for i in range(nrows)])
-    bx[0].get_shared_x_axes().join(*[bx[i] for i in range(nrows)])
+    # ax[0].get_shared_x_axes().join(*[ax[i] for i in range(nrows)])
+    # bx[0].get_shared_x_axes().join(*[bx[i] for i in range(nrows)])
 
     for i in range(nrows-1):
         ax[i].set_xticklabels([])

--- a/test_suites/benchmarking/chemistry/isotherms_1d/isotherms_1d.py
+++ b/test_suites/benchmarking/chemistry/isotherms_1d/isotherms_1d.py
@@ -56,8 +56,8 @@ if __name__ == "__main__":
     amanzi_totc_crunch = [amanzi_totc_templ.format(x) for x in compcrunch] #range(len(components))]
 
     amanzi_sorb_templ = "total_sorbed.{0}"
-    amanzi_sorb = [amanzi_sorb_templ.format(x) for x in range(len(components))]
-    amanzi_sorb_crunch = [amanzi_sorb_templ.format(x) for x in range(len(compcrunch))]
+    amanzi_sorb = [amanzi_sorb_templ.format(x) for x in components]
+    amanzi_sorb_crunch = [amanzi_sorb_templ.format(x) for x in compcrunch]
 
 
 # pflotran data --->
@@ -117,7 +117,8 @@ if __name__ == "__main__":
 
         native = len(x_native)  
 
-    except:
+    except Exception as err:
+        print(err)
         native = 0 
         pass
 
@@ -142,7 +143,8 @@ if __name__ == "__main__":
 
         alq = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq = False
 
 # AmanziU + Alquimia + PFloTran WITH WRITER --->
@@ -165,7 +167,8 @@ if __name__ == "__main__":
 
         alq_writer = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq_writer = False      
 
 # AmanziU + Alquimia + CrunchFlow chemistry --->
@@ -188,7 +191,8 @@ if __name__ == "__main__":
 
         alqc = True
 
-    except:
+    except Exception as err:
+        print(err)
         alqc = False
 
 
@@ -207,7 +211,8 @@ if __name__ == "__main__":
             compS = "{0}_Sorbed_Concentration".format(comp)
             x_amanziS, v_amanziS[j] = GetXY_AmanziS_1D(path_to_amanzi,root_amanziS,compS,1)
         struct = len(x_amanziS)
-    except:
+    except Exception as err:
+        print(err)
         struct = 0
 
 
@@ -223,7 +228,8 @@ if __name__ == "__main__":
         compS = "A_Sorbed_Concentration"
         x_amanziS_crunch, v_amanziS_crunch = GetXY_AmanziS_1D(path_to_amanzi,root_amanziS,compS,1)
         struct_c = len(x_amanziS_crunch)
-    except:
+    except Exception as err:
+        print(err)
         struct_c = 0
 
 

--- a/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation-alq-pflo-writer.xml
+++ b/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation-alq-pflo-writer.xml
@@ -77,6 +77,7 @@
 
       <unstr_chemistry_controls>
 	  <auxiliary_data>pH</auxiliary_data>
+          <initial_time_step>1.e7</initial_time_step>
       </unstr_chemistry_controls>
 
       <unstr_steady-state_controls>

--- a/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation-alq-pflo.xml
@@ -76,6 +76,7 @@
 
       <unstr_chemistry_controls>
 	  <auxiliary_data>pH</auxiliary_data>
+          <initial_time_step>1.e7</initial_time_step>
       </unstr_chemistry_controls>
 
       <unstr_steady-state_controls>

--- a/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation.xml
+++ b/test_suites/benchmarking/chemistry/surface_complexation_1d/amanzi-u-1d-surface-complexation.xml
@@ -76,8 +76,8 @@
         <time_step_control_method>simple</time_step_control_method>
         <maximum_newton_iterations>250</maximum_newton_iterations>
         <tolerance>1.5e-12</tolerance>
-        <max_time_step>1700000.0</max_time_step>
-        <initial_time_step>10000.0</initial_time_step>
+        <max_time_step>6.e10</max_time_step>
+        <initial_time_step>6.e10</initial_time_step>
         <time_step_cut_threshold>20</time_step_cut_threshold>
       </unstr_chemistry_controls>
       

--- a/test_suites/benchmarking/chemistry/surface_complexation_1d/surface_complexation_1d.py
+++ b/test_suites/benchmarking/chemistry/surface_complexation_1d/surface_complexation_1d.py
@@ -52,8 +52,8 @@ if __name__ == "__main__":
     amanzi_totc_crunch = [amanzi_totc_templ.format(x) for x in compcrunch] #range(len(components))]
 
     amanzi_sorb_templ = "total_sorbed.{0}"
-    amanzi_sorb = [amanzi_sorb_templ.format(x+1) for x in range(len(components))]
-    amanzi_sorb_crunch = [amanzi_sorb_templ.format(x+1) for x in range(len(compcrunch))]
+    amanzi_sorb = [amanzi_sorb_templ.format(x) for x in components]
+    amanzi_sorb_crunch = [amanzi_sorb_templ.format(x) for x in compcrunch]
 
 # amanzi output (structured - alquimia)
     amanzi_totc_templ = "{0}_water_Concentration"
@@ -237,7 +237,8 @@ if __name__ == "__main__":
 
         alq_crunch = True
 
-    except:
+    except Exception as err:
+        print(err)
         alq_crunch = False
 
 
@@ -462,8 +463,8 @@ if __name__ == "__main__":
         bx[i].yaxis.set_label_position("right")
 
     # Set axes to be shared + only have ticks on the bottom row
-    ax[0].get_shared_x_axes().join(*[ax[i] for i in range(main_rows)])
-    bx[0].get_shared_x_axes().join(*[bx[i] for i in range(main_rows)])
+    # ax[0].get_shared_x_axes().join(*[ax[i] for i in range(main_rows)])
+    # bx[0].get_shared_x_axes().join(*[bx[i] for i in range(main_rows)])
 
     for i in range(main_rows-1):
         ax[i].set_xticklabels([])

--- a/test_suites/benchmarking/chemistry/tritium_1d/amanzi-s-1d-tritium-alq-crunch.xml
+++ b/test_suites/benchmarking/chemistry/tritium_1d/amanzi-s-1d-tritium-alq-crunch.xml
@@ -43,7 +43,7 @@
       <density>998.2</density>
       <dissolved_components>
         <primaries>
-          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09">Tritium</primary>
+          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09">Tritium</primary>
           <primary coefficient_of_diffusion="1.0E-9">Daughter</primary>
         </primaries>
       </dissolved_components>

--- a/test_suites/benchmarking/chemistry/tritium_1d/amanzi-s-1d-tritium-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/tritium_1d/amanzi-s-1d-tritium-alq-pflo.xml
@@ -44,7 +44,7 @@
       <density>998.2</density>
       <dissolved_components>
         <primaries>
-          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09">Tritium</primary>
+          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09">Tritium</primary>
         </primaries>
       </dissolved_components>
     </liquid_phase>

--- a/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-crunch.xml
+++ b/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-crunch.xml
@@ -37,7 +37,7 @@
       <molar_mass>0.018015</molar_mass>
       <dissolved_components>
         <primaries>
-          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09">Tritium</primary>
+          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09">Tritium</primary>
           <primary coefficient_of_diffusion="1.0E-9">Daughter</primary>
         </primaries>
       </dissolved_components>

--- a/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-pflo-writer.xml
+++ b/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-pflo-writer.xml
@@ -38,7 +38,7 @@
       <molar_mass>0.018015</molar_mass>
       <dissolved_components>
         <primaries>
-          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09">Tritium</primary>
+          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09">Tritium</primary>
         </primaries>
       </dissolved_components>
     </liquid_phase>

--- a/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-pflo.xml
+++ b/test_suites/benchmarking/chemistry/tritium_1d/amanzi-u-1d-tritium-alq-pflo.xml
@@ -37,7 +37,7 @@
       <molar_mass>0.018015</molar_mass>
       <dissolved_components>
         <primaries>
-          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_constant="1.78577e-09">Tritium</primary>
+          <primary coefficient_of_diffusion="1.0E-9" first_order_decay_rate_constant="1.78577e-09">Tritium</primary>
         </primaries>
       </dissolved_components>
     </liquid_phase>

--- a/tools/amanzi_xml/amanzi_xml/common/parameter.py
+++ b/tools/amanzi_xml/amanzi_xml/common/parameter.py
@@ -71,9 +71,9 @@ def _validValueFromType(ptype, value):
             except ValueError:
                 raise ValueError("Parameter of type float given non-Decimal-convertible value.")
 
-        if '.' not in str(d) and 'e' not in str(d).lower():
-            return Decimal(str(d)+'.0')
-        return d
+        if '.' not in str(value) and 'e' not in str(value).lower():
+            value = Decimal(str(value)+'.0')
+        return value
 
     else:
         raise ValueError(f"Invalid ptype {ptype}")
@@ -106,15 +106,18 @@ def _convertTypeToString(ptype, value):
     _checkType(ptype, value)
     
     retval = None
+
     if ptype == 'bool':
         if value is True:
             retval = "true"
         elif value is False:
             retval = "false"
+
     elif ptype == 'double':
         retval = f'{value:g}'
         if '.' not in retval and 'e' not in retval.lower():
             retval = retval + '.0'
+
     else:
         retval = str(value).strip()
     return retval

--- a/tools/amanzi_xml/fix_chemistry_ts_control.py
+++ b/tools/amanzi_xml/fix_chemistry_ts_control.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Amanzi and ATS input converter to fix timestep controller in chemistry."""
+
+import sys, os
+
+from amanzi_xml.utils import search as asearch
+from amanzi_xml.utils import io as aio
+from amanzi_xml.utils import errors as aerrors
+from amanzi_xml.common import parameter, parameter_list
+
+def fixTSControl(pk_list):
+    ts_control = pk_list.sublist("timestep controller")
+    if ts_control.isElement("timestep controller type"):
+        tsc_type = ts_control.getElement("timestep controller type").getValue()
+        return
+
+    elif pk_list.isElement("timestep control method"):
+        method = pk_list.pop("timestep control method").getValue()
+        if method == "simple":
+            method = "standard"
+    else:
+        method = "fixed" # default in chem PK    
+
+    ts_control.setParameter("timestep controller type", "string", method)
+    tsc_params = ts_control.sublist(f"timestep controller {method} parameters")
+
+    # parameters in the fixed timestep controller
+    if method == "fixed":
+        if pk_list.isElement("initial timestep (s)"):
+            tsc_params.setParameter("timestep [s]", "double",
+                                  pk_list.pop("initial timestep (s)").getValue())
+        else:
+            tsc_params.setParameter("timestep [s]", "double", 1.e16);
+
+        # remove dead stuff
+        for dead in ["min timestep (s)",
+                     "max timestep (s)",
+                     "timestep cut threshold",
+                     "timestep increase threshold",
+                     "timestep cut factor",
+                     "timestep increase factor"]:
+            if pk_list.isElement(dead):
+                pk_list.pop(dead)
+
+    # parameters in the simple timestep controller
+    elif method == "standard":
+        if pk_list.isElement("initial timestep (s)"):
+            tsc_params.setParameter("initial timestep [s]", "double",
+                                  pk_list.pop("initial timestep (s)").getValue())
+        if tsc_params.isElement("min timestep (s)"):
+            tsc_params.setParameter("min timestep [s]", "double",
+                                  pk_list.pop("min timestep (s)").getValue())
+        if pk_list.isElement("max timestep (s)"):
+            tsc_params.setParameter("max timestep [s]", "double",
+                                  pk_list.pop("max timestep (s)").getValue())
+        if pk_list.isElement("timestep cut threshold"):
+            tsc_params.setParameter("max iterations", "int",
+                                  pk_list.pop("timestep cut threshold").getValue())
+        if pk_list.isElement("timestep increase threshold"):
+            tsc_params.setParameter("min iterations", "int",
+                                  pk_list.pop("timestep increase threshold").getValue())
+        if pk_list.isElement("timestep cut factor"):
+            tsc_params.setParameter("timestep reduction factor", "double",
+                                  pk_list.pop("timestep cut factor").getValue())
+        if pk_list.isElement("timestep increase factor"):
+            tsc_params.setParameter("timestep increase factor", "double",
+                                  pk_list.pop("timestep increase factor").getValue())
+            
+
+
+def preOrder(xml):
+    yield xml
+    for child in xml:
+        for c in preOrder(child):
+            yield c
+
+            
+def findAllPKType(xml, pk_type):
+    """Amanzi doesn't always include "PK type" in the PKs sublist,
+    only in the tree.  This works, but makes it hard to find all
+    PKs of a given type.
+    """
+    flat_pks = xml.sublist("PKs")
+    
+    for pk_tree in asearch.findall_path(xml, ["PK tree"]):
+        for pk in preOrder(pk_tree):
+            if isinstance(pk, parameter_list.ParameterList):
+                if pk.isElement("PK type"):
+                    if pk.getElement("PK type").getValue() == pk_type:
+                        yield flat_pks.getElement(pk.getName())
+
+
+def fixAll(xml):
+    if xml.isElement("PKs"):
+        for pk_list in findAllPKType(xml, "chemistry alquimia"):
+            print(f"Fixing {pk_list.getName()}")
+            fixTSControl(pk_list)
+        for pk_list in findAllPKType(xml, "chemistry amanzi"):
+            print(f"Fixing {pk_list.getName()}")
+            fixTSControl(pk_list)
+        
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("infile", help="input filename")
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-i", "--inplace", action="store_true", help="fix file in place")
+    group.add_argument("-o", "--outfile", help="output filename")
+
+    parser.add_argument("-s", "--skip", action="store_true", help="read and write only, no changes")
+    args = parser.parse_args()
+
+    # check for orig file
+    print("Converting file: %s"%args.infile)
+    xml = aio.fromFile(args.infile, True)
+
+    if not args.skip:
+        fixAll(xml)
+
+    if args.inplace:
+        aio.toFile(xml, args.infile)
+    else:
+        aio.toFile(xml, args.outfile)
+    sys.exit(0)
+

--- a/tools/amanzi_xml/fix_chemistry_ts_control.py
+++ b/tools/amanzi_xml/fix_chemistry_ts_control.py
@@ -60,8 +60,9 @@ def fixTSControl(pk_list):
             tsc_params.setParameter("min iterations", "int",
                                   pk_list.pop("timestep increase threshold").getValue())
         if pk_list.isElement("timestep cut factor"):
+            # NOTE: the old cut factor is > 1, while the reduction factor is < 1
             tsc_params.setParameter("timestep reduction factor", "double",
-                                  pk_list.pop("timestep cut factor").getValue())
+                                  1.0 / pk_list.pop("timestep cut factor").getValue())
         if pk_list.isElement("timestep increase factor"):
             tsc_params.setParameter("timestep increase factor", "double",
                                   pk_list.pop("timestep increase factor").getValue())

--- a/tools/cmake/AmanziVersion.cmake
+++ b/tools/cmake/AmanziVersion.cmake
@@ -41,7 +41,7 @@ if ( (EXISTS ${CMAKE_SOURCE_DIR}/.git/) AND (GIT_FOUND) )
   if (err_occurred)
     message(WARNING "Error executing git:\n ${cmd}\n${err}")
     set(cmd_output cmd_output-NOTFOUND)
-    exit()
+    #exit()
   endif()
 
   # Put the status in a list
@@ -72,7 +72,7 @@ if ( (EXISTS ${CMAKE_SOURCE_DIR}/.git/) AND (GIT_FOUND) )
   if(err_occurred)
     message(WARNING "Error executing git:\n ${cmd}\n${err}")
     set(cmd_output cmd_output-NOTFOUND)
-    exit()
+    #exit()
   endif()
 
   message(STATUS ">>>> JDM: AMANZI_GIT_GLOBAL_HASH = ${AMANZI_GIT_GLOBAL_HASH}")
@@ -89,7 +89,7 @@ if ( (EXISTS ${CMAKE_SOURCE_DIR}/.git/) AND (GIT_FOUND) )
   if(err_occurred)
     message(WARNING "Error executing git:\n ${cmd}\n${cmd_output}\n${err}")
     set(cmd_output cmd_output-NOTFOUND)
-    exit()
+    #exit()
   endif()
     
   # Get the latest amanzi-* version number tag    


### PR DESCRIPTION
- Chemistry_PK was largely unused, and now does only a few specific things, most notably timestep size control through TimestepController
- Alquimia_PK now uses tags
- Alquimia_PK now has a struct for all vectors to amortize State calls
- Alquimia_PK names/keys now use variable names that match Alquimia, not Amanzi chemistry
- runs tools/amanzi_xml/fix_chemistry_ts_control.py on all xml, which changes xml parameters to use "timestep controller" object