### PR TITLE
updates Alquimia TPL to v1.2.0

### DIFF
--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -195,7 +195,7 @@
 #                - update HDF5 to 1.14.6
 #                - update netcdf-c to 4.9.2
 #                - update netcdf-fortran to 4.6.2
-#                - update Alquimia to version 1.1.1
+#                - update Alquimia to version 1.2.0 (supersedes earlier update to version 1.1.1)
 #                - update ExprTK to version 0.0.3
 
 
@@ -554,13 +554,13 @@ set(PFLOTRAN_MD5_SUM        d44b5670223ea9e6fbb894a8842161e0)
 # TPL: Alquimia
 #
 set(Alquimia_VERSION_MAJOR 1)
-set(Alquimia_VERSION_MINOR 1)
-set(Alquimia_VERSION_PATCH 1)
+set(Alquimia_VERSION_MINOR 2)
+set(Alquimia_VERSION_PATCH 0)
 set(Alquimia_VERSION ${Alquimia_VERSION_MAJOR}.${Alquimia_VERSION_MINOR}.${Alquimia_VERSION_PATCH})
 set(Alquimia_URL_STRING     https://github.com/LBL-EESA/alquimia-dev/archive/refs/tags)
 set(Alquimia_ARCHIVE_FILE   v${Alquimia_VERSION}.tar.gz)
 set(Alquimia_SAVEAS_FILE    alquimia-dev-${Alquimia_VERSION}.tar.gz)
-set(Alquimia_MD5_SUM        4e288e576777d43a907cdfef71427449)
+set(Alquimia_MD5_SUM        63b3b60a48643a863f7fdfd97a8b79c6)
 
 #
 # TPL: Silo

--- a/config/SuperBuild/TPLVersions.cmake
+++ b/config/SuperBuild/TPLVersions.cmake
@@ -195,8 +195,9 @@
 #                - update HDF5 to 1.14.6
 #                - update netcdf-c to 4.9.2
 #                - update netcdf-fortran to 4.6.2
-#                - update Alquimia to version 1.2.0 (supersedes earlier update to version 1.1.1)
+#                - update Alquimia to version 1.1.0
 #                - update ExprTK to version 0.0.3
+#   0.98.12      - update Alquimia to version 1.2.0
 
 
 include(CMakeParseArguments)
@@ -250,7 +251,7 @@ endmacro(amanzi_tpl_version_write)
 #
 set(AMANZI_TPLS_VERSION_MAJOR 0)
 set(AMANZI_TPLS_VERSION_MINOR 98)
-set(AMANZI_TPLS_VERSION_PATCH 11)
+set(AMANZI_TPLS_VERSION_PATCH 12)
 set(AMANZI_TPLS_VERSION ${AMANZI_TPLS_VERSION_MAJOR}.${AMANZI_TPLS_VERSION_MINOR}.${AMANZI_TPLS_VERSION_PATCH})
 # Not sure how to create a meaningful hash key for the collection
 


### PR DESCRIPTION
Alquimia v1.2.0 enables surface area update in the PFLOTRAN engine based on mineral volume fractions (example available in Alquimia repository batch chemistry benchmarks).
Supersedes Alquimia v1.1.1 (which was minor bug fixes) in this TPL release. 

Passes all 330 Amanzi reg tests on my machine (Ubuntu 22.04 LTS, gcc/12.2.0, openmpi/4.1.5, lapack/3.11.0)