### PR TITLE
Transport changes to enable ATS transport refactor

### DIFF
--- a/src/common/interface_platform/InputConverterU_Transport.cc
+++ b/src/common/interface_platform/InputConverterU_Transport.cc
@@ -212,7 +212,7 @@ InputConverterU::TranslateTransport_(const std::string& domain)
 
           std::string formula = GetAttributeValueS_(node, "alpha", TYPE_NONE, false, "m");
 
-          tmp_list.sublist("parameters for scalar")
+          tmp_list.sublist("scalar parameters")
             .sublist("alpha")
             .sublist("function-exprtk")
             .set<int>("number of arguments", dim_ + 1)
@@ -223,7 +223,7 @@ InputConverterU::TranslateTransport_(const std::string& domain)
           al = GetAttributeValueD_(node, "alpha_l", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
           at = GetAttributeValueD_(node, "alpha_t", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
 
-          tmp_list.sublist("parameters for Bear")
+          tmp_list.sublist("Bear parameters")
             .set<double>("alpha_l", al)
             .set<double>("alpha_t", at);
         } else if (strcmp(model.c_str(), "burnett_frind") == 0) {
@@ -233,7 +233,7 @@ InputConverterU::TranslateTransport_(const std::string& domain)
           ath = GetAttributeValueD_(node, "alpha_th", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
           atv = GetAttributeValueD_(node, "alpha_tv", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
 
-          tmp_list.sublist("parameters for Burnett-Frind")
+          tmp_list.sublist("Burnett-Frind parameters")
             .set<double>("alpha_l", al)
             .set<double>("alpha_th", ath)
             .set<double>("alpha_tv", atv);
@@ -247,7 +247,7 @@ InputConverterU::TranslateTransport_(const std::string& domain)
           ath = GetAttributeValueD_(node, "alpha_th", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
           atv = GetAttributeValueD_(node, "alpha_tv", TYPE_NUMERICAL, 0.0, DVAL_MAX, "m");
 
-          tmp_list.sublist("parameters for Lichtner-Kelkar-Robinson")
+          tmp_list.sublist("Lichtner-Kelkar-Robinson parameters")
             .set<double>("alpha_lh", alh)
             .set<double>("alpha_lv", alv)
             .set<double>("alpha_th", ath)

--- a/src/common/interface_platform/test/converter_u_validate01.xml
+++ b/src/common/interface_platform/test/converter_u_validate01.xml
@@ -710,7 +710,7 @@
         <ParameterList name="Facies_1">
           <Parameter name="regions" type="Array(string)" value="{RegionMiddle}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="1.0e-02"/>
             <Parameter name="alpha_t" type="double" value="1.0e-03"/>
           </ParameterList>
@@ -718,7 +718,7 @@
         <ParameterList name="Facies_2">
           <Parameter name="regions" type="Array(string)" value="{RegionBottom}"/>
           <Parameter name="model" type="string" value="Burnett-Frind"/>
-          <ParameterList name="parameters for Burnett-Frind">
+          <ParameterList name="Burnett-Frind parameters">
             <Parameter name="alpha_l" type="double" value="1.0e-02"/>
             <Parameter name="alpha_th" type="double" value="1.0e-03"/>
             <Parameter name="alpha_tv" type="double" value="2.0e-03"/>
@@ -727,7 +727,7 @@
         <ParameterList name="Facies_3">
           <Parameter name="regions" type="Array(string)" value="{RegionTop}"/>
           <Parameter name="model" type="string" value="Lichtner-Kelkar-Robinson"/>
-          <ParameterList name="parameters for Lichtner-Kelkar-Robinson">
+          <ParameterList name="Lichtner-Kelkar-Robinson parameters">
             <Parameter name="alpha_lh" type="double" value="1.0e-02"/>
             <Parameter name="alpha_lv" type="double" value="2.0e-02"/>
             <Parameter name="alpha_th" type="double" value="1.0e-03"/>

--- a/src/common/interface_platform/test/converter_u_validate04.xml
+++ b/src/common/interface_platform/test/converter_u_validate04.xml
@@ -705,7 +705,7 @@
         <ParameterList name="Soil">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.0"/>
             <Parameter name="alpha_t" type="double" value="0.0"/>
           </ParameterList>

--- a/src/mpc/test/mpc_coupled_dispersive_transport.xml
+++ b/src/mpc/test/mpc_coupled_dispersive_transport.xml
@@ -383,7 +383,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.0"/>
             <Parameter name="alpha_t" type="double" value="0.0"/>
           </ParameterList>
@@ -438,7 +438,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.0"/>
             <Parameter name="alpha_t" type="double" value="0.0"/>
           </ParameterList>

--- a/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
+++ b/src/mpc/test/mpc_coupled_flow_transport_implicit.xml
@@ -699,7 +699,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.01"/>
             <Parameter name="alpha_t" type="double" value="0.001"/>
           </ParameterList>
@@ -799,7 +799,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.1"/>
             <Parameter name="alpha_t" type="double" value="0.01"/>
           </ParameterList>

--- a/src/output/HDF5_MPI.cc
+++ b/src/output/HDF5_MPI.cc
@@ -1074,6 +1074,15 @@ HDF5_MPI::readAttrInt(int& value, const std::string attrname)
                               data_file_,
                               loc_h5path,
                               &IOgroup_);
+  if (ierr < 0) {
+    // try to read ints as int or long.
+    ierr = parallelIO_read_simple_attr(loc_attrname,
+            reinterpret_cast<void**>(&loc_value),
+            PIO_LONG,
+            data_file_,
+            loc_h5path,
+            &IOgroup_);
+  }
   checkThrow_(ierr, attrname, H5DataFilename_);
 
   value = *loc_value;

--- a/src/pks/PK_DomainFunctionCoupling.hh
+++ b/src/pks/PK_DomainFunctionCoupling.hh
@@ -40,16 +40,16 @@ There are a few coupling submodels:
 /*
 The following parameter names were changed:
     "flux_key" -> "flux key"
-    "copy_flux_tag" -> "flux copy key"
+    "copy_flux_tag" -> "flux tag"
 
     "field_in_key" -> removed
     "copy_field_in_key" -> removed
 
     "field_out_key" -> "external field key"
-    "copy_field_out_tag" -> "external field copy key"
+    "copy_field_out_tag" -> "external field tag"
 
     "conserved_quantity_key" -> "conserved quantity key"
-    "copy_conserved_quantity_key" -> "conserved quantity copy key"
+    "copy_conserved_quantity_key" -> "conserved quantity tag"
 */
 
 #ifndef AMANZI_PK_DOMAIN_FUNCTION_COUPLING_HH_
@@ -104,9 +104,9 @@ class PK_DomainFunctionCoupling : public FunctionBase {
  private:
   std::string submodel_;
 
-  Key flux_key_;
-  Key field_cons_key_, field_out_key_;
-  Tag copy_flux_tag_, copy_field_out_tag_, copy_field_cons_tag_;
+  Key flux_key_, field_cons_key_, field_out_key_;
+  Tag flux_tag_, field_cons_tag_, field_out_tag_;
+
 
   Teuchos::RCP<MeshIDs> entity_ids_;
   std::map<AmanziMesh::Entity_ID, AmanziMesh::Entity_ID> reverse_map_;
@@ -147,13 +147,13 @@ PK_DomainFunctionCoupling<FunctionBase>::Init(const Teuchos::ParameterList& plis
     "field_out_key", "copy_field_out_tag", "conserved_quantity_key", "copy_conserved_quantity_key"
   };
   std::vector<std::string> newstyle = { "flux key",
-                                        "flux copy key",
+                                        "flux tag",
                                         "removed1",
                                         "removed2",
                                         "external field key",
-                                        "external field copy key",
+                                        "external field tag",
                                         "conserved quantity key",
-                                        "conserved quantity copy key" };
+                                        "conserved quantity tag" };
 
   for (int i = 0; i < deprecated.size(); ++i) {
     std::string name = deprecated[i];
@@ -170,11 +170,11 @@ PK_DomainFunctionCoupling<FunctionBase>::Init(const Teuchos::ParameterList& plis
   // get keys of owned (in) and exterior (out) fields
   if (submodel_ == "rate" || submodel_ == "flux exchange") {
     flux_key_ = slist.get<std::string>("flux key");
-    copy_flux_tag_ = Keys::readTag(slist, "flux copy key");
+    flux_tag_ = Keys::readTag(slist, "flux");
 
   } else if (submodel_ == "conserved quantity") {
     field_cons_key_ = slist.get<std::string>("conserved quantity key");
-    copy_field_cons_tag_ = Keys::readTag(slist, "conserved quantity copy key");
+    field_cons_tag_ = Keys::readTag(slist, "conserved quantity");
 
   } else if (submodel_ == "field") {
     // pass
@@ -186,7 +186,7 @@ PK_DomainFunctionCoupling<FunctionBase>::Init(const Teuchos::ParameterList& plis
   }
 
   field_out_key_ = slist.get<std::string>("external field key");
-  copy_field_out_tag_ = Keys::readTag(slist, "external field copy key");
+  field_out_tag_ = Keys::readTag(slist, "external field");
 
   // create a list of domain ids
   RegionList regions = plist.get<Teuchos::Array<std::string>>("regions").toVector();
@@ -218,7 +218,7 @@ PK_DomainFunctionCoupling<FunctionBase>::Compute(double t0, double t1)
   Errors::Message msg;
 
   // compute reverse map: should we move this to Init() ???
-  mesh_out_ = S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_).Mesh();
+  mesh_out_ = S_->Get<CompositeVector>(field_out_key_, field_out_tag_).Mesh();
 
   if (submodel_ == "field" || submodel_ == "conserved quantity") {
     if (mesh_->getSpaceDimension() == mesh_->getManifoldDimension() && reverse_map_.size() == 0) {
@@ -233,13 +233,13 @@ PK_DomainFunctionCoupling<FunctionBase>::Compute(double t0, double t1)
   // create the input tuple (time + space)
   if (submodel_ == "rate") {
     const auto& flux =
-      *S_->Get<CompositeVector>(flux_key_, copy_flux_tag_).ViewComponent("face", true);
+      *S_->Get<CompositeVector>(flux_key_, flux_tag_).ViewComponent("face", true);
     const auto& flux_map =
-      S_->Get<CompositeVector>(flux_key_, copy_flux_tag_).Map().Map("face", true);
+      S_->Get<CompositeVector>(flux_key_, flux_tag_).Map().Map("face", true);
 
     const auto& field_out =
-      *S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_).ViewComponent("cell", true);
-    S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_).ScatterMasterToGhosted("cell");
+      *S_->Get<CompositeVector>(field_out_key_, field_out_tag_).ViewComponent("cell", true);
+    S_->Get<CompositeVector>(field_out_key_, field_out_tag_).ScatterMasterToGhosted("cell");
 
     int num_vec = field_out.NumVectors();
 
@@ -286,9 +286,9 @@ PK_DomainFunctionCoupling<FunctionBase>::Compute(double t0, double t1)
 
   } else if (submodel_ == "flux exchange") {
     const auto& flux =
-      *S_->Get<CompositeVector>(flux_key_, copy_flux_tag_).ViewComponent("face", true);
+      *S_->Get<CompositeVector>(flux_key_, flux_tag_).ViewComponent("face", true);
     const auto& flux_map =
-      S_->Get<CompositeVector>(flux_key_, copy_flux_tag_).Map().Map("face", true);
+      S_->Get<CompositeVector>(flux_key_, flux_tag_).Map().Map("face", true);
 
     // loop over cells on the manifold
     for (auto c : *entity_ids_) {
@@ -322,7 +322,7 @@ PK_DomainFunctionCoupling<FunctionBase>::Compute(double t0, double t1)
 
   } else if (submodel_ == "field") {
     const auto& field_out =
-      *S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_).ViewComponent("cell", true);
+      *S_->Get<CompositeVector>(field_out_key_, field_out_tag_).ViewComponent("cell", true);
 
     int num_vec = field_out.NumVectors();
     std::vector<double> val(num_vec);
@@ -340,9 +340,9 @@ PK_DomainFunctionCoupling<FunctionBase>::Compute(double t0, double t1)
 
   } else if (submodel_ == "conserved quantity") {
     const auto& field_out =
-      *S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_).ViewComponent("cell", true);
+      *S_->Get<CompositeVector>(field_out_key_, field_out_tag_).ViewComponent("cell", true);
     const auto& field_cons =
-      *S_->Get<CompositeVector>(field_cons_key_, copy_field_cons_tag_).ViewComponent("cell", true);
+      *S_->Get<CompositeVector>(field_cons_key_, field_cons_tag_).ViewComponent("cell", true);
 
     int num_vec = field_out.NumVectors();
     std::vector<double> val(num_vec);

--- a/src/pks/PK_DomainFunctionFactory.hh
+++ b/src/pks/PK_DomainFunctionFactory.hh
@@ -135,21 +135,21 @@ PK_DomainFunctionFactory<FunctionBase>::Create(Teuchos::ParameterList& plist,
   } else if (model == "first order exchange") {
     AMANZI_ASSERT(kind == AmanziMesh::Entity_kind::CELL);
     plist.sublist("source function")
-      .set<std::string>("total component concentration copy", tag.get());
+      .set<std::string>("exchanged quantity tag", tag.get());
     Teuchos::RCP<PK_DomainFunctionFirstOrderExchange<FunctionBase>> func =
       Teuchos::rcp(new PK_DomainFunctionFirstOrderExchange<FunctionBase>(mesh_, plist, kind));
     func->Init(plist, keyword);
     return func;
   } else if (model == "subgrid") {
     AMANZI_ASSERT(kind == AmanziMesh::Entity_kind::FACE);
-    plist.sublist(keyword).set<std::string>("copy_field_out_tag", tag.get());
+    plist.sublist(keyword).set<std::string>("disaggregated tag", tag.get());
     Teuchos::RCP<PK_DomainFunctionSubgrid<FunctionBase>> func =
       Teuchos::rcp(new PK_DomainFunctionSubgrid<FunctionBase>(mesh_));
     func->Init(plist, keyword, kind);
     return func;
   } else if (model == "subgrid return") {
     AMANZI_ASSERT(kind == AmanziMesh::Entity_kind::CELL);
-    plist.sublist("source function").set<std::string>("copy subgrid field", tag.get());
+    plist.sublist("source function").set<std::string>("subgrid field tag", tag.get());
     Teuchos::RCP<PK_DomainFunctionSubgridReturn<FunctionBase>> func =
       Teuchos::rcp(new PK_DomainFunctionSubgridReturn<FunctionBase>(mesh_, plist));
     func->Init(plist, keyword);

--- a/src/pks/PK_DomainFunctionField.hh
+++ b/src/pks/PK_DomainFunctionField.hh
@@ -120,7 +120,7 @@ PK_DomainFunctionField<FunctionBase>::Init(const Teuchos::ParameterList& plist,
           std::stringstream sublist_name;
           sublist_name << "field " << lcv << " info";
           Key field_key_ = flist.sublist(sublist_name.str()).get<std::string>("field key");
-          Tag tag = Keys::readTag(flist.sublist(sublist_name.str()), "tag");
+          Tag tag = Keys::readTag(flist.sublist(sublist_name.str()));
           field_keys_.push_back(field_key_);
           tags_.push_back(tag);
         }
@@ -128,7 +128,7 @@ PK_DomainFunctionField<FunctionBase>::Init(const Teuchos::ParameterList& plist,
     } else { // for only ONE field evaluator (without number of fields sublist)
       Key field_key_ = flist.get<std::string>("field key");
       field_keys_.push_back(field_key_);
-      Tag tag = Keys::readTag(flist, "tag");
+      Tag tag = Keys::readTag(flist);
       tags_.push_back(tag);
       // component_key_ = flist.get<std::string>("component", "cell");
     }

--- a/src/pks/PK_DomainFunctionFirstOrderExchange.hh
+++ b/src/pks/PK_DomainFunctionFirstOrderExchange.hh
@@ -59,15 +59,15 @@ class PK_DomainFunctionFirstOrderExchange : public FunctionBase,
   using FunctionBase::value_;
   using FunctionBase::keyword_;
 
-  Teuchos::RCP<const State> S_;
+  Teuchos::RCP<State> S_;
 
  private:
   AmanziMesh::Entity_kind kind_;
-  Key tcc_key_;
-  Tag tcc_copy_;
+  Key exchanged_key_;
+  Tag exchanged_tag_;
 
-  Key saturation_key_, porosity_key_, molar_density_key_;
-  Tag saturation_copy_, porosity_copy_, molar_density_copy_;
+  Key lwc_key_;
+  Tag lwc_tag_;
 };
 
 
@@ -79,24 +79,14 @@ void
 PK_DomainFunctionFirstOrderExchange<FunctionBase>::Init(const Teuchos::ParameterList& plist,
                                                         const std::string& keyword)
 {
-  keyword_ = keyword;
-
-  // get the model parameters
   Teuchos::ParameterList blist = plist.sublist("source function");
-  std::string domain_name = blist.get<std::string>("domain name", "domain");
 
-  tcc_key_ = Keys::readKey(
-    blist, domain_name, "total component concentration", "total_component_concentration");
-  tcc_copy_ = Keys::readTag(blist, "total component concentration copy");
+  Key domain_name = Keys::readDomain(blist, "domain", "domain");
+  exchanged_key_ = Keys::readKey(blist, domain_name, "exchanged quantity", "molar_ratio");
+  exchanged_tag_ = Keys::readTag(blist, "exchanged quantity");
 
-  saturation_key_ = Keys::readKey(blist, domain_name, "saturation liquid", "ponded_depth");
-  saturation_copy_ = Keys::readTag(blist, "saturation liquid copy");
-
-  porosity_key_ = Keys::readKey(blist, domain_name, "porosity", "porosity");
-  porosity_copy_ = Keys::readTag(blist, "porosity copy");
-
-  molar_density_key_ = Keys::readKey(blist, domain_name, "molar density", "molar_density_liquid");
-  molar_density_copy_ = Keys::readTag(blist, "molar density copy");
+  lwc_key_ = Keys::readKey(blist, domain_name, "liquid water content", "water_content");
+  lwc_tag_ = Keys::readTag(blist, "liquid water content", exchanged_tag_);
 
   // get and check the regions
   auto regions = plist.get<Teuchos::Array<std::string>>("regions").toVector();
@@ -125,40 +115,35 @@ template <class FunctionBase>
 void
 PK_DomainFunctionFirstOrderExchange<FunctionBase>::Compute(double t0, double t1)
 {
+  std::cout << "FirstOrderExchange" << std::endl;
   if (unique_specs_.size() == 0) return;
 
   // create the input tuple (time + space)
   int dim = mesh_->getSpaceDimension();
   std::vector<double> args(1 + dim);
+  args[0] = t1;
 
-  // get the tcc vector
-  const auto& tcc = *S_->Get<CompositeVector>(tcc_key_, tcc_copy_).ViewComponent("cell");
-  const auto& ws =
-    *S_->Get<CompositeVector>(saturation_key_, saturation_copy_).ViewComponent("cell");
-  const auto& phi = *S_->Get<CompositeVector>(porosity_key_, porosity_copy_).ViewComponent("cell");
-  const auto& mol_dens =
-    *S_->Get<CompositeVector>(molar_density_key_, molar_density_copy_).ViewComponent("cell");
+  // get the molar mixing ratio, water contents
+  S_->GetEvaluator(exchanged_key_, exchanged_tag_).Update(*S_, exchanged_key_+"_first_order_exchange");
+  S_->GetEvaluator(lwc_key_, lwc_tag_).Update(*S_, lwc_key_+"_first_order_exchange");
+  const auto& ex = *S_->Get<CompositeVector>(exchanged_key_, exchanged_tag_).ViewComponent("cell");
+  const auto& lwc = *S_->Get<CompositeVector>(lwc_key_, lwc_tag_).ViewComponent("cell");
 
-  for (UniqueSpecList::const_iterator uspec = unique_specs_.at(kind_)->begin();
-       uspec != unique_specs_.at(kind_)->end();
-       ++uspec) {
-    args[0] = t1;
-    Teuchos::RCP<MeshIDs> ids = (*uspec)->second;
-    // uspec->first is a RCP<Spec>, Spec's second is an RCP to the function.
-    int nfun = (*uspec)->first->second->size();
+  for (const auto& uspec : *unique_specs_.at(kind_)) {
+    // uspec is a RCP<pair<RCP<Spec>>, RCP<MeshIDs>>
+    Teuchos::RCP<MeshIDs> ids = uspec->second;
+    int nfun = uspec->first->second->size();
     std::vector<double> val_vec(nfun, 0.);
 
-    for (auto c = ids->begin(); c != ids->end(); ++c) {
-      auto xc = PKUtils_EntityCoordinates(*c, kind_, *mesh_);
-
+    for (auto c : *ids) {
+      const auto& xc = mesh_->getCentroid(kind_, c);
       for (int i = 0; i != dim; ++i) args[i + 1] = xc[i];
 
       // uspec->first is a RCP<Spec>, Spec's second is an RCP to the function.
-      double tmp = ws[0][*c] * phi[0][*c] * mol_dens[0][*c];
       for (int i = 0; i < nfun; ++i) {
-        val_vec[i] = -(*(*uspec)->first->second)(args)[i] * tcc[i][*c] * tmp;
+        val_vec[i] = -(*uspec->first->second)(args)[i] * ex[i][c] * lwc[0][c] / mesh_->getCellVolume(c);
       }
-      value_[*c] = val_vec;
+      value_[c] = val_vec;
     }
   }
 }

--- a/src/pks/PK_DomainFunctionParentMeshField.hh
+++ b/src/pks/PK_DomainFunctionParentMeshField.hh
@@ -100,8 +100,9 @@ PK_DomainFunctionParentMeshField<FunctionBase>::Init(const Teuchos::ParameterLis
   AMANZI_ASSERT(region_kind == AmanziMesh::Entity_kind::FACE);
 
   // get field name and tag
-  field_key_ = slist.get<std::string>("external field key");
-  field_tag_ = Keys::readTag(slist, "external field tag");
+  Key domain_name = Keys::readDomain(slist, "domain", "domain");
+  field_key_ = Keys::readKey(slist, domain_name, "external field");
+  field_tag_ = Keys::readTag(slist, "external field");
 
   // create a list of domain ids
   RegionList regions = plist.get<Teuchos::Array<std::string>>("regions").toVector();

--- a/src/pks/PK_DomainFunctionSubgrid.hh
+++ b/src/pks/PK_DomainFunctionSubgrid.hh
@@ -58,8 +58,8 @@ class PK_DomainFunctionSubgrid : public FunctionBase {
   AmanziMesh::Entity_ID entity_lid_;
   AmanziMesh::Entity_ID entity_gid_out_;
 
-  Key field_out_key_;
-  Tag copy_field_out_tag_;
+  Key disaggregated_key_;
+  Tag disaggregated_tag_;
 };
 
 
@@ -74,15 +74,10 @@ PK_DomainFunctionSubgrid<FunctionBase>::Init(const Teuchos::ParameterList& plist
 {
   keyword_ = keyword;
 
-  try {
-    Teuchos::ParameterList blist = plist.sublist(keyword);
-    field_out_key_ = blist.get<std::string>("field_out_key");
-    copy_field_out_tag_ = Keys::readTag(blist, "copy_field_out_tag");
-  } catch (Errors::Message& msg) {
-    Errors::Message m;
-    m << "error in domain subgrid sublist : " << msg.what();
-    Exceptions::amanzi_throw(m);
-  }
+  Teuchos::ParameterList blist = plist.sublist(keyword);
+  Key domain_name = Keys::readDomain(blist, "domain", "domain");
+  disaggregated_key_ = Keys::readKey(blist, domain_name, "disaggregated");
+  disaggregated_tag_ = Keys::readTag(blist, "disaggregated");
 
   auto regions = plist.get<Teuchos::Array<std::string>>("regions");
   if (regions.size() != 1) {
@@ -108,7 +103,7 @@ PK_DomainFunctionSubgrid<FunctionBase>::Init(const Teuchos::ParameterList& plist
     Exceptions::amanzi_throw(m);
   }
 
-  entity_gid_out_ = plist.get<int>("entity_gid_out");
+  entity_gid_out_ = plist.get<int>("entity GID");
 }
 
 
@@ -119,16 +114,16 @@ template <class FunctionBase>
 void
 PK_DomainFunctionSubgrid<FunctionBase>::Compute(double t0, double t1)
 {
-  auto& vec_out = S_->Get<CompositeVector>(field_out_key_, copy_field_out_tag_);
-  const auto& field_out = *vec_out.ViewComponent("cell", true);
+  auto& vec_out = S_->Get<CompositeVector>(disaggregated_key_, disaggregated_tag_);
+  const auto& disaggregated = *vec_out.ViewComponent("cell", true);
 
-  int num_vec = field_out.NumVectors();
+  int num_vec = disaggregated.NumVectors();
   std::vector<double> val(num_vec);
 
   AmanziMesh::Entity_ID entity_lid_out =
     vec_out.Mesh()->getMap(AmanziMesh::Entity_kind::CELL, false).LID(entity_gid_out_);
   AMANZI_ASSERT(entity_lid_out >= 0);
-  for (int k = 0; k < num_vec; ++k) val[k] = field_out[k][entity_lid_out];
+  for (int k = 0; k < num_vec; ++k) val[k] = disaggregated[k][entity_lid_out];
   value_[entity_lid_] = val;
 }
 

--- a/src/pks/PK_DomainFunctionSubgridReturn.hh
+++ b/src/pks/PK_DomainFunctionSubgridReturn.hh
@@ -53,14 +53,14 @@ class PK_DomainFunctionSubgridReturn : public FunctionBase, public Functions::Un
   using FunctionBase::value_;
   using FunctionBase::keyword_;
   using Functions::UniqueMeshFunction::mesh_;
-  Teuchos::RCP<const State> S_;
+  Teuchos::RCP<State> S_;
 
  private:
-  Key field_out_suffix_, dset_;
-  Tag copy_field_out_tag_;
+  Key exchanged_suffix_, dset_;
+  Tag exchanged_tag_;
 
-  Key saturation_key_, porosity_key_, molar_density_key_;
-  Tag saturation_copy_, porosity_copy_, molar_density_copy_;
+  Key lwc_key_;
+  Tag lwc_tag_;
 };
 
 
@@ -76,25 +76,17 @@ PK_DomainFunctionSubgridReturn<FunctionBase>::Init(const Teuchos::ParameterList&
 
   // get and check the model parameters
   Teuchos::ParameterList blist = plist.sublist("source function");
-  std::string domain_name = blist.get<std::string>("domain name", "surface");
+  Key domain_name = Keys::readDomain(blist, "surface", "surface");
 
-  field_out_suffix_ = blist.get<std::string>("subgrid field suffix");
-  copy_field_out_tag_ = Keys::readTag(blist, "copy subgrid field");
+  exchanged_suffix_ = blist.get<std::string>("subgrid field suffix");
+  exchanged_tag_ = Keys::readTag(blist, "subgrid field");
 
-  // check for prefixing -- mostly used in the multisubgrid models
+  // domain set of the collection of subgrids
   dset_ = blist.get<std::string>("subgrid domain set", "subgrid");
 
-  // can "surface" prefix for this field be read automatically? it is hardcoded now, or may be not?
-  saturation_key_ = Keys::readKey(blist, domain_name, "saturation liquid", "ponded_depth");
-  saturation_copy_ = Keys::readTag(blist, "saturation liquid copy");
+  lwc_key_ = Keys::readKey(blist, domain_name, "liquid water content", "water_content");
+  lwc_tag_ = Keys::readTag(blist, "liquid water content");
 
-  porosity_key_ = Keys::readKey(blist, domain_name, "porosity", "porosity");
-  porosity_copy_ = Keys::readTag(blist, "porosity copy");
-
-  molar_density_key_ = Keys::readKey(blist, domain_name, "molar density", "molar_density_liquid");
-  molar_density_copy_ = Keys::readTag(blist, "molar density copy");
-
-  // get and check the region
   auto regions = plist.get<Teuchos::Array<std::string>>("regions").toVector();
 
   // get the function for alpha
@@ -126,44 +118,38 @@ PK_DomainFunctionSubgridReturn<FunctionBase>::Compute(double t0, double t1)
   // create the input tuple (time + space)
   int dim = mesh_->getSpaceDimension();
   std::vector<double> args(1 + dim);
+  args[0] = t1;
 
   // get the map to convert to subgrid GID
   auto& map = mesh_->getMap(AmanziMesh::Entity_kind::CELL, false);
 
-  const auto& ws_ =
-    *S_->Get<CompositeVector>(saturation_key_, saturation_copy_).ViewComponent("cell");
-  const auto& phi_ = *S_->Get<CompositeVector>(porosity_key_, porosity_copy_).ViewComponent("cell");
-  const auto& mol_dens_ =
-    *S_->Get<CompositeVector>(molar_density_key_, molar_density_copy_).ViewComponent("cell");
+  S_->GetEvaluator(lwc_key_, lwc_tag_).Update(*S_, lwc_key_+"_subgrid_return");
+  const auto& lwc = *S_->Get<CompositeVector>(lwc_key_, lwc_tag_).ViewComponent("cell");
 
-  for (auto uspec = unique_specs_.at(AmanziMesh::Entity_kind::CELL)->begin();
-       uspec != unique_specs_.at(AmanziMesh::Entity_kind::CELL)->end();
-       ++uspec) {
-    args[0] = t1;
-    Teuchos::RCP<MeshIDs> ids = (*uspec)->second;
+  for (const auto& uspec : *unique_specs_.at(AmanziMesh::Entity_kind::CELL)) {
+    Teuchos::RCP<MeshIDs> ids = uspec->second;
 
     // uspec->first is a RCP<Spec>, Spec's second is an RCP to the function.
-    int nfun = (*uspec)->first->second->size();
+    int nfun = uspec->first->second->size();
 
     // loop over all entities in the spec
-    for (MeshIDs::const_iterator c = ids->begin(); c != ids->end(); ++c) {
-      const AmanziGeometry::Point& xc = mesh_->getCellCentroid(*c);
+    for (const AmanziMesh::Entity_ID& c : *ids) {
+      const AmanziGeometry::Point& xc = mesh_->getCellCentroid(c);
 
       // set the xyz coords
       for (int i = 0; i != dim; ++i) args[i + 1] = xc[i];
 
       // uspec->first is a RCP<Spec>, Spec's second is an RCP to the function.
       std::vector<double> alpha(nfun);
-
-      for (int i = 0; i < nfun; ++i) { alpha[i] = (*(*uspec)->first->second)(args)[i]; }
+      for (int i = 0; i < nfun; ++i) { alpha[i] = (*uspec->first->second)(args)[i]; }
 
       // find the subgrid gid to be integrated
-      auto gid = map.GID(*c);
+      auto gid = map.GID(c);
       Key domain = Keys::getDomainInSet(dset_, gid);
-      Key var = Keys::getKey(domain, field_out_suffix_);
+      Key var = Keys::getKey(domain, exchanged_suffix_);
 
       // get the vector to be integrated
-      const auto& vec_out = S_->Get<CompositeVector>(var, copy_field_out_tag_);
+      const auto& vec_out = S_->Get<CompositeVector>(var, exchanged_tag_);
       const auto& vec_c = *vec_out.ViewComponent("cell", true);
 
       std::vector<double> val(nfun, 0.);
@@ -175,9 +161,9 @@ PK_DomainFunctionSubgridReturn<FunctionBase>::Compute(double t0, double t1)
         for (int k = 0; k != nfun; ++k) { val[k] += vec_c[k][c_sg] * alpha[k]; }
       }
       for (int k = 0; k != nfun; ++k) {
-        val[k] *= ws_[0][*c] * phi_[0][*c] * mol_dens_[0][*c] / ncells_sg;
+        val[k] *= lwc[0][c] / mesh_->getCellVolume(c) / ncells_sg;
       }
-      value_[*c] = val;
+      value_[c] = val;
     }
   }
 }

--- a/src/pks/PK_Physical_Default.cc
+++ b/src/pks/PK_Physical_Default.cc
@@ -25,11 +25,7 @@ namespace Amanzi {
 void
 PK_Physical_Default::parseParameterList()
 {
-  if (key_.empty()) {
-    key_ = Keys::readKey(*plist_, domain_, "primary variable");
-  } else {
-    key_ = Keys::readKey(*plist_, domain_, "primary variable", key_);
-  }
+  key_ = Keys::readKey(*plist_, domain_, "primary variable");
   passwd_ = plist_->get<std::string>("primary variable password", name());
 
   // require primary variable evaluators

--- a/src/pks/chemistry/Alquimia_PK.hh
+++ b/src/pks/chemistry/Alquimia_PK.hh
@@ -9,38 +9,69 @@
 
 /*!
 
-The Alquimia chemistry process kernel only requires the *Engine* and *Engine Input File*
-entries, but will also accept and respect the value given for *max timestep (s)*.
-Most details are provided in the trimmed PFloTran file *1d-tritium-trim.in*.
+The Alquimia PK leverages the Alquimia interface to implement chemical
+reactions by calling out to a chemical engine.
 
-.. admonition:: alquimia-spec
+This PK, by it self, solves the following set of ODEs:
 
-  * `"minerals`" ``[Array(string)]`` is the list of mineral names.
+.. math::
+   \frac{\partial C_ij}{\partial t} = \sum_{k=1..nreactions} R_ik(C_{i=1..ncomponents,j})
 
-  * `"sorption sites`" ``[Array(string)]`` is the list of sorption sites.
+for k indexing reactions, i indexing components, and j indexing grid cell.  The
+concentrations C are in `[kg L^-1]`.
 
-  * `"auxiliary data`" ``[Array(string)]`` defines additional chemistry related data that the user
-    can request be saved to vis files.
+The details of how to parameterize and specify a reaction network are specific
+to each geochemical engine, of which currently only PFloTran and Crunch are
+supported.  Corresponding input files for these engines must be provided.
+Examples are available in Amanzi's user guide tests and ATS's regression tests.
 
-  * `"min timestep (s)`" ``[double]`` is the minimum timestep that chemistry will allow 
-    the MPC to take.
+`"PK type`" = `"chemistry alquimia`"
 
-.. code-block:: xml
+.. _alquimia-pk-spec
+.. admonition:: alquimia-pk-spec
+
+  * `"timestep controller`" ``[timestep-controller-typed-spec]`` Timestep control parameters.
+
+  * `"engine`" ``[string]`` One of:
+
+    - `"CrunchFlow`"
+    - `"PfloTran`"
+
+  * `"engine input file`" ``[string]`` Path to the engine's input file.
+
+  KEYS:
+  - `"total component concentration`"
+  - `"mass density liquid`"
+  - `"porosity`"
+  - `"saturation liquid`"
+  - `"temperature`"
+  - `"mineral volume fractions`"
+  - `"mineral specific surface area`"
+  - `"mineral rate constant`"
+  - `"surface site density`"
+  - `"total_sorbed`"
+  - `"isotherm kd`"
+  - `"isotherm freundlich n`"
+  - `"isotherm langmuir b`"
+  - `"first order decay ratae constant`"
+  - `"cation exchange capacity`"
+  - `"aux data`"
+  - `"pH`"
+
+
+See the Alquimia documentation for the needed input spec for a given engine.    
+
+ .. code-block:: xml
 
   <ParameterList>  <!-- parent list -->
-  <ParameterList name="_CHEMISTRY">
+  <ParameterList name="alquimia PK">
     <Parameter name="engine" type="string" value="PFloTran"/>
-    <Parameter name="engine input file" type="string" value="_TRITIUM.in"/>
-    <Parameter name="minerals" type="Array(string)" value="{quartz, kaolinite, goethite, opal}"/>
-    <Parameter name="min timestep (s)" type="double" value="1.5778463e-07"/>
-    <Parameter name="max timestep (s)" type="double" value="1.5778463e+07"/>
-    <Parameter name="initial timestep (s)" type="double" value="1.0e-02"/>
-    <Parameter name="timestep control method" type="string" value="simple"/>
-    <Parameter name="timestep cut threshold" type="int" value="8"/>
-    <Parameter name="timestep cut factor" type="double" value="2.0"/>
-    <Parameter name="timestep increase threshold" type="int" value="4"/>
-    <Parameter name="timestep increase factor" type="double" value="1.2"/>
-  </ParameterList>
+    <Parameter name="engine input file" type="string" value="tritium.in"/>
+    <ParameterList name="timestep controller">
+    <Parameter name="timestep control type" type="string" value="fixed"/>
+    <ParameterList name="fixed parameters">
+      <Parameter name="timestep [s]" type="double" value="1.0e-02"/>
+    </ParameterList>
   </ParameterList>
 
 */
@@ -210,7 +241,7 @@ class Alquimia_PK : public Chemistry_PK {
     return chem_engine_;
   }
   void copyToAlquimia(int cell, AlquimiaBeaker& beaker);
-  void updateSubstate() override;
+  void updateSubstate(const Tag& water_tag) override;
 
  protected:
   void XMLParameters();

--- a/src/pks/chemistry/Amanzi_PK.hh
+++ b/src/pks/chemistry/Amanzi_PK.hh
@@ -113,7 +113,7 @@ class Amanzi_PK : public Chemistry_PK {
 
   void ErrorAnalysis(int ierr, std::string& internal_msg);
 
-  virtual void updateSubstate() override {}
+  virtual void updateSubstate(const Tag& water_tag) override {}
 
  private:
   void AllocateAdditionalChemistryStorage_();

--- a/src/pks/chemistry/Chemistry_PK.hh
+++ b/src/pks/chemistry/Chemistry_PK.hh
@@ -107,7 +107,7 @@ class Chemistry_PK : public PK_Physical_Default {
   virtual void set_dt(double dt) override {};
   virtual double get_dt() override;
 
-  virtual void updateSubstate() = 0;
+  virtual void updateSubstate(const Tag& water_tag) = 0;
 
  protected:
   // error messages in Chemistry are rank-local.  This method does the

--- a/src/pks/transport/CMakeLists.txt
+++ b/src/pks/transport/CMakeLists.txt
@@ -53,6 +53,7 @@ set(transport_inc_files
   MDMPartition.hh
   MDM_Isotropic.hh
   MDM_Bear.hh
+  EvaluatorMDM.hh
   MultiscaleTransportPorosity.hh
   MultiscaleTransportPorosityFactory.hh
   MultiscaleTransportPorosityPartition.hh
@@ -76,6 +77,7 @@ set(transport_src_files Transport_PK.cc Transport_TI.cc
                         Transport_HenryLaw.cc
                         MDM_Isotropic.cc MDM_Bear.cc MDM_BurnettFrind.cc MDM_LichtnerKelkarRobinson.cc
                         MDMPartition.cc MDMFactory.cc
+                        EvaluatorMDM.cc
                         MultiscaleTransportPorosityFactory.cc
                         MultiscaleTransportPorosity_DPM.cc MultiscaleTransportPorosity_GDPM.cc
                         MultiscaleTransportPorosityPartition.cc

--- a/src/pks/transport/EvaluatorMDM.cc
+++ b/src/pks/transport/EvaluatorMDM.cc
@@ -1,0 +1,116 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (ecoon@lanl.gov)
+*/
+
+
+#include "TensorVector.hh"
+#include "MDMFactory.hh"
+#include "MDMPartition.hh"
+#include "EvaluatorMDM.hh"
+
+namespace Amanzi {
+namespace Transport {
+
+EvaluatorMDM::EvaluatorMDM(Teuchos::ParameterList& plist) :
+  EvaluatorSecondary(plist)
+{
+  std::string domain = Keys::getDomain(my_keys_.front().first);
+  Tag tag = my_keys_.front().second;
+
+  is_surface_ = plist_.get<bool>("is surface", Keys::in(domain, "surface"));
+
+  if (!is_surface_) {
+    poro_key_ = Keys::readKey(plist_, domain, "porosity", "porosity");
+    dependencies_.insert(KeyTag{poro_key_, tag});
+  }
+
+  if (is_surface_) {
+    velocity_key_ = Keys::readKey(plist_, domain, "velocity", "water_velocity");
+  } else {
+    velocity_key_ = Keys::readKey(plist_, domain, "velocity", "darcy_velocity");
+  }
+  dependencies_.insert(KeyTag{velocity_key_, tag});
+}
+
+void
+EvaluatorMDM::Update_(State& S)
+{
+  KeyTag key_tag = my_keys_.front();
+  Tag tag = key_tag.second;
+
+  TensorVector& D = S.GetW<TensorVector>(my_keys_.front().first, tag, my_keys_.front().first);
+  const Epetra_MultiVector& velocity = *S.Get<CompositeVector>(velocity_key_, tag)
+    .ViewComponent("cell", false);
+
+  const AmanziMesh::Mesh& m = *S.GetMesh(Keys::getDomain(key_tag.first));
+
+  const double& time = S.Get<double>("time", tag);
+  int space_dim = m.getSpaceDimension();
+
+  // NOTE: here we always assume the axi-symmetry is the vertical.  Amanzi
+  // computes this by looking at permeability.
+  int axi_symmetry = space_dim - 1;
+  AmanziGeometry::Point v(space_dim);
+
+  if (is_surface_) {
+    for (int c = 0; c != D.size(); ++c) {
+      for (int i = 0; i != space_dim; ++i) v[i] = velocity[i][c];
+      D[c] = mdms_->second[(*mdms_->first)[c]]->mech_dispersion(
+        time, m.getCellCentroid(c), v, axi_symmetry, 1.0, 1.0);
+    }
+
+  } else {
+    const Epetra_MultiVector& poro = *S.Get<CompositeVector>(poro_key_, tag)
+      .ViewComponent("cell", false);
+
+    for (int c = 0; c != D.size(); ++c) {
+      for (int i = 0; i != space_dim; ++i) v[i] = velocity[i][c];
+      D[c] = mdms_->second[(*mdms_->first)[c]]->mech_dispersion(
+        time, m.getCellCentroid(c), v, axi_symmetry, 1.0, poro[0][c]);
+    }
+  }
+}
+
+
+void
+EvaluatorMDM::EnsureCompatibility(State& S)
+{
+  KeyTag my_keytag = my_keys_.front();
+  auto& fac = S.Require<TensorVector, TensorVector_Factory>(my_keytag.first, my_keytag.second, my_keytag.first);
+  EnsureCompatibility_Flags_(S);
+
+  if (fac.map().Mesh() != Teuchos::null && mdms_ == Teuchos::null) {
+    auto mesh = fac.map().Mesh();
+    auto plist = Teuchos::rcpFromRef(plist_);
+    bool flag(false);
+    mdms_ = CreateMDMPartition(fac.map().Mesh(), Teuchos::sublist(plist, "mechanical dispersion parameters"), flag);
+
+    if (!is_surface_) {
+      S.Require<CompositeVector,CompositeVectorSpace>(poro_key_, my_keytag.second)
+        .SetMesh(mesh)
+        ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+    }
+
+    S.Require<CompositeVector,CompositeVectorSpace>(velocity_key_, my_keytag.second)
+      .SetMesh(mesh)
+      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, mesh->getSpaceDimension());
+
+    CompositeVectorSpace space;
+    space.SetMesh(mesh)
+      ->SetComponent("cell", AmanziMesh::Entity_kind::CELL, 1);
+    fac.set_map(space);
+  }
+
+  for (const auto& dep : dependencies_) {
+    S.GetEvaluator(dep.first, dep.second).EnsureCompatibility(S);
+  }
+}
+
+
+} // namespace Transport
+} // namespace Amanzi

--- a/src/pks/transport/EvaluatorMDM.hh
+++ b/src/pks/transport/EvaluatorMDM.hh
@@ -1,0 +1,96 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  ATS is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon (ecoon@lanl.gov)
+*/
+
+//! Evaluates a dispersion tensor.
+/*!
+
+The dispersion tensor may be parameterized by a variety of different models,
+and is specified by region to allow different models across, e.g. stream vs
+sheet flow, or fracture vs matrix.
+
+Note that this computes the dispersion coefficient tensor, units [m^2 s^-1].
+
+It does NOT include the water content term which multiplies this tensor to
+become the diffusion tensor.  This is different from Amanzi, which uses the MDM
+class to include the water content term.
+
+`"evaluator type`" = `"dispersion tensor`"
+
+.. _mdm-evaluator-spec
+.. admonition: mdm-evaluator-spec
+
+   * `"mechanical dispersion parameters`"
+     ``[mechanical-dispersion-typed-spec-list]`` List of region-based
+     models defining the dispersion model.
+
+   * `"is surface`" ``[bool]`` **optional** Default is set if "surface" is in
+     the domain name of this variable's key, e.g. in the case
+     "surface-dispersion_coefficient".  
+
+   KEYS:
+   - `"velocity`"
+   - `"porosity`" Note this is only used if `"is surface`" = False.
+   
+
+*/
+
+#pragma once
+
+#include "dbc.hh"
+#include "EvaluatorSecondary.hh"
+#include "MDMPartition.hh"
+
+namespace Amanzi {
+namespace Transport {
+
+class EvaluatorMDM : public EvaluatorSecondary
+{
+ public:
+  // constructor format for all derived classes
+  explicit EvaluatorMDM(Teuchos::ParameterList& plist);
+
+  EvaluatorMDM(const EvaluatorMDM& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override {
+    return Teuchos::rcp(new EvaluatorMDM(*this));
+  }
+
+ protected:
+  // Required methods from EvaluatorSecondaryMonotypeCV
+  virtual void Update_(State& S) override;
+
+  virtual void UpdateDerivative_(State& S,
+          const Key& wrt_key,
+          const Tag& wrt_tag) override
+  {
+    AMANZI_ASSERT(false); // not implemented
+  }
+
+  virtual void EnsureCompatibility(State& S) override;
+
+  virtual bool IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override
+  {
+    // derivatives not implemented
+    return false;
+  }
+
+ protected:
+  Teuchos::RCP<MDMPartition> mdms_;
+
+  bool is_surface_;
+  Key poro_key_;
+  Key velocity_key_;
+
+ private:
+  static Utils::RegisteredFactory<Evaluator, EvaluatorMDM> reg_;
+
+
+};
+
+} // namespace Transport
+} // namespace Amanzi

--- a/src/pks/transport/MDM.hh
+++ b/src/pks/transport/MDM.hh
@@ -14,45 +14,21 @@ for aqueous and gaseous phases.
 The dispersivity is defined as a soil property.
 The diffusivity is defined independently for each solute.
 
-.. admonition:: mdm-spec
 
-  * _SOIL ``[list]`` Defines material properties.
+.. _mdm-typed-spec:
+.. admonition:: mdm-typed-spec
 
-    * `"region`" ``[Array(string)]`` Defines geometric regions for material SOIL.
-    * `"model`" ``[string]`` Defines dispersivity model, choose exactly one of the following: `"scalar`", `"Bear`",
-      `"Burnett-Frind`", or `"Lichtner-Kelkar-Robinson`".
-    * `"parameters for MODEL`" [list] where `"MODEL`" is the model name.
-      For model `"scalar`", *only* one of the following options must be specified:
+   * `"MDM type`" ``[string]`` Defines dispersivity model, choose exactly one of the following:
 
-      * `"alpha`" ``[double]`` defines dispersivity in all directions, [m].
-      * `"dispersion coefficient`" ``[double]`` defines dispersion coefficient [m^2/s].
+     - `"scalar`"
+     - `"Bear`",
+     - `"Burnett-Frind`"
+     - `"Lichtner-Kelkar-Robinson`"
+     
+   * `"region`" ``[Array(string)]`` Defines geometric regions for material SOIL.
 
-      For model `"Bear`", the following options must be specified:
-
-      * `"alpha_l`" ``[double]`` defines dispersion in the direction of Darcy velocity, [m].
-      * `"alpha_t`" ``[double]`` defines dispersion in the orthogonal direction, [m].
-
-      For model `"Burnett-Frind`", the following options must be specified:
-
-      * `"alphaL`" ``[double]`` defines the longitudinal dispersion in the direction of Darcy velocity, [m].
-      * `"alpha_th`" ``[double]`` Defines the transverse dispersion in the horizonla direction orthogonal directions, [m].
-      * `"alpha_tv`" ``[double]`` Defines dispersion in the orthogonal directions, [m].
-        When `"alpha_th`" equals to `"alpha_tv`", we obtain dispersion in the direction of the Darcy velocity.
-        This and the above parameters must be defined for `"Burnett-Frind`" and `"Lichtner-Kelkar-Robinson`" models.
-
-      For model `"Lichtner-Kelker-Robinson`", the following options must be specified:
-
-      * `"alpha_lh`" ``[double]`` defines the longitudinal dispersion in the horizontal direction, [m].
-      * `"alpha_lv`" ``[double]`` Defines the longitudinal dispersion in the vertical direction, [m].
-        When `"alpha_lh`" equals to `"alpha_lv`", we obtain dispersion in the direction of the Darcy velocity.
-        This and the above parameters must be defined for `"Burnett-Frind`" and `"Lichtner-Kelker-Robinson`" models.
-      * `"alpha_th`" ``[double]`` Defines the transverse dispersion in the horizontal direction orthogonal directions, [m].
-      * `"alpha_tv" ``[double]`` Defines dispersion in the orthogonal directions.
-        When `"alpha_th`" equals to `"alpha_tv`", we obtain dispersion in the direction of the Darcy velocity.
-        This and the above parameters must be defined for `"Burnett-Frind`" and `"Lichtner-Kelker-Robinson`" models.
-
-    * `"aqueous tortuosity`" ``[double]`` Defines tortuosity for calculating diffusivity of liquid solutes, [-].
-    * `"gaseous tortuosity`" ``[double]`` Defines tortuosity for calculating diffusivity of gas solutes, [-].
+   * `"_MDM_type_ parameters`" ``[_MDM_type_-spec]``] See below for the
+     required parameter spec for each type.
 
 Three examples are below:
 
@@ -63,24 +39,20 @@ Three examples are below:
     <ParameterList name="_WHITE SOIL">
       <Parameter name="regions" type="Array(string)" value="{_TOP_REGION, _BOTTOM_REGION}"/>
       <Parameter name="model" type="string" value="Bear"/>
-      <ParameterList name="parameters for Bear">
+      <ParameterList name="Bear parameters">
         <Parameter name="alpha_l" type="double" value="1e-2"/>
         <Parameter name="alpha_t" type="double" value="1e-5"/>
       <ParameterList>
-      <Parameter name="aqueous tortuosity" type="double" value="1.0"/>
-      <Parameter name="gaseous tortuosity" type="double" value="1.0"/>
     </ParameterList>
 
     <ParameterList name="_GREY SOIL">
       <Parameter name="regions" type="Array(string)" value="{_MIDDLE_REGION}"/>
       <Parameter name="model" type="string" value="Burnett-Frind"/>
-      <ParameterList name="parameters for Burnett-Frind">
+      <ParameterList name="Burnett-Frind parameters">
         <Parameter name="alpha_l" type="double" value="1e-2"/>
         <Parameter name="alpha_th" type="double" value="1e-3"/>
         <Parameter name="alpha_tv" type="double" value="2e-3"/>
       <ParameterList>
-      <Parameter name="aqueous tortuosity" type="double" value="0.5"/>
-      <Parameter name="gaseous tortuosity" type="double" value="1.0"/>
     </ParameterList>
   </ParameterList>
   </ParameterList>

--- a/src/pks/transport/MDMFactory.cc
+++ b/src/pks/transport/MDMFactory.cc
@@ -24,8 +24,14 @@ namespace Transport {
 Teuchos::RCP<MDM>
 MDMFactory::Create(Teuchos::ParameterList& plist)
 {
-  std::string mdm_typename = plist.get<std::string>("model", "scalar");
-  Teuchos::ParameterList& tmp_list = plist.sublist("parameters for " + mdm_typename);
+  std::string mdm_typename;
+  if (plist.isParameter("model")) {
+    mdm_typename = plist.get<std::string>("model");
+  } else {
+    mdm_typename = plist.get<std::string>("mechanical dispersion type", "isotropic");
+  }
+
+  Teuchos::ParameterList& tmp_list = plist.sublist(mdm_typename + " parameters");
   return Teuchos::rcp(CreateInstance(mdm_typename, tmp_list));
 };
 

--- a/src/pks/transport/MDMFactory.hh
+++ b/src/pks/transport/MDMFactory.hh
@@ -7,10 +7,20 @@
   Authors: Konstantin Lipnikov
 */
 
-/*
-  Transport PK
+/*!
 
-  Self-registering factory for MDM implementations.
+The mechanical dispersion coefficient may be described by a number of different
+models.  Each is defined on its own region.
+
+.. _mechanical-dispersion-typed-spec:
+.. admonition:: mechanical-dispersion-typed-spec
+
+   * `"region`" ``[string]`` Region on which the model is valid.
+   * `"mechanical dispersion type`" ``[string]`` Name of the model, see below for options.
+   * `"_mechanical_dispersion_type_ parameters`"
+     ``[_mechanical_dispersion_type_-spec]`` See below for the required
+     parameter spec for each type.
+
 */
 
 #ifndef PK_TRANSPORT_MDM_FACTORY_HH_

--- a/src/pks/transport/MDMPartition.cc
+++ b/src/pks/transport/MDMPartition.cc
@@ -24,7 +24,7 @@ namespace Transport {
 * Non-member factory.
 ****************************************************************** */
 Teuchos::RCP<MDMPartition>
-CreateMDMPartition(Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
+CreateMDMPartition(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                    Teuchos::RCP<Teuchos::ParameterList> plist,
                    bool& flag)
 {
@@ -38,7 +38,12 @@ CreateMDMPartition(Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
     std::string name = lcv->first;
     if (plist->isSublist(name)) {
       Teuchos::ParameterList sublist = plist->sublist(name);
-      regions.push_back(sublist.get<Teuchos::Array<std::string>>("regions").toVector());
+
+      if (sublist.isParameter("region")) {
+        regions.push_back(std::vector<std::string>{sublist.get<std::string>("region")});
+      } else {
+        regions.push_back(sublist.get<Teuchos::Array<std::string>>("regions").toVector());
+      }
 
       mdm = factory.Create(sublist);
       mdm->set_dim(mesh->getSpaceDimension());

--- a/src/pks/transport/MDMPartition.hh
+++ b/src/pks/transport/MDMPartition.hh
@@ -29,7 +29,7 @@ typedef std::pair<Teuchos::RCP<Functions::MeshPartition>, MDMList> MDMPartition;
 
 // Non-member factory returns false if all models generate zero dispersion tensor.
 Teuchos::RCP<MDMPartition>
-CreateMDMPartition(Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
+CreateMDMPartition(const Teuchos::RCP<const AmanziMesh::Mesh>& mesh,
                    Teuchos::RCP<Teuchos::ParameterList> plist,
                    bool& flag);
 

--- a/src/pks/transport/MDM_Bear.cc
+++ b/src/pks/transport/MDM_Bear.cc
@@ -29,8 +29,17 @@ namespace Transport {
 ****************************************************************** */
 MDM_Bear::MDM_Bear(Teuchos::ParameterList& plist)
 {
-  alphaL_ = plist.get<double>("alpha_l");
-  alphaT_ = plist.get<double>("alpha_t");
+  if (plist.isParameter("alpha_l")) {
+    alphaL_ = plist.get<double>("alpha_l");
+  } else {
+    alphaL_ = plist.get<double>("longitudinal dispersivity [m]");
+  }
+
+  if (plist.isParameter("alpha_t")) {
+    alphaT_ = plist.get<double>("alpha_t");
+  } else {
+    alphaT_ = plist.get<double>("transverse dispersivity [m]");
+  }
 }
 
 

--- a/src/pks/transport/MDM_Bear.hh
+++ b/src/pks/transport/MDM_Bear.hh
@@ -7,10 +7,27 @@
   Authors: Konstantin Lipnikov (lipnikov@lanl.gov)
 */
 
-/*
-  Transport PK
+/*!
 
-  Anisotropic mechanical dispersion model.
+Anisotropic mechanical dispersion model by Bear.
+
+`"mechanical dispersion type`" = `"Bear`"
+
+.. _MDM-Bear-spec
+.. admonition:: MDM-Bear-spec
+
+   ONE OF
+   * `"alpha_l`" ``[double]`` Longitudinal dispersivity.
+   OR
+   * `"longitudinal dispersivity [m]`" ``[double]``
+   END
+
+   ONE OF
+   * `"alpha_t`" ``[double]`` Transverse dispersivity.
+   OR
+   * `"transverse dispersivity [m]`" ``[double]``
+   END
+
 */
 
 #ifndef AMANZI_MDM_BEAR_HH_

--- a/src/pks/transport/MDM_BurnettFrind.hh
+++ b/src/pks/transport/MDM_BurnettFrind.hh
@@ -8,9 +8,20 @@
 */
 
 /*
-  Transport PK
 
-  Anisotropic mechanical dispersion model.
+Anisotropic mechanical dispersion model by Burnett & Frind.
+
+`"mechanical dispersion type`" = `"Burnett-Frind`"
+
+.. _MDM-Burnett-Frind-spec
+.. admonition:: MDM-Burnett-Frind-spec
+
+   * `"alpha_l`" ``[double]`` Longitudinal dispersivity/dispersion coefficient.
+   * `"alpha_tv`" ``[double]`` Vertical transverse dispersivity/dispersion coefficient.
+   * `"alpha_th`" ``[double]`` Horizontal transverse dispersivity/dispersion coefficient.
+
+
+
 */
 
 #ifndef AMANZI_MDM_BURNETT_FRIND_HH_

--- a/src/pks/transport/MDM_Isotropic.cc
+++ b/src/pks/transport/MDM_Isotropic.cc
@@ -61,11 +61,11 @@ MDM_Isotropic::MDM_Isotropic(Teuchos::ParameterList& plist)
   }
 
   if (count > 1) {
-    Errors::Message msg("Only one of \"alpha\" and \"dispersion coefficient\" may be supplied.");
+    Errors::Message msg("Only one of \"alpha\" and \"dispersion coefficient\", and \"dispersivity\" may be supplied.");
     Exceptions::amanzi_throw(msg);
   }
   if (count == 0) {
-    Errors::Message msg("Either \"alpha\" or \"dispersion coefficient\" must be supplied.");
+    Errors::Message msg("Either \"alpha\", \"dispersion coefficient\", or \"dispersivity\" must be supplied.");
     Exceptions::amanzi_throw(msg);
   }
 }
@@ -85,7 +85,6 @@ MDM_Isotropic::ParseAlpha_(Teuchos::ParameterList& plist, const std::string& key
     alpha_ = (*alpha_func_)(args);
   } else {
     alpha_ = plist.get<double>(keyword, 0.0);
-    alpha_func_ = std::make_unique<FunctionConstant>(alpha_);
   }
 }
 
@@ -98,16 +97,18 @@ MDM_Isotropic::mech_dispersion(double t,
                                const AmanziGeometry::Point& xc,
                                const AmanziGeometry::Point& u,
                                int axi_symmetric,
-                               double s,
+                               double wc,
                                double phi) const
 {
-  std::vector<double> args(1 + dim_);
-  args[0] = t;
-  for (int i = 0; i < dim_; ++i) args[i + 1] = xc[i];
-  alpha_ = (*alpha_func_)(args);
+  if (alpha_func_ != nullptr) {
+    std::vector<double> args(1 + dim_);
+    args[0] = t;
+    for (int i = 0; i < dim_; ++i) args[i + 1] = xc[i];
+    alpha_ = (*alpha_func_)(args);
+  }
 
   WhetStone::Tensor D(dim_, 1);
-  D(0, 0) = dispersivity_ ? alpha_ * s * phi * norm(u) : alpha_ * s * phi;
+  D(0, 0) = dispersivity_ ? alpha_ * wc * norm(u) / phi : alpha_ * wc;
   return D;
 }
 

--- a/src/pks/transport/MDM_Isotropic.hh
+++ b/src/pks/transport/MDM_Isotropic.hh
@@ -7,10 +7,38 @@
   Authors: Konstantin Lipnikov (lipnikov@lanl.gov)
 */
 
-/*
-  Transport PK
+/*!
 
-  Isotropic mechanical dispersion model, primarily for code testing.
+Isotropic mechanical dispersion model.
+
+`"mechanical dispersion type`" = `"scalar`"
+
+OR
+
+`"mechanical dispersion type`" = `"isotropic`"
+
+
+.. _MDM-scalar-spec
+.. admonition:: MDM-scalar-spec
+
+  ONE OF:
+
+  * `"dispersivity [m]`" ``[double]``
+
+  OR
+
+  * `"dispersivity [m]`" ``[function-spec]``
+
+  OR
+
+  * `"dispersion coefficient [m^2 s^-1]`" ``[double]``
+
+  OR
+
+  * `"dispersion coefficient [m^2 s^-1]`" ``[function-spec]``
+
+  END
+
 */
 
 #ifndef AMANZI_MDM_ISOTROPIC_HH_
@@ -58,6 +86,7 @@ class MDM_Isotropic : public MDM {
   bool dispersivity_;
 
   static Utils::RegisteredFactory<MDM, MDM_Isotropic> reg_;
+  static Utils::RegisteredFactory<MDM, MDM_Isotropic> reg2_;
 };
 
 } // namespace Transport

--- a/src/pks/transport/MDM_LichtnerKelkarRobinson.hh
+++ b/src/pks/transport/MDM_LichtnerKelkarRobinson.hh
@@ -8,9 +8,19 @@
 */
 
 /*
-  Transport PK
 
-  Anisotropic mechanical dispersion model.
+Anisotropic mechanical dispersion model by Lichtner, Kelkar, and Robinson.
+
+`"mechanical dispersion type`" = `"Lichtner-Kelkar-Robinson`"
+
+.. _MDM-Lichtner-Kelkar-Robinson-spec
+.. admonition:: MDM-Lichtner-Kelkar-Robinson-spec
+
+   * `"alpha_lv`" ``[double]`` **0.** Vertical longitudinal dispersivity/dispersion coefficient.
+   * `"alpha_lh`" ``[double]`` **0.** Horizontal longitudinal dispersivity/dispersion coefficient.
+   * `"alpha_tv`" ``[double]`` **0.** Vertical transverse dispersivity/dispersion coefficient.
+   * `"alpha_th`" ``[double]`` **0.** Horizontal transverse dispersivity/dispersion coefficient.
+
 */
 
 #ifndef AMANZI_MDM_LICHTNER_KELKAR_ROBINSON_HH_

--- a/src/pks/transport/TransportBoundaryFunction_Alquimia.hh
+++ b/src/pks/transport/TransportBoundaryFunction_Alquimia.hh
@@ -49,8 +49,6 @@ class TransportBoundaryFunction_Alquimia : public TransportDomainFunction {
 
  protected:
   std::string name_;
-
- private:
   Teuchos::RCP<const AmanziMesh::Mesh> mesh_;
 
   // string function of geochemical conditions

--- a/src/pks/transport/TransportDomainFunction_UnitConversion.hh
+++ b/src/pks/transport/TransportDomainFunction_UnitConversion.hh
@@ -50,7 +50,7 @@ _vector_ coefficient, but not the scalar one.
 namespace Amanzi {
 namespace Transport {
 
-template <class T>
+template <class T, AmanziMesh::Entity_kind E>
 class TransportDomainFunction_UnitConversion : public T {
  public:
   using T::T;
@@ -64,11 +64,25 @@ class TransportDomainFunction_UnitConversion : public T {
 
     if (reciprocal_) {
       for (auto& it : *this) {
-        for (auto& val : it.second) { val *= scalar_ / vector[0][it.first]; }
+        AmanziMesh::Entity_ID lid = it.first;
+        if constexpr (E == AmanziMesh::Entity_kind::FACE) {
+          lid = AmanziMesh::getFaceOnBoundaryInternalCell(*mesh_, lid);
+        }
+
+        for (auto& val : it.second) {
+          val *= scalar_ / vector[0][lid];
+        }
       }
     } else {
       for (auto& it : *this) {
-        for (auto& val : it.second) { val *= scalar_ * vector[0][it.first]; }
+        AmanziMesh::Entity_ID lid = it.first;
+        if constexpr (E == AmanziMesh::Entity_kind::FACE) {
+          lid = AmanziMesh::getFaceOnBoundaryInternalCell(*mesh_, lid);
+        }
+
+        for (auto& val : it.second) {
+          val *= scalar_ * vector[0][lid];
+        }
       }
     }
   }
@@ -84,6 +98,8 @@ class TransportDomainFunction_UnitConversion : public T {
 
 
  protected:
+  using T::mesh_;
+
   double scalar_;
   Teuchos::RCP<const Epetra_MultiVector> vector_;
   bool reciprocal_;
@@ -92,11 +108,11 @@ class TransportDomainFunction_UnitConversion : public T {
 
 #ifdef ALQUIMIA_ENABLED
 using TransportBoundaryFunction_Alquimia_Units =
-  TransportDomainFunction_UnitConversion<TransportBoundaryFunction_Alquimia>;
+  TransportDomainFunction_UnitConversion<TransportBoundaryFunction_Alquimia, AmanziMesh::Entity_kind::FACE>;
 using TransportSourceFunction_Alquimia_Units =
-  TransportDomainFunction_UnitConversion<TransportSourceFunction_Alquimia>;
+  TransportDomainFunction_UnitConversion<TransportSourceFunction_Alquimia, AmanziMesh::Entity_kind::CELL>;
 using TransportSourceFunction_Concentrations =
-  TransportDomainFunction_UnitConversion<TransportDomainFunction>;
+  TransportDomainFunction_UnitConversion<TransportDomainFunction, AmanziMesh::Entity_kind::CELL>;
 #endif
 
 } // namespace Transport

--- a/src/pks/transport/TransportSourceFunction_Alquimia.cc
+++ b/src/pks/transport/TransportSourceFunction_Alquimia.cc
@@ -98,8 +98,8 @@ TransportSourceFunction_Alquimia::Compute(double t_old, double t_new)
     alquimia_pk_->copyToAlquimia(cell, beaker_);
 
     // Enforce the condition.
-    chem_engine_->EnforceCondition(cond_name, t_new,
-      beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
+    chem_engine_->EnforceCondition(
+      cond_name, t_new, beaker_.properties, beaker_.state, beaker_.aux_data, beaker_.aux_output);
 
     // Move the concentrations into place.
     std::vector<double>& values = it->second;

--- a/src/pks/transport/models_transport_reg.hh
+++ b/src/pks/transport/models_transport_reg.hh
@@ -18,6 +18,7 @@
 #include "MDM_BurnettFrind.hh"
 #include "MDM_Isotropic.hh"
 #include "MDM_LichtnerKelkarRobinson.hh"
+#include "EvaluatorMDM.hh"
 
 #include "MultiscaleTransportPorosityFactory.hh"
 #include "MultiscaleTransportPorosity_GDPM.hh"
@@ -43,7 +44,8 @@ namespace Transport {
 
 Utils::RegisteredFactory<MDM, MDM_Bear> MDM_Bear::reg_("Bear");
 Utils::RegisteredFactory<MDM, MDM_BurnettFrind> MDM_BurnettFrind::reg_("Burnett-Frind");
-Utils::RegisteredFactory<MDM, MDM_Isotropic> MDM_Isotropic::reg_("scalar");
+Utils::RegisteredFactory<MDM, MDM_Isotropic> MDM_Isotropic::reg_("isotropic");
+Utils::RegisteredFactory<MDM, MDM_Isotropic> MDM_Isotropic::reg2_("scalar");
 Utils::RegisteredFactory<MDM, MDM_LichtnerKelkarRobinson>
   MDM_LichtnerKelkarRobinson::reg_("Lichtner-Kelkar-Robinson");
 
@@ -52,6 +54,9 @@ Utils::RegisteredFactory<MultiscaleTransportPorosity, MultiscaleTransportPorosit
 
 Utils::RegisteredFactory<MultiscaleTransportPorosity, MultiscaleTransportPorosity_GDPM>
   MultiscaleTransportPorosity_GDPM::reg_("generalized dual porosity");
+
+Utils::RegisteredFactory<Evaluator, EvaluatorMDM>
+  EvaluatorMDM::reg_("dispersion tensor");
 
 } // namespace Transport
 } // namespace Amanzi

--- a/src/pks/transport/test/transport_dispersion.cc
+++ b/src/pks/transport/test/transport_dispersion.cc
@@ -369,3 +369,5 @@ TEST(GAS_DIFFUSION)
   GMV::write_cell_data(tcc, 1, "Component_1");
   GMV::close_data_file();
 }
+
+

--- a/src/pks/transport/test/transport_dispersion.xml
+++ b/src/pks/transport/test/transport_dispersion.xml
@@ -54,7 +54,7 @@
         <ParameterList name="Soil1">
           <Parameter name="regions" type="Array(string)" value="{Part1}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.1"/>
             <Parameter name="alpha_t" type="double" value="0.01"/>
           </ParameterList>
@@ -63,7 +63,7 @@
         <ParameterList name="Soil2">
           <Parameter name="regions" type="Array(string)" value="{Part2}"/>
           <Parameter name="model" type="string" value="scalar"/>
-          <ParameterList name="parameters for scalar">
+          <ParameterList name="scalar parameters">
             <ParameterList name="alpha">
               <ParameterList name="function-exprtk">
                 <Parameter name="number of arguments" type="int" value="4"/>

--- a/src/pks/transport/test/transport_implicit_2D.xml
+++ b/src/pks/transport/test/transport_implicit_2D.xml
@@ -219,7 +219,7 @@
         <ParameterList name="All">
           <Parameter name="regions" type="Array(string)" value="{All}"/>
           <Parameter name="model" type="string" value="Bear"/>
-          <ParameterList name="parameters for Bear">
+          <ParameterList name="Bear parameters">
             <Parameter name="alpha_l" type="double" value="0.1"/>
             <Parameter name="alpha_t" type="double" value="0.01"/>
           </ParameterList>

--- a/src/state/CMakeLists.txt
+++ b/src/state/CMakeLists.txt
@@ -77,6 +77,7 @@ set(state_inc_files
   evaluators/EvaluatorTemporalInterpolation.hh
   evaluators/EvaluatorSecondaryMonotypeFromFunction.hh
   evaluators/EvaluatorAlias.hh
+  evaluators/EvaluatorVelocityReconstruction.hh
   IO.hh
   Observable.hh
   StateDefs.hh
@@ -108,6 +109,7 @@ add_amanzi_library(state
                           evaluators/EvaluatorTemporalInterpolation.cc
                           evaluators/EvaluatorSecondaryMonotypeFromFunction.cc
                           evaluators/EvaluatorAlias.cc
+                            evaluators/EvaluatorVelocityReconstruction.cc
                           IO.cc
                           Observable.cc
                           UnstructuredObservations.cc

--- a/src/state/Debugger.hh
+++ b/src/state/Debugger.hh
@@ -66,9 +66,12 @@ class Debugger {
   // Write a vector individually.
   void WriteVector(const std::string& vname,
                    const Teuchos::Ptr<const CompositeVector>& vec,
-                   bool include_faces = false);
+                   bool include_faces = false,
+                   std::vector<std::string> const * subfield_names = nullptr);
 
-  void WriteCellVector(const std::string& name, const Epetra_MultiVector& vec);
+  void WriteCellVector(const std::string& name,
+                       const Epetra_MultiVector& vec,
+                       std::vector<std::string> const * subfield_names = nullptr);
 
   // Write boundary condition data.
   void WriteBoundaryConditions(const std::vector<int>& flag, const std::vector<double>& data);

--- a/src/state/evaluators/EvaluatorIndependent.cc
+++ b/src/state/evaluators/EvaluatorIndependent.cc
@@ -22,7 +22,7 @@ namespace Amanzi {
 // ---------------------------------------------------------------------------
 EvaluatorIndependent_::EvaluatorIndependent_(Teuchos::ParameterList& plist)
   : my_key_(Keys::cleanPListName(plist.name())),
-    my_tag_(Keys::readTag(plist, "tag")),
+    my_tag_(Keys::readTag(plist)),
     time_(0.0),
     temporally_variable_(!plist.get<bool>("constant in time", false)),
     computed_once_(false),

--- a/src/state/evaluators/EvaluatorIndependentFromFile.hh
+++ b/src/state/evaluators/EvaluatorIndependentFromFile.hh
@@ -46,6 +46,11 @@ This evaluator is used by providing the option:
    * `"mesh entity`" ``[string]`` **cell** Name of the entity on which the
      component is defined.
    * `"number of dofs`" ``[int]`` **1** Number of degrees of freedom to read.
+   * `"constant in time`" ``[bool]`` **false** Is the value constant throughout all time?
+   * `"checkpoint file`" ``[bool]`` **false** If this is true, then it is
+     expected that `"filename`" is a checkpoint-file-like object, where
+     /variable_name.ENTITY.DOF is itself a vector, and not a group.  Note this
+     forces `"constant in time`" to be true.
    * `"time function`" ``[function-spec]`` **optional** If provided, time is
      first manipulated by this function before interpolation.  This is useful
      for things like cyclic data, which can use a modulo time function to
@@ -124,9 +129,10 @@ class EvaluatorIndependentFromFile
   std::string meshname_;
   std::string compname_;
   std::string varname_;
-  std::string locname_;
+  AmanziMesh::Entity_kind locname_;
   int ndofs_;
 
+  bool checkpoint_file_;
   Teuchos::RCP<Function> time_func_;
 
  private:

--- a/src/state/evaluators/EvaluatorPrimary.cc
+++ b/src/state/evaluators/EvaluatorPrimary.cc
@@ -25,7 +25,7 @@ namespace Amanzi {
 // ---------------------------------------------------------------------------
 EvaluatorPrimary_::EvaluatorPrimary_(Teuchos::ParameterList& plist)
   : my_key_(Keys::cleanPListName(plist.name())),
-    my_tag_(Keys::readTag(plist, "tag")),
+    my_tag_(Keys::readTag(plist)),
     vo_(Keys::cleanPListName(plist.name()), plist)
 {
   type_ = EvaluatorType::PRIMARY;

--- a/src/state/evaluators/EvaluatorSecondary.cc
+++ b/src/state/evaluators/EvaluatorSecondary.cc
@@ -86,7 +86,7 @@ EvaluatorSecondary::EvaluatorSecondary(Teuchos::ParameterList& plist)
       }
     } else {
       auto my_tag = my_keys_.front().second;
-      auto dep_tag = Keys::readTag(plist_, my_tag);
+      auto dep_tag = Keys::readTag(plist_, "dependency", my_tag);
       for (const auto& dep : deps) { dependencies_.insert(KeyTag(dep, dep_tag)); }
     }
 
@@ -110,7 +110,7 @@ EvaluatorSecondary::EvaluatorSecondary(Teuchos::ParameterList& plist)
       }
     } else {
       const auto& my_tag = my_keys_[0].second;
-      auto dep_tag = Keys::readTag(plist_, my_tag);
+      auto dep_tag = Keys::readTag(plist_, "dependency", my_tag);
       for (const auto& suffix : dep_suff) {
         dependencies_.insert(KeyTag(Keys::getKey(domain, suffix), dep_tag));
       }

--- a/src/state/evaluators/EvaluatorVelocityReconstruction.cc
+++ b/src/state/evaluators/EvaluatorVelocityReconstruction.cc
@@ -1,0 +1,106 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+#include "Teuchos_LAPACK.hpp"
+#include "Teuchos_SerialDenseMatrix.hpp"
+
+#include "Tag.hh"
+#include "State.hh"
+#include "EvaluatorVelocityReconstruction.hh"
+
+namespace Amanzi {
+
+EvaluatorVelocityReconstruction::EvaluatorVelocityReconstruction(Teuchos::ParameterList& plist)
+  : EvaluatorSecondaryMonotype<CompositeVector,CompositeVectorSpace>(plist)
+{
+  std::string domain = Keys::getDomain(my_keys_.front().first);
+  Tag tag = my_keys_.front().second;
+
+  flux_key_ = Keys::readKey(plist, domain, "water flux", "water_flux");
+  dependencies_.insert({flux_key_, tag});
+
+  molar_dens_key_ = Keys::readKey(plist, domain, "molar density liquid", "molar_density_liquid");
+  dependencies_.insert({molar_dens_key_, tag});
+}
+
+
+Teuchos::RCP<Evaluator>
+EvaluatorVelocityReconstruction::Clone() const {
+  return Teuchos::rcp(new EvaluatorVelocityReconstruction(*this));
+}
+
+
+void
+EvaluatorVelocityReconstruction::Evaluate_(const State& S, const std::vector<CompositeVector*>& results)
+{
+  Tag tag = my_keys_.front().second;
+  const Epetra_MultiVector& flux =
+    *S.Get<CompositeVector>(flux_key_, tag).ViewComponent("face", true);
+  const Epetra_MultiVector& nliq_c =
+    *S.Get<CompositeVector>(molar_dens_key_, tag).ViewComponent("cell", false);
+
+  Epetra_MultiVector& velocity =
+    *results[0]->ViewComponent("cell", false);
+
+  int d(mesh_->getSpaceDimension());
+  AmanziGeometry::Point local_velocity(d);
+
+  Teuchos::LAPACK<int, double> lapack;
+  Teuchos::SerialDenseMatrix<int, double> matrix(d, d);
+  double rhs[d];
+
+  for (int c = 0; c != velocity.MyLength(); ++c) {
+    auto faces = mesh_->getCellFaces(c);
+    int nfaces = faces.size();
+
+    for (int i = 0; i != d; ++i) rhs[i] = 0.0;
+    matrix.putScalar(0.0);
+
+    for (int n = 0; n != nfaces; ++n) { // populate least-square matrix
+      int f = faces[n];
+      const AmanziGeometry::Point& normal = mesh_->getFaceNormal(f);
+      double area = mesh_->getFaceArea(f);
+
+      for (int i = 0; i != d; ++i) {
+        rhs[i] += normal[i] * flux[0][f];
+        matrix(i, i) += normal[i] * normal[i];
+        for (int j = i + 1; j < d; ++j) { matrix(j, i) = matrix(i, j) += normal[i] * normal[j]; }
+      }
+    }
+
+    int info;
+    lapack.POSV('U', d, 1, matrix.values(), d, rhs, d, &info);
+
+    for (int i = 0; i != d; ++i) velocity[i][c] = rhs[i] / nliq_c[0][c];
+  }
+}
+
+
+
+void
+EvaluatorVelocityReconstruction::EnsureCompatibility_ToDeps_(State& S)
+{
+  Tag tag = my_keys_.front().second;
+  CompositeVectorSpace& cvs = S.Require<CompositeVector,CompositeVectorSpace>(my_keys_.front().first, my_keys_.front().second);
+  if (mesh_ == Teuchos::null && cvs.Mesh() != Teuchos::null) {
+    mesh_ = cvs.Mesh();
+
+    S.Require<CompositeVector,CompositeVectorSpace>(flux_key_, tag)
+      .SetMesh(mesh_)
+      ->AddComponent("face", AmanziMesh::Entity_kind::FACE, 1)
+      ->SetGhosted("true");
+
+    S.Require<CompositeVector,CompositeVectorSpace>(molar_dens_key_, tag)
+      .SetMesh(mesh_)
+      ->AddComponent("cell", AmanziMesh::Entity_kind::CELL, 1)
+      ->SetGhosted("true");
+  }
+}
+
+} // namespace Amanzi

--- a/src/state/evaluators/EvaluatorVelocityReconstruction.hh
+++ b/src/state/evaluators/EvaluatorVelocityReconstruction.hh
@@ -1,0 +1,78 @@
+/*
+  Copyright 2010-202x held jointly by participating institutions.
+  Amanzi is released under the three-clause BSD License.
+  The terms of use and "as is" disclaimer for this license are
+  provided in the top-level COPYRIGHT file.
+
+  Authors: Ethan Coon
+*/
+
+/*!
+
+Computes a reconstructed velocity field given a face-based flux field and
+density.
+
+`"evaluator type`" = `"velocity reconstruction`"
+
+.. _evaluator-velocity-reconstruction-spec:
+.. admonition:: evaluator-velocity-reconstruction-spec
+
+   KEYS:
+   - `"water flux`"
+   - `"molar density liquid`"
+
+*/
+
+#pragma once
+
+#include "EvaluatorSecondaryMonotype.hh"
+#include "Evaluator_Factory.hh"
+
+namespace Amanzi {
+class State;
+
+class EvaluatorVelocityReconstruction
+  : public EvaluatorSecondaryMonotype<CompositeVector,CompositeVectorSpace> {
+
+public:
+  explicit EvaluatorVelocityReconstruction(Teuchos::ParameterList& plist);
+  EvaluatorVelocityReconstruction(const EvaluatorVelocityReconstruction& other) = default;
+  virtual Teuchos::RCP<Evaluator> Clone() const override;
+
+ protected:
+  // These do the actual work
+  virtual void Evaluate_(const State& S, const std::vector<CompositeVector*>& results) override;
+
+  // This should get some careful thought of the right strategy.  Punting for
+  // now --etc
+  virtual bool IsDifferentiableWRT(const State& S, const Key& wrt_key, const Tag& wrt_tag) const override {
+    return false;
+  }
+
+  virtual void UpdateDerivative_(State& S, const Key& wrt_key, const Tag& wrt_tag) override {}
+
+  // This should get some careful thought of the right strategy.  Punting for
+  // now --etc
+  virtual void EvaluatePartialDerivative_(const State& S,
+                                          const Key& wrt_key,
+                                          const Tag& wrt_tag,
+                                          const std::vector<CompositeVector*>& results) override
+  {}
+
+protected:
+  // helper function -- calls Require on all dependencies
+  // Called in Basics
+  virtual void EnsureCompatibility_ToDeps_(State& S) override;
+
+protected:
+  Key flux_key_;
+  Key molar_dens_key_;
+  Teuchos::RCP<const AmanziMesh::Mesh> mesh_;
+
+ private:
+  static Utils::RegisteredFactory<Evaluator, EvaluatorVelocityReconstruction> fac_;
+};
+
+} // namespace Amanzi
+
+

--- a/src/state/state_evaluators_registration.hh
+++ b/src/state/state_evaluators_registration.hh
@@ -23,6 +23,7 @@
 #include "EvaluatorSecondaryMonotypeFromFunction.hh"
 #include "EvaluatorPrimary.hh"
 #include "EvaluatorTemporalInterpolation.hh"
+#include "EvaluatorVelocityReconstruction.hh"
 
 namespace Amanzi {
 
@@ -52,5 +53,8 @@ Utils::RegisteredFactory<Evaluator, EvaluatorPrimaryCV>
 
 Utils::RegisteredFactory<Evaluator, EvaluatorTemporalInterpolation>
   EvaluatorTemporalInterpolation::fac_("temporal interpolation");
+
+Utils::RegisteredFactory<Evaluator, EvaluatorVelocityReconstruction>
+  EvaluatorVelocityReconstruction::fac_("velocity reconstruction");
 
 } // namespace Amanzi

--- a/src/utils/Key.cc
+++ b/src/utils/Key.cc
@@ -575,16 +575,10 @@ readKeys(Teuchos::ParameterList& list,
 
 
 Tag
-readTag(Teuchos::ParameterList& list, const Tag& default_tag)
-{
-  return readTag(list, "dependency tag", default_tag);
-}
-
-
-Tag
 readTag(Teuchos::ParameterList& list, const std::string& param, const Tag& default_tag)
 {
-  std::string tag_str = list.get<std::string>(param, default_tag.get());
+  std::string tag_str = list.get<std::string>(param.empty() ? "tag" : param + " tag",
+          default_tag.get());
   return Tag{ tag_str };
 }
 

--- a/src/utils/Key.hh
+++ b/src/utils/Key.hh
@@ -317,12 +317,9 @@ readKeys(Teuchos::ParameterList& list,
          const Key& basename,
          Teuchos::Array<Key> const* const default_names = nullptr);
 
-// Read a dependency tag or tag list from a parameter list, given some default
-// information.
+// Read a tag from a parameter list
 Tag
-readTag(Teuchos::ParameterList& list, const Tag& default_tag = Tag{});
-Tag
-readTag(Teuchos::ParameterList& list, const std::string& param, const Tag& default_tag = Tag{});
+readTag(Teuchos::ParameterList& list, const std::string& param="", const Tag& default_tag = Tag{});
 
 } // namespace Keys
 } // namespace Amanzi

--- a/test_suites/benchmarking/chemistry/calcite_1d/calcite_1d.py
+++ b/test_suites/benchmarking/chemistry/calcite_1d/calcite_1d.py
@@ -279,7 +279,40 @@ if __name__ == "__main__":
         print(err)
         alq_crunch = False
 
-    
+
+    # Amanzi U + Alquimia + CruchFlow chemistry
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-calcite.regression')
+
+        root_ATS = "ats_vis"
+        comp = 'total_component_concentration.Ca++'
+        Ca_ATS = []
+        for i, time in enumerate(times):
+            x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS, root_ATS, comp, 1)
+            Ca_ATS = Ca_ATS +[c_ATS]
+
+        comp = 'primary_free_ion_concentration.H+'
+        pH_ATS = []
+        for i, time in enumerate(times):
+           x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
+           pH_ATS = pH_ATS +[-np.log10(c_ATS)]
+
+        comp = 'mineral_volume_fractions.Calcite'
+        VF_ATS = []
+        for i, time in enumerate(times):
+           x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_amanzi,root,comp,1)
+           VF_ATS = VF_ATS +[c_ATS]
+
+        ats = True
+
+    except Exception as err:
+        print(err)
+        ats = False
+
+        
     # Amanzi S + Alquimia + PFloTran chemistry
     try:
         # import pdb; pdb.set_trace()
@@ -333,6 +366,8 @@ if __name__ == "__main__":
             ax[0].plot(x_amanzi_alquimia_crunch, Ca_amanzi_alquimia_crunch[i],'r*',linewidth=2,markersize=CRUNCH_MARKER_SIZE)
         if native:
             ax[0].plot(x_amanzi_native, Ca_amanzi_native[i],'rx')
+        if ats:
+            ax[0].plot(x_ATS, Ca_ATS[i], 'c-x')
 
         ax[0].plot(x_pflotran_OS, Ca_pflotran_OS[i],'-',linewidth=PFLOTRAN_LINE_WIDTH,c=PFLOTRAN_LINE_COLOR)
         ax[0].plot(x_crunchflow, Ca_crunchOS3D[i],'m*',markersize=CRUNCH_MARKER_SIZE)
@@ -346,6 +381,10 @@ if __name__ == "__main__":
         if native:
             ax[1].plot(x_amanzi_native, pH_amanzi_native[i],'rx',label='AmanziU(2nd-O) Native Chem.')
 
+        if ats:
+            ax[1].plot(x_ATS, pH_ATS[i], 'c-x', label='ATS+Crunch')
+
+            
         ax[1].plot(x_pflotran_OS, pH_pflotran_OS[i],'-',linewidth=PFLOTRAN_LINE_WIDTH,c=PFLOTRAN_LINE_COLOR)
         ax[1].plot(x_crunchflow, pH_crunchOS3D[i],'m*',markersize=CRUNCH_MARKER_SIZE)
 
@@ -370,6 +409,9 @@ if __name__ == "__main__":
                 ax[2].plot(x_amanzi_alquimia_crunch, VF_amanzi_alquimia_crunch[i],'r*',linewidth=2,markersize=CRUNCH_MARKER_SIZE)
             if native:
                 ax[2].plot(x_amanzi_native, VF_amanzi_native[i],'rx')
+
+            if ats:
+                ax[2].plot(x_ATS, VF_ATS[i], 'c-x')
 
             ax[2].plot(x_pflotran_OS, VF_pflotran_OS[i],'-',linewidth=PFLOTRAN_LINE_WIDTH,c=PFLOTRAN_LINE_COLOR)
 

--- a/test_suites/benchmarking/chemistry/farea_1d/farea_1d.py
+++ b/test_suites/benchmarking/chemistry/farea_1d/farea_1d.py
@@ -204,6 +204,43 @@ if __name__ == "__main__":
     except Exception as err:
         print(err)
         alq_writer = False
+
+
+    # ATS + PFloTran
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-farea.regression')
+
+        root_ATS = "ats_vis"
+
+        # tot concentration
+        u_ATS = [[] for x in range(len(totcama))]
+        for j, comp in enumerate(totcama):
+            x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+            u_ATS[j] = c_ATS  
+
+        # sorbed concentration
+        v_ATS = [[] for x in range(len(sorbama))]
+        for j, sorb in enumerate(sorbama):
+            x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,sorb,1)
+            v_ATS[j] = c_ATS
+
+        # mineral volume fraction
+        w_ATS = [[] for x in range(len(vfama))]
+        for j, vf in enumerate(vfama):
+            x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,vf,1)
+            w_ATS[j] = c_ATS
+
+        ats = True
+
+    except Exception as err:
+        print(err)
+        ats = False
+    
+        
+
         
     # initialize subplots
     fig, ax = plt.subplots(3,sharex=True,figsize=(8,15))
@@ -213,8 +250,7 @@ if __name__ == "__main__":
 
     colors= ['r','b','m','g'] # components
     colors2= ['c','k','g','y'] # components
-    styles = ['-','o','x','--'] # codes
-    codes = ['Amanzi+Alquimia(PFloTran)','Amanzi Native Chemistry','PFloTran'] + [None,]*9
+    styles = ['-','o','x','--','^'] # codes
 
     # lines on axes
     # ax[0],b[0] ---> Aqueous concentrations
@@ -227,6 +263,8 @@ if __name__ == "__main__":
             ax[0].plot(x_amanzi_alquimia_w, u_amanzi_alquimia_w[j],color=colors[j],linestyle=styles[3],linewidth=2)
         if native:
             ax[0].plot(x_amanzi_native, u_amanzi_native[j],color=colors[j],marker=styles[1],linestyle='None',linewidth=2,label=comp)
+        if ats:
+            ax[0].plot(x_ATS, u_ATS[j], color=colors[j], marker=styles[4], linestyle='None', linewidth=2)
 
         ax[0].plot(x_pflotran, u_pflotran[j],color=colors[j],linestyle='None',marker=styles[2],linewidth=2)
         
@@ -239,6 +277,11 @@ if __name__ == "__main__":
         if native:
             label='Amanzi Native Chemistry' if j==0 else None
             ax[1].plot(x_amanzi_native, v_amanzi_native[j],color=colors[j],marker=styles[1],linestyle='None',linewidth=2,label=label)
+        if ats:
+            label = 'ATS' if j == 0 else None
+            ax[1].plot(x_ATS, v_ATS[j], color=colors[j], marker=styles[4], linestyle='None',linewidth=2,label=label)
+
+
         label='PFloTran' if j==0 else None
         ax[1].plot(x_pflotran, v_pflotran[j],color=colors[j],linestyle='None',marker=styles[2],linewidth=2,label=label)
 
@@ -251,7 +294,9 @@ if __name__ == "__main__":
             ax[2].plot(x_amanzi_alquimia_w, w_amanzi_alquimia_w[j],color=colors2[j],linestyle=styles[3],linewidth=2)
         if native:
             ax[2].plot(x_amanzi_native, w_amanzi_native[j],color=colors2[j],marker=styles[1],linestyle='None',linewidth=2,label=vf) 
-            ax[2].plot(x_pflotran, w_pflotran[j],color=colors2[j],linestyle='None',marker=styles[2],linewidth=2)
+        if ats:
+            ax[2].plot(x_ATS, w_ATS[j], color=colors2[j], marker=styles[4], linestyle='None',linewidth=2)
+        ax[2].plot(x_pflotran, w_pflotran[j],color=colors2[j],linestyle='None',marker=styles[2],linewidth=2)
 
     # axes
     ax[2].set_xlabel("Distance (m)",fontsize=15)

--- a/test_suites/benchmarking/chemistry/ion_exchange_1d/ion_exchange_1d.py
+++ b/test_suites/benchmarking/chemistry/ion_exchange_1d/ion_exchange_1d.py
@@ -275,6 +275,33 @@ if __name__ == "__main__":
         struct_c = 0
 
 
+    # ATS + PFloTran
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-ion_exchange.regression')
+
+        root_ATS = "ats_vis"
+
+        u_ATS = [[[] for x in range(len(amanzi_components))] for x in range(len(times))]
+        for i, time in enumerate(times):
+            for j, comp in enumerate(amanzi_components):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+                u_ATS[i][j] = c_ATS
+              
+        v_ATS = [[[] for x in range(len(amanzi_sorbed))] for x in range(len(times))]
+        for i, time in enumerate(times):
+            for j, comp in enumerate(amanzi_sorbed):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+                v_ATS[i][j] = c_ATS
+
+        ats = len(u_ATS)
+
+    except:
+        ats = 0
+
+        
     components = ['Na+','Ca++','Mg++','Cl-']
 
     # define subplots as a subgrid
@@ -315,6 +342,12 @@ if __name__ == "__main__":
             ax[j].plot(x_amanzi_native, u_amanzi_native[i][j],'x',label='AmanziU Native Chem',c=PFLOTRAN_LINE_COLOR)
             bx[j].plot(x_amanzi_native, v_amanzi_native[i][j],'rx',label='AmanziU Native Chem')
 
+    if ats:
+        i = 0
+        for j, comp in enumerate(components):
+            ax[j].plot(x_ATS, u_ATS[i][j],'c-x',label='ATS')
+            bx[j].plot(x_ATS, v_ATS[i][j],'c-x',label='ATS')
+            
     if crunch:
         i = 0  # hardwired for time 50 years
         for j, comp in enumerate(components):

--- a/test_suites/benchmarking/chemistry/isotherms_1d/isotherms_1d.py
+++ b/test_suites/benchmarking/chemistry/isotherms_1d/isotherms_1d.py
@@ -59,7 +59,6 @@ if __name__ == "__main__":
     amanzi_sorb = [amanzi_sorb_templ.format(x) for x in components]
     amanzi_sorb_crunch = [amanzi_sorb_templ.format(x) for x in compcrunch]
 
-
 # pflotran data --->
     path_to_pflotran = "pflotran"
     root_pflotran = "1d-"+root
@@ -232,6 +231,34 @@ if __name__ == "__main__":
         print(err)
         struct_c = 0
 
+        
+    # ATS
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-isotherms.regression')
+        root_ats = "ats_vis"
+        comp_ats = "total_component_concentration.A"
+        x_ATS, u_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ats,comp_ats,1)
+        ats = len(x_ATS)
+
+        u_ATS = [[[] for x in range(len(amanzi_totc_crunch))] for x in range(len(timesama))]
+        for i, time in enumerate(timesama):
+            for j, comp in enumerate(amanzi_totc_crunch):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS, root_ats, comp,1)
+                u_ATS[i][j] = c_ATS
+              
+        v_ATS = [[[] for x in range(len(amanzi_sorb_crunch))] for x in range(len(timesama))]
+        for i, time in enumerate(timesama):
+            for j, comp in enumerate(amanzi_sorb_crunch):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS, root_ats, comp, 1)
+                v_ATS[i][j] = c_ATS
+
+    except RuntimeError:
+        ats = 0
+        
+        
 
 ## plotting ---------------------------------
     # subplots
@@ -324,6 +351,11 @@ if __name__ == "__main__":
         samc = ax[0].plot(x_amanziS_crunch, c_amanziS_crunch,'g*',label='AmanziS+Alq(CF)',linewidth=LINE_WIDTH) 
         samcv = ax[1].plot(x_amanziS_crunch, v_amanziS_crunch,'g*',linewidth=LINE_WIDTH) #,markersize=20) 
 
+    if ats:
+        ax[0].plot(x_ATS, u_ATS[i][0],color='c',linestyle='-',marker='x',linewidth=LINE_WIDTH,label='ATS+Crunch')
+        ax[1].plot(x_ATS, v_ATS[i][0],color='c',linestyle='-',marker='x',linewidth=LINE_WIDTH,label='ATS+Crunch')
+
+        
     # axes
     ax[0].set_title("Kd linear sorption model",fontsize=15)
     ax[1].set_xlabel("Distance (m)",fontsize=15)

--- a/test_suites/benchmarking/chemistry/surface_complexation_1d/surface_complexation_1d.py
+++ b/test_suites/benchmarking/chemistry/surface_complexation_1d/surface_complexation_1d.py
@@ -242,6 +242,38 @@ if __name__ == "__main__":
         alq_crunch = False
 
 
+# ATS --->
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-surface_complexation.regression')
+        root_ATS = "ats_vis"
+        
+        u_ATS = [[[] for x in range(len(amanzi_totc))] for x in range(len(times))]
+        for i, time in enumerate(times):
+            for j, comp in enumerate(amanzi_totc):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+                u_ATS[i][j] = c_ATS
+
+        v_ATS = [[[] for x in range(len(amanzi_sorb))] for x in range(len(times))]
+        for i, time in enumerate(times):
+            for j, comp in enumerate(amanzi_sorb):
+                x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+                v_ATS[i][j] = c_ATS
+
+        pH_ATS = [ [] for x in range(len(times)) ]
+        comp = 'pH.0'
+        for i, time in enumerate(times):
+            x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ATS,comp,1)
+            pH_ATS[i] = c_ATS
+
+        ats = True
+
+    except:
+        ats = False
+        
+
 # AmanziS + Alquimia + PFlowTran chemistry --->
     try:
         input_file = os.path.join("amanzi-s-1d-surface-complexation-alq-pflo.xml")
@@ -417,6 +449,15 @@ if __name__ == "__main__":
         px.plot(x_amanzi_alquimia_crunch, pH_amanzi_alquimia_crunch[i],color='r',linestyle='None',marker='*',linewidth=2,label='AmanziU+Alquimia(CrunchFlow)')
 
 
+    # ATS
+    if ats:
+        for j, comp in enumerate(components):
+            ax[j].plot(x_ATS, u_ATS[i][j],color='c',linestyle='-',marker='x',linewidth=2)
+            bx[j].plot(x_ATS, v_ATS[i][j],color='c',linestyle='-',marker='x',linewidth=2,label='ATS')
+
+        px.plot(x_ATS, pH_ATS[i],color='c',linestyle='-',marker='x',linewidth=2,label='ATS')
+        
+
     # amanzi-structured-alquimia-pflotran
     if struct:
         for j, comp in enumerate(components):
@@ -505,3 +546,4 @@ if __name__ == "__main__":
 
     # finally:
     #     pass 
+ 

--- a/test_suites/benchmarking/chemistry/tracer_1d/tracer_1d.py
+++ b/test_suites/benchmarking/chemistry/tracer_1d/tracer_1d.py
@@ -142,6 +142,21 @@ if __name__ == "__main__":
         struct_crunch = len(x_amanziS_crunch)
     except:
         struct_crunch = 0
+
+    # ATS
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-tracer.regression')
+        root_ats = "ats_vis"
+        comp_ats = "total_component_concentration.tracer"
+        x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ats,comp_ats,1)
+        ats = len(x_ATS)
+
+    except RuntimeError:
+        ats = 0
+
         
 # plotting --------------------------------------------------------
     fig = plt.figure(figsize=[8.00,5.25])
@@ -177,7 +192,11 @@ if __name__ == "__main__":
 
     # struct amanzi alquimia + pflotran
     if (struct_crunch>0):
-        sam = ax.plot(x_amanziS_crunch, c_amanziS_crunch,'g*',label='AmanziS+Alq(CF)',linewidth=2) 
+        sam = ax.plot(x_amanziS_crunch, c_amanziS_crunch,'g*',label='AmanziS+Alq(CF)',linewidth=2)
+
+    if (ats > 0):
+        print('plotting ATS')
+        ax.plot(x_ATS, c_ATS, 'c-x', label='ATS', linewidth=2)
         
 # figure look
     # axes

--- a/test_suites/benchmarking/chemistry/tritium_1d/tritium_1d.py
+++ b/test_suites/benchmarking/chemistry/tritium_1d/tritium_1d.py
@@ -143,6 +143,20 @@ if __name__ == "__main__":
     except:
         unstruct_crunch = False
 
+    # ATS
+    try:
+        print("looking for ATS")
+        path_to_ATS = os.path.join(os.environ['ATS_SRC_DIR'], 'testing',
+                                   'ats-regression-tests', '07_reactive_transport',
+                                   'amanzi_benchmark-tritium.regression')
+        root_ats = "ats_vis"
+        comp_ats = "total_component_concentration.Tritium"
+        x_ATS, c_ATS = GetXY_AmanziU_1D(path_to_ATS,root_ats,comp_ats,1)
+        ats = len(x_ATS)
+    except RuntimeError:
+        ats = 0
+
+        
     # Do plot
     if (native > 0):
         nat = ax.plot(x_amanziU_native, c_amanziU_native,'rx',markersize=8,label='AmanziU(2nd-Order)+Native',linewidth=2)
@@ -162,6 +176,10 @@ if __name__ == "__main__":
     if (struct_crunch > 0):
         sam_crunch = ax.plot(x_amanziS_crunch, c_amanziS_crunch,'g*',label='AmanziS+Alquimia(CrunchFlow)',linewidth=2) 
 
+    if (ats > 0):
+        ax.plot(x_ATS, c_ATS, 'c-x', label='ATS', linewidth=2)
+
+        
     pfl = ax.plot(x_pflotran, c_pflotran,'b-',label='PFloTran',linewidth=2)
     crunch = ax.plot(x_crunchflow, c_crunchflow,'m*',markersize=10,label='CrunchFlow(OS3D)',linewidth=2)
 
@@ -192,6 +210,8 @@ if __name__ == "__main__":
         sams = a.plot(x_amanziS, c_amanziS,'g-',label='AmanziS+Alq(PFT)',linewidth=2) 
     if (struct_crunch>0):
         sams_crunch = a.plot(x_amanziS_crunch, c_amanziS_crunch,'g*',label='AmanziS+Alq(CF)',linewidth=2) 
+    if (ats > 0):
+        a.plot(x_ATS, c_ATS, 'c-x', label='ATS', linewidth=2)
 
     pfls = a.plot(x_pflotran, c_pflotran,'b-',label='PFloTran',linewidth=2)
     cfs = a.plot(x_crunchflow, c_crunchflow,'m*',markersize=9,label='CrunchFlow',linewidth=2)


### PR DESCRIPTION
- changes "parameters for X" in MDM factory to "X parameters" to match all other Amanzi/ATS factories
- fixes bug in MDM_Scalar whereby water content and saturation were incorrectly used
- Adds an MDM Evaluator
- improves documentation and increases options for parameter names in MDM models, e.g. "dispersion coefficient" vs "dispersivity," with correct units