### PR TITLE
fmyuan/tpls 0.98.11

### DIFF
--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -191,6 +191,7 @@
 #                - remove Boost and Trilinos dependency on Boost
 #   0.98.10      - patch ascem/io to improve error handling
 #   0.98.11      - update zlib to 1.3.1 (compatible with MacOSX Apple clang 17)
+#                - patch Trilinos/kokkos-kernels (error shown up when building by Apple clang 17 or LLVM clang 19)
 
 
 include(CMakeParseArguments)

--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -245,7 +245,7 @@ endmacro(amanzi_tpl_version_write)
 #
 set(AMANZI_TPLS_VERSION_MAJOR 0)
 set(AMANZI_TPLS_VERSION_MINOR 98)
-set(AMANZI_TPLS_VERSION_PATCH 10)
+set(AMANZI_TPLS_VERSION_PATCH 11)
 set(AMANZI_TPLS_VERSION ${AMANZI_TPLS_VERSION_MAJOR}.${AMANZI_TPLS_VERSION_MINOR}.${AMANZI_TPLS_VERSION_PATCH})
 # Not sure how to create a meaningful hash key for the collection
 

--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -190,6 +190,8 @@
 #                - update Silo to 4.11.1
 #                - remove Boost and Trilinos dependency on Boost
 #   0.98.10      - patch ascem/io to improve error handling
+#   0.98.11      - update zlib to 1.3.1 (compatible with MacOSX Apple clang 17)
+
 
 include(CMakeParseArguments)
 
@@ -293,13 +295,13 @@ set(MPICH_MD5_SUM        e175452f4d61646a52c73031683fc375)
 # TPL: zlib
 #
 set(ZLIB_VERSION_MAJOR 1)
-set(ZLIB_VERSION_MINOR 2)
-set(ZLIB_VERSION_PATCH 11)
+set(ZLIB_VERSION_MINOR 3)
+set(ZLIB_VERSION_PATCH 1)
 set(ZLIB_VERSION ${ZLIB_VERSION_MAJOR}.${ZLIB_VERSION_MINOR}.${ZLIB_VERSION_PATCH})
 set(ZLIB_URL_STRING     ${AMANZI_TPLS_DOWNLOAD_URL})
 set(ZLIB_ARCHIVE_FILE   zlib-${ZLIB_VERSION}.tar.gz)
 set(ZLIB_SAVEAS_FILE    ${ZLIB_ARCHIVE_FILE})
-set(ZLIB_MD5_SUM        1c9f62f0778697a09d36121ead88e08e) 
+set(ZLIB_MD5_SUM        9855b6d802d7fe5b7bd5b196a2271655) 
 
 #
 # TPL: METIS

--- a/config/SuperBuild/include/Build_Trilinos.cmake
+++ b/config/SuperBuild/include/Build_Trilinos.cmake
@@ -313,6 +313,7 @@ if (ENABLE_Trilinos_Patch)
   set(Trilinos_patch_file
     trilinos-duplicate-parameters.patch
     trilinos-ifpack.patch
+    trilinos-kokkos-kernels.patch
     )
   configure_file(${SuperBuild_TEMPLATE_FILES_DIR}/trilinos-patch-step.sh.in
                  ${Trilinos_prefix_dir}/trilinos-patch-step.sh

--- a/config/SuperBuild/templates/trilinos-kokkos-kernels.patch
+++ b/config/SuperBuild/templates/trilinos-kokkos-kernels.patch
@@ -1,0 +1,15 @@
+diff -rupN trilinos-15-1-0-source/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp trilinos-15-1-0-source-patch/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp
+--- trilinos-15-1-0-source/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp	2024-02-29 10:55:54
++++ trilinos-15-1-0-source-patch/packages/kokkos-kernels/sparse/src/KokkosSparse_spadd_handle.hpp	2025-04-30 10:47:42
+@@ -72,9 +72,9 @@
+    */
+   size_type get_c_nnz() { return this->result_nnz_size; }
+ 
+-  void set_sort_option(int option) { this->sort_option = option; }
++  //void set_sort_option(int option) { this->sort_option = option; }
+ 
+-  int get_sort_option() { return this->sort_option; }
++  //int get_sort_option() { return this->sort_option; }
+ 
+   /**
+    * \brief Default constructor.


### PR DESCRIPTION
Amanzi-TPLs update so that Apple clang 17, the most recent one provided around April 2025. Those would also be good to fix similar errors if compiling by LLVM clang 19. 