### PR TITLE
Meshes gain the ability to name their dimensions

### DIFF
--- a/src/mesh/MeshCache_decl.hh
+++ b/src/mesh/MeshCache_decl.hh
@@ -353,7 +353,13 @@ struct MeshCacheBase {
 
   // space dimension describes the dimension of coordinates in space
   std::size_t getSpaceDimension() const { return space_dim_; }
-  void setSpaceDimension(unsigned int dim) { space_dim_ = dim; }
+  void setSpaceDimension(unsigned int dim);
+
+  // name the space dimensions
+  const std::vector<std::string>& getSpaceDimensionNames() const {
+    return space_dim_names_;
+  }
+  void setSpaceDimensionNames(const std::vector<std::string>& names);
 
   // manifold dimension describes the dimensionality of the corresponding R^n
   // manifold onto which this mesh can be projected.
@@ -366,6 +372,7 @@ struct MeshCacheBase {
   Teuchos::RCP<Teuchos::ParameterList> plist_;
   Teuchos::RCP<const AmanziGeometry::GeometricModel> gm_;
   int space_dim_;
+  std::vector<std::string> space_dim_names_;
   int manifold_dim_;
   bool is_ordered_;
   bool is_logical_;

--- a/src/mesh/MeshCache_impl.hh
+++ b/src/mesh/MeshCache_impl.hh
@@ -25,6 +25,39 @@ namespace AmanziMesh {
 
 class SingleFaceMesh;
 
+inline void
+MeshCacheBase::setSpaceDimension(unsigned int dim)
+{
+  space_dim_ = dim;
+  std::vector<std::string> names;
+  if (plist_->isParameter("space dimension names")) {
+    names = plist_->get<Teuchos::Array<std::string>>("space dimension names").toVector();
+  } else {
+    names.resize(space_dim_);
+    if (space_dim_ > 0) names[0] = "x";
+    if (space_dim_ > 1) names[0] = "y";
+    if (space_dim_ > 2) names[0] = "z";
+  }
+  setSpaceDimensionNames(names);
+}
+
+
+inline void
+MeshCacheBase::setSpaceDimensionNames(const std::vector<std::string>& names)
+{
+  space_dim_names_ = names;
+  if (space_dim_ != space_dim_names_.size()) {
+    Errors::Message msg;
+    msg << "Mesh was provided space dimension names: ";
+    for (const auto& n : space_dim_names_) {
+      msg << "\"" << n << "\", ";
+    }
+    msg << " which is of length " << space_dim_names_.size() << " but the mesh is of dimension " << space_dim_;
+    Exceptions::amanzi_throw(msg);
+  }
+}
+
+
 template <MemSpace_kind MEM>
 template <MemSpace_kind MEM_OTHER>
 MeshCache<MEM>::MeshCache(MeshCache<MEM_OTHER>& other)
@@ -60,7 +93,7 @@ MeshCache<MEM>::setMeshFramework(const Teuchos::RCP<MeshFramework>& framework_me
   has_node_faces_ = framework_mesh->hasNodeFaces();
   comm_ = framework_mesh_->getComm();
   gm_ = framework_mesh_->getGeometricModel();
-  space_dim_ = framework_mesh_->getSpaceDimension();
+  setSpaceDimension(framework_mesh_->getSpaceDimension());
   manifold_dim_ = framework_mesh_->getManifoldDimension();
   is_logical_ = framework_mesh_->isLogical();
   is_ordered_ = framework_mesh_->isOrdered();

--- a/src/mesh/mesh_extracted/MeshExtractedManifold.cc
+++ b/src/mesh/mesh_extracted/MeshExtractedManifold.cc
@@ -64,9 +64,9 @@ MeshExtractedManifold::MeshExtractedManifold(
   vo_ = Teuchos::rcp(new VerboseObject(comm_, "MeshExtractedManifold", *plist_));
 
   int d = parent_mesh_->getSpaceDimension();
-  setSpaceDimension(d);
   setManifoldDimension(d - 1);
   if (flattened_) setSpaceDimension(d - 1);
+  else setSpaceDimension(d);
 
   InitParentMaps(setname);
   InitEpetraMaps();

--- a/src/mesh/mesh_extracted/MeshSurfaceCell.cc
+++ b/src/mesh/mesh_extracted/MeshSurfaceCell.cc
@@ -41,11 +41,9 @@ MeshSurfaceCell::MeshSurfaceCell(const Teuchos::RCP<const MeshFramework>& parent
   parent_ = parent_mesh;
 
   // set dimensions
-  if (flatten) {
-    setSpaceDimension(2);
-  } else {
-    setSpaceDimension(3);
-  }
+  if (flatten) setSpaceDimension(2);
+  else setSpaceDimension(3);
+
   setManifoldDimension(2);
   parent_face_ = 0; // the parent face is always the 0th by construction of a
                     // MeshColumn

--- a/src/mesh/mesh_factory/MeshFactory.cc
+++ b/src/mesh/mesh_factory/MeshFactory.cc
@@ -35,6 +35,14 @@ MeshFactory::create(const Teuchos::RCP<const Mesh>& parent_mesh,
     MeshFrameworkFactory::create(parent_mesh, setids, setkind, flatten);
   auto mesh = Teuchos::rcp(new Mesh(mesh_fw, Teuchos::rcp(new MeshAlgorithms()), Teuchos::null));
   mesh->setParentMesh(parent_mesh);
+
+  if (flatten) {
+    std::vector<std::string> names = parent_mesh->getSpaceDimensionNames();
+    names.pop_back();
+    mesh->setSpaceDimensionNames(names);
+  } else {
+    mesh->setSpaceDimensionNames(parent_mesh->getSpaceDimensionNames());
+  }
   return mesh;
 }
 
@@ -56,6 +64,14 @@ MeshFactory::create(const Teuchos::RCP<const Mesh>& parent_mesh,
   if (mesh_fw != Teuchos::null) {
     mesh = Teuchos::rcp(new Mesh(mesh_fw, Teuchos::rcp(new MeshAlgorithms()), Teuchos::null));
     mesh->setParentMesh(parent_mesh);
+  }
+
+  if (flatten) {
+    std::vector<std::string> names = parent_mesh->getSpaceDimensionNames();
+    names.pop_back();
+    mesh->setSpaceDimensionNames(names);
+  } else {
+    mesh->setSpaceDimensionNames(parent_mesh->getSpaceDimensionNames());
   }
   return mesh;
 }
@@ -95,6 +111,7 @@ MeshFactory::createColumn(const Teuchos::RCP<Mesh>& parent,
   // create and return the Mesh
   auto mesh = Teuchos::rcp(new Mesh(column_1D, Teuchos::rcp(new MeshColumnAlgorithms()), plist));
   mesh->setParentMesh(parent);
+  mesh->setSpaceDimensionNames(parent->getSpaceDimensionNames());
   return mesh;
 }
 
@@ -111,6 +128,10 @@ MeshFactory::createSurfaceCell(const Teuchos::RCP<const Mesh>& parent)
   auto mesh =
     Teuchos::rcp(new Mesh(mesh_surf_cell_fw, Teuchos::rcp(new MeshAlgorithms()), Teuchos::null));
   mesh->setParentMesh(parent);
+
+  std::vector<std::string> names = parent->getSpaceDimensionNames();
+  names.pop_back();
+  mesh->setSpaceDimensionNames(names);
   return mesh;
 }
 

--- a/src/pks/PK_DomainFunctionFirstOrderExchange.hh
+++ b/src/pks/PK_DomainFunctionFirstOrderExchange.hh
@@ -82,7 +82,7 @@ PK_DomainFunctionFirstOrderExchange<FunctionBase>::Init(const Teuchos::Parameter
   Teuchos::ParameterList blist = plist.sublist("source function");
 
   Key domain_name = Keys::readDomain(blist, "domain", "domain");
-  exchanged_key_ = Keys::readKey(blist, domain_name, "exchanged quantity", "molar_ratio");
+  exchanged_key_ = Keys::readKey(blist, domain_name, "exchanged quantity", "mole_fraction");
   exchanged_tag_ = Keys::readTag(blist, "exchanged quantity");
 
   lwc_key_ = Keys::readKey(blist, domain_name, "liquid water content", "water_content");
@@ -123,7 +123,7 @@ PK_DomainFunctionFirstOrderExchange<FunctionBase>::Compute(double t0, double t1)
   std::vector<double> args(1 + dim);
   args[0] = t1;
 
-  // get the molar mixing ratio, water contents
+  // get the mole fraction, water contents
   S_->GetEvaluator(exchanged_key_, exchanged_tag_).Update(*S_, exchanged_key_+"_first_order_exchange");
   S_->GetEvaluator(lwc_key_, lwc_tag_).Update(*S_, lwc_key_+"_first_order_exchange");
   const auto& ex = *S_->Get<CompositeVector>(exchanged_key_, exchanged_tag_).ViewComponent("cell");

--- a/src/utils/VerboseObject.hh
+++ b/src/utils/VerboseObject.hh
@@ -15,12 +15,17 @@ and physics.
 .. _verbose-object-spec:
 .. admonition:: verbose-object-spec
 
-   * `"verbosity level`" ``[string]`` **GLOBAL_VERBOSITY**, `"low`",
-     `"medium`", `"high`", `"extreme`" The default is set by the global
-     verbosity spec, (fix me!)  Typically, `"low`" prints out minimal
-     information, `"medium`" prints out errors and overall high level
-     information, `"high`" prints out basic debugging, and `"extreme`" prints
-     out local debugging information.
+   * `"verbosity level`" ``[string]`` **optional** valid options are:
+
+     - `"none`"
+     - `"low`"
+     - `"medium`"
+     - `"high`"
+     - `"extreme`"
+
+     The default is set by the global verbosity spec, wich can be set on the
+     command line, and defaults to `"medium`".  See below for a list of what
+     each level produces.
 
    * `"write on rank`" ``[int]`` **0** VerboseObjects only write on a single
      rank -- by deafult the 0th rank.  However, sometimes it is useful for
@@ -31,6 +36,24 @@ and physics.
      specific file rather than writing to screen.  Note this will be done
      by-the-instance, so this may not catch as much as one might think.
 
+
+In general, the levels are as follows:
+
+   - `"none`" No log output at all
+   - `"low`" Basic flow control from the cycle driver including timing info of
+     each main step (mesh creation, setup, initialization, etc).  Each PK that
+     takes a step writes basic info for that step, including the size of the
+     step and the result of the step (success, fail, etc).
+   - `"medium`" In addition to the above, each PK that advances a step writes
+     basic error control information, e.g. nonlinear solver convergence
+     information.
+   - `"high`" In addition to the above, all PKs may write debug cells.
+     Evaluators write debug cell info.
+   - `"extreme`" Each subroutine of a PK writes some info for debugging.  Each
+     Update() writes info about the state of the dependency graph trace to
+     debug whether it is actually updated or not.
+
+     
 Example:
 
 .. code-block:: xml


### PR DESCRIPTION
adds

```
    std::vector<std::string> Mesh::getSpaceDimensionNames()
    Mesh::setSpaceDimensionNames(std::vector<std::string>)
```

By default, these get set to 'x', 'y', and (if 3D) 'z'.  The user may change them using the MeshFactory parameter list using the parameter `"space dimension names`" (e.g. for 2D x,z problems, or 1D problems).

Also changes molar_ratio to mole_fraction in a few places (cleanup) and adds more documentation to the verbosity level option description (docs).