### PR TITLE
[WIP] Create matrix of TPL images for broader CI testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -10,8 +10,28 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+            mpi_ver: "4.0.3"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+            mpi_ver: "4.3.1"
+            cmake_version: "4.1.2"
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+            cmake_version: "4.1.2"
     runs-on: ${{ matrix.os }}
     name: Build Docker container
     steps:
@@ -98,8 +118,28 @@ jobs:
 
   serial-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+            mpi_ver: "4.0.3"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+            mpi_ver: "4.3.1"
+            cmake_version: "4.1.2"
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+            cmake_version: "4.1.2"
     runs-on: ${{ matrix.os }}
     name: serial tests
     needs: build
@@ -120,11 +160,31 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL -LE REG --output-on-failure"
   parallel-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+            mpi_ver: "4.0.3"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+            mpi_ver: "4.3.1"
+            cmake_version: "4.1.2"
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+            cmake_version: "4.1.2"
     runs-on: ${{ matrix.os }}
     name: parallel tests
     needs: build
@@ -148,8 +208,28 @@ jobs:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL -LE REG --output-on-failure"
   regression-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+            mpi_ver: "4.0.3"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+            mpi_ver: "4.3.1"
+            cmake_version: "4.1.2"
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+            cmake_version: "4.1.2"
     runs-on: ${{ matrix.os }}
     name: regression tests
     needs: build
@@ -189,10 +269,25 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L REG --output-on-failure"
   fix-manifest:
     runs-on: ubuntu-latest
     needs: [parallel-tests, serial-tests, regression-tests]
+    strategy:
+      matrix:
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
     if: success()
     steps:
       - name: Check out the Amanzi repo

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -10,31 +10,8 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: Build Docker container
     steps:
@@ -121,31 +98,8 @@ jobs:
 
   serial-tests:
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: serial tests
     needs: build
@@ -166,34 +120,11 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL --output-on-failure"
   parallel-tests:
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: parallel tests
     needs: build
@@ -263,30 +194,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [parallel-tests, serial-tests, regression-tests]
     if: success()
-    strategy:
-      matrix:
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
     steps:
       - name: Check out the Amanzi repo
         uses: actions/checkout@v4
@@ -300,11 +207,11 @@ jobs:
           password: ${{secrets.DOCKERHUB_PASSWORD}}
       - name: Pull images
         run: |
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
       - name: Edit manifest
         run: |
-          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
-          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest
+          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
+          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -10,8 +10,31 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: Build Docker container
     steps:
@@ -70,11 +93,15 @@ jobs:
         context: .
         file: ./Docker/Dockerfile-Amanzi-build
         push: true
-        tags: metsi/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest
+        tags: ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest
         build-args: |
-          ARCH=linux/${{env.ARCH}}
           amanzi_branch=${{env.AMANZI_BRANCH}}
-          amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}  
+          amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
+          base_image=${{matrix.images.base_image}}
+          ver_tag=${{matrix.images.ver_tag}}
+          mpi_distro=${{matrix.images.mpi_distro}}
+          mpi_ver=${{matrix.images.mpi_ver}}
+          ARCH=linux/${{env.ARCH}} 
     - name: Build and push image - pull requests
       if: steps.pr_check.outputs.exist_pr_to_master == 'true'
       uses: docker/build-push-action@v6
@@ -82,16 +109,43 @@ jobs:
         context: .
         file: ./Docker/Dockerfile-Amanzi-build
         push: true
-        tags: metsi/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest
+        tags: ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest
         build-args: |
-          ARCH=linux/${{env.ARCH}}
           amanzi_branch=${{env.AMANZI_BRANCH}}
           amanzi_tpls_ver=${{env.AMANZI_TPLS_VER}}
-          additional_bootstrap_args=--enable-reg_tests
+          base_image=${{matrix.images.base_image}}
+          ver_tag=${{matrix.images.ver_tag}}
+          mpi_distro=${{matrix.images.mpi_distro}}
+          mpi_ver=${{matrix.images.mpi_ver}}
+          ARCH=linux/${{env.ARCH}}
+
   serial-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: serial tests
     needs: build
@@ -112,11 +166,34 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL -LE REG --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL --output-on-failure"
   parallel-tests:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
     runs-on: ${{ matrix.os }}
     name: parallel tests
     needs: build
@@ -181,11 +258,35 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L REG --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL --output-on-failure"
   fix-manifest:
     runs-on: ubuntu-latest
     needs: [parallel-tests, serial-tests, regression-tests]
     if: success()
+    strategy:
+      matrix:
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
     steps:
       - name: Check out the Amanzi repo
         uses: actions/checkout@v4
@@ -199,11 +300,11 @@ jobs:
           password: ${{secrets.DOCKERHUB_PASSWORD}}
       - name: Pull images
         run: |
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
       - name: Edit manifest
         run: |
-          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
-          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest
+          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
+          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest

--- a/.github/workflows/amanzi-ci.yml
+++ b/.github/workflows/amanzi-ci.yml
@@ -8,30 +8,14 @@ on:
       - amanzi-*
 
 jobs:
+  setup:
+    uses: ./.github/workflows/image-matrix.yml
+
   build:
+    needs: setup
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-            mpi_ver: "4.0.3"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-            mpi_ver: "4.3.1"
-            cmake_version: "4.1.2"
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-            cmake_version: "4.1.2"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: Build Docker container
     steps:
@@ -98,7 +82,7 @@ jobs:
           ver_tag=${{matrix.images.ver_tag}}
           mpi_distro=${{matrix.images.mpi_distro}}
           mpi_ver=${{matrix.images.mpi_ver}}
-          ARCH=linux/${{env.ARCH}} 
+          ARCH=linux/${{env.ARCH}}
     - name: Build and push image - pull requests
       if: steps.pr_check.outputs.exist_pr_to_master == 'true'
       uses: docker/build-push-action@v6
@@ -119,30 +103,10 @@ jobs:
   serial-tests:
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-            mpi_ver: "4.0.3"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-            mpi_ver: "4.3.1"
-            cmake_version: "4.1.2"
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-            cmake_version: "4.1.2"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: serial tests
-    needs: build
+    needs: [ setup, build ]
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
@@ -160,34 +124,14 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL -LE REG --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L SERIAL -LE REG --output-on-failure"
   parallel-tests:
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-            mpi_ver: "4.0.3"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-            mpi_ver: "4.3.1"
-            cmake_version: "4.1.2"
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-            cmake_version: "4.1.2"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: parallel tests
-    needs: build
+    needs: [ setup, build ]
     steps:
     - name: Check out the Amanzi repo
       uses: actions/checkout@v4
@@ -205,34 +149,14 @@ jobs:
       id: tests
       working-directory: Docker
       run:
-        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL -LE REG --output-on-failure"
+        docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L PARALLEL -LE REG --output-on-failure"
   regression-tests:
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-            mpi_ver: "4.0.3"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-            mpi_ver: "4.3.1"
-            cmake_version: "4.1.2"
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-            cmake_version: "4.1.2"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     name: regression tests
-    needs: build
+    needs: [ setup, build ]
     steps:
     - name: Check for open PR to master from this branch
       uses: actions/github-script@v7
@@ -272,22 +196,10 @@ jobs:
         docker run --rm ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}-latest /bin/bash -c "cd ~/amanzi_builddir/amanzi; ctest -L REG --output-on-failure"
   fix-manifest:
     runs-on: ubuntu-latest
-    needs: [parallel-tests, serial-tests, regression-tests]
+    needs: [setup, parallel-tests, serial-tests, regression-tests]
     strategy:
       matrix:
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
+        images: ${{ fromJSON(needs.setup.outputs.images) }}
     if: success()
     steps:
       - name: Check out the Amanzi repo
@@ -302,11 +214,11 @@ jobs:
           password: ${{secrets.DOCKERHUB_PASSWORD}}
       - name: Pull images
         run: |
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
       - name: Edit manifest
         run: |
-          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-arm64-latest \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-amd64-latest
-          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-latest
+          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64-latest \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64-latest
+          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi:${{env.AMANZI_BRANCH_TAG}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-latest

--- a/.github/workflows/build-tpls.yml
+++ b/.github/workflows/build-tpls.yml
@@ -22,32 +22,22 @@ jobs:
             mpi_ver: "4.0.3"
             target: tpls
           - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-            mpi_ver: "4.2.3"
-            target: tpls
-          - base_image: gcc
             ver_tag: latest
             mpi_distro: mpich
             mpi_ver: "4.3.1"
             target: tpls
-            cmake_version: "4.1.1"
+            cmake_version: "4.2.0"
           - base_image: ubuntu
             ver_tag: jammy
             mpi_distro: openmpi
             mpi_ver: "4.1.8"
             target: tpls
           - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: openmpi
-            mpi_ver: "5.0.5"
-            target: tpls
-          - base_image: gcc
             ver_tag: latest
             mpi_distro: openmpi
             mpi_ver: "5.0.8"
             target: tpls
-            cmake_version: "4.1.1"
+            cmake_version: "4.2.0"
     runs-on: ${{matrix.os}}
     steps:
     - name: Check out the Amanzi repo
@@ -105,16 +95,10 @@ jobs:
             ver_tag: jammy
             mpi_distro: mpich
           - base_image: gcc
-            ver_tag: "14"
-            mpi_distro: mpich
-          - base_image: gcc
             ver_tag: latest
             mpi_distro: mpich
           - base_image: ubuntu
             ver_tag: jammy
-            mpi_distro: openmpi
-          - base_image: gcc
-            ver_tag: "14"
             mpi_distro: openmpi
           - base_image: gcc
             ver_tag: latest

--- a/.github/workflows/build-tpls.yml
+++ b/.github/workflows/build-tpls.yml
@@ -26,7 +26,7 @@ jobs:
             mpi_distro: mpich
             mpi_ver: "4.3.1"
             target: tpls
-            cmake_version: "4.2.0"
+            cmake_version: "4.1.2"
           - base_image: ubuntu
             ver_tag: jammy
             mpi_distro: openmpi
@@ -37,7 +37,7 @@ jobs:
             mpi_distro: openmpi
             mpi_ver: "5.0.8"
             target: tpls
-            cmake_version: "4.2.0"
+            cmake_version: "4.1.2"
     runs-on: ${{matrix.os}}
     steps:
     - name: Check out the Amanzi repo

--- a/.github/workflows/build-tpls.yml
+++ b/.github/workflows/build-tpls.yml
@@ -12,8 +12,42 @@ on:
 jobs:
   build-tpl-image:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, ubuntu-24.04-arm ]
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+            mpi_ver: "4.0.3"
+            target: tpls
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+            mpi_ver: "4.2.3"
+            target: tpls
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+            mpi_ver: "4.3.1"
+            target: tpls
+            cmake_version: "4.0.1"
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+            mpi_ver: "4.1.8"
+            target: tpls
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+            mpi_ver: "5.0.5"
+            target: tpls
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
+            mpi_ver: "5.0.8"
+            target: tpls
+            cmake_version: "4.0.1"
     runs-on: ${{matrix.os}}
     steps:
     - name: Check out the Amanzi repo
@@ -50,13 +84,41 @@ jobs:
         context: .
         file: ./Docker/Dockerfile-TPLs
         push: true
-        tags: ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{env.ARCH}}-mpich-ubuntu-jammy
+        tags: ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-${{env.ARCH}}
         build-args: |
           amanzi_branch=${{env.AMANZI_BRANCH}}
-          mpi_flavor=mpich
+          base_image=${{matrix.images.base_image}}
+          ver_tag=${{matrix.images.ver_tag}}
+          mpi_flavor=${{matrix.images.mpi_distro}}
+          mpi_version=${{matrix.images.mpi_ver}}
+          trilinos_ver="15-1-0"
+          petsc_ver="3.21"
+          cmake_version=${{matrix.images.cmake_version}}
+        target: ${{matrix.images.target}}
 
   fix-manifest:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        images:
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: mpich
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: mpich
+          - base_image: ubuntu
+            ver_tag: jammy
+            mpi_distro: openmpi
+          - base_image: gcc
+            ver_tag: "14"
+            mpi_distro: openmpi
+          - base_image: gcc
+            ver_tag: latest
+            mpi_distro: openmpi
     needs: build-tpl-image
     if: success()
     steps:
@@ -74,11 +136,11 @@ jobs:
           password: ${{secrets.DOCKERHUB_PASSWORD}}
       - name: Pull images (remove with artifacts??)
         run: |
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-arm64-mpich-ubuntu-jammy
-          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-amd64-mpich-ubuntu-jammy
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64
+          docker pull ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64
       - name: Edit manifest
         run: |
-          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-mpich-ubuntu-jammy \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-amd64-mpich-ubuntu-jammy \
-            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-arm64-mpich-ubuntu-jammy
-          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-mpich-ubuntu-jammy
+          docker manifest create ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}} \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-amd64 \
+            --amend ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}-arm64
+          docker manifest push ${{secrets.DOCKERHUB_USERNAME}}/amanzi-tpls:${{env.AMANZI_TPLS_VER}}-${{matrix.images.mpi_distro}}-${{matrix.images.base_image}}-${{matrix.images.ver_tag}}

--- a/.github/workflows/build-tpls.yml
+++ b/.github/workflows/build-tpls.yml
@@ -31,7 +31,7 @@ jobs:
             mpi_distro: mpich
             mpi_ver: "4.3.1"
             target: tpls
-            cmake_version: "4.0.1"
+            cmake_version: "4.1.1"
           - base_image: ubuntu
             ver_tag: jammy
             mpi_distro: openmpi
@@ -47,7 +47,7 @@ jobs:
             mpi_distro: openmpi
             mpi_ver: "5.0.8"
             target: tpls
-            cmake_version: "4.0.1"
+            cmake_version: "4.1.1"
     runs-on: ${{matrix.os}}
     steps:
     - name: Check out the Amanzi repo

--- a/.github/workflows/build-tpls.yml
+++ b/.github/workflows/build-tpls.yml
@@ -6,38 +6,18 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - 'config/Superbuild/**'
+      - 'config/SuperBuild/**'
       - 'tools/**'
 
 jobs:
+  setup:
+    uses: ./.github/workflows/image-matrix.yml
+
   build-tpl-image:
+    needs: [setup]
     strategy:
       fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, ubuntu-24.04-arm ]
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-            mpi_ver: "4.0.3"
-            target: tpls
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-            mpi_ver: "4.3.1"
-            target: tpls
-            cmake_version: "4.1.2"
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-            mpi_ver: "4.1.8"
-            target: tpls
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-            mpi_ver: "5.0.8"
-            target: tpls
-            cmake_version: "4.1.2"
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
     runs-on: ${{matrix.os}}
     steps:
     - name: Check out the Amanzi repo
@@ -90,20 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        images:
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: mpich
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: mpich
-          - base_image: ubuntu
-            ver_tag: jammy
-            mpi_distro: openmpi
-          - base_image: gcc
-            ver_tag: latest
-            mpi_distro: openmpi
-    needs: build-tpl-image
+        images: ${{ fromJSON(needs.setup.outputs.images) }}
+    needs: [build-tpl-image, setup]
     if: success()
     steps:
       - name: Check out the Amanzi repo

--- a/.github/workflows/image-matrix.yml
+++ b/.github/workflows/image-matrix.yml
@@ -1,0 +1,161 @@
+# =============================================================================
+# image-matrix.yml
+#
+# SINGLE SOURCE OF TRUTH for the CI Docker image build matrix.
+#
+# This is a REUSABLE workflow (triggered via `workflow_call`). Other workflows
+# call it and consume its two JSON outputs:
+#
+#   * matrix  - a JSON object {"os":[...],"images":[...]} suitable for direct
+#               use as `strategy: matrix: ${{ fromJSON(needs.<job>.outputs.matrix) }}`.
+#               GitHub Actions expands it as the os x images cross product.
+#   * images  - a JSON ARRAY of just the 4 image objects (no os axis). Used by
+#               architecture-independent jobs (e.g. multi-arch manifest fixup).
+#
+# Each image object has EXACTLY these keys (consumers depend on the names):
+#   base_image, ver_tag, mpi_distro, mpi_ver, cmake_version, target
+# Use "" (empty string) where a field does not apply.
+#
+# The 4 image variants are defined ONCE, below, in the "Assemble matrix" step.
+# To add a 5th variant, add one more object to the `jq` array in that step.
+#
+# Variants 3 & 4 use "latest" tool versions that are resolved at RUN TIME from
+# the upstream GitHub releases APIs, each with a pinned fallback default.
+# =============================================================================
+name: Resolve image build matrix
+
+on:
+  workflow_call:
+    outputs:
+      matrix:
+        description: 'JSON object {"os":[...],"images":[...]} for use as a job strategy matrix.'
+        value: ${{ jobs.matrix.outputs.matrix }}
+      images:
+        description: "JSON array of the 4 image objects (no os axis)."
+        value: ${{ jobs.matrix.outputs.images }}
+
+jobs:
+  matrix:
+    runs-on: ubuntu-latest
+    # Map the job-level outputs to the outputs of the id'd step below.
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      images: ${{ steps.set.outputs.images }}
+    steps:
+      - name: Resolve latest tool versions
+        id: versions
+        # gh is pre-installed on ubuntu runners and authenticates via GITHUB_TOKEN.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+
+          # resolve <repo> <fallback-default>
+          #   Query the upstream "latest" release tag, strip a leading "v",
+          #   and fall back to the pinned default if the API errors or is empty.
+          resolve() {
+            local repo="$1" fallback="$2" tag=""
+            tag="$(gh api "repos/${repo}/releases/latest" --jq .tag_name 2>/dev/null || true)"
+            tag="${tag#v}"          # strip a leading "v" (e.g. v4.3.1 -> 4.3.1)
+            if [ -z "${tag}" ]; then
+              tag="${fallback}"
+            fi
+            echo "${tag}"
+          }
+
+          MPICH_VER="$(resolve pmodels/mpich 4.3.1)"
+          OPENMPI_VER="$(resolve open-mpi/ompi 5.0.8)"
+          CMAKE_VER="$(resolve Kitware/CMake 4.1.2)"
+
+          # Echo resolved versions so they are visible in the run log.
+          echo "Resolved latest mpich   version: ${MPICH_VER}"
+          echo "Resolved latest openmpi version: ${OPENMPI_VER}"
+          echo "Resolved latest cmake   version: ${CMAKE_VER}"
+
+          # Hand off to the assembly step via env.
+          {
+            echo "MPICH_VER=${MPICH_VER}"
+            echo "OPENMPI_VER=${OPENMPI_VER}"
+            echo "CMAKE_VER=${CMAKE_VER}"
+          } >> "$GITHUB_ENV"
+
+      - name: Assemble matrix
+        id: set
+        env:
+          # Consumed by the jq program below.
+          MPICH_VER: ${{ env.MPICH_VER }}
+          OPENMPI_VER: ${{ env.OPENMPI_VER }}
+          CMAKE_VER: ${{ env.CMAKE_VER }}
+        run: |
+          set -euo pipefail
+
+          # -------------------------------------------------------------------
+          # Define the 4 image variants HERE (single source of truth).
+          # Each object MUST carry all of: base_image, ver_tag, mpi_distro,
+          # mpi_ver, cmake_version, target. Use "" where not applicable.
+          #
+          #   1. ubuntu-bundled + mpich   (pinned, source-built)
+          #   2. ubuntu-bundled + openmpi (pinned, source-built)
+          #   3. latest gcc + mpich       (mpi_ver & cmake_version resolved)
+          #   4. latest gcc + openmpi     (mpi_ver & cmake_version resolved)
+          # -------------------------------------------------------------------
+          images="$(jq -c -n \
+            --arg mpich   "$MPICH_VER" \
+            --arg openmpi "$OPENMPI_VER" \
+            --arg cmake   "$CMAKE_VER" \
+            '[
+              {
+                base_image:    "ubuntu",
+                ver_tag:       "jammy",
+                mpi_distro:    "mpich",
+                mpi_ver:       "4.0.3",
+                cmake_version: "",
+                target:        "tpls"
+              },
+              {
+                base_image:    "ubuntu",
+                ver_tag:       "jammy",
+                mpi_distro:    "openmpi",
+                mpi_ver:       "4.1.8",
+                cmake_version: "",
+                target:        "tpls"
+              },
+              {
+                base_image:    "gcc",
+                ver_tag:       "latest",
+                mpi_distro:    "mpich",
+                mpi_ver:       $mpich,
+                cmake_version: $cmake,
+                target:        "tpls"
+              },
+              {
+                base_image:    "gcc",
+                ver_tag:       "latest",
+                mpi_distro:    "openmpi",
+                mpi_ver:       $openmpi,
+                cmake_version: $cmake,
+                target:        "tpls"
+              }
+            ]')"
+
+          # The runner OS axis for the cross-product matrix.
+          os='["ubuntu-latest","ubuntu-24.04-arm"]'
+
+          # matrix = {"os":[...],"images":[...]}
+          matrix="$(jq -c -n \
+            --argjson os "$os" \
+            --argjson images "$images" \
+            '{os: $os, images: $images}')"
+
+          echo "images JSON: ${images}"
+          echo "matrix JSON: ${matrix}"
+
+          # Emit both outputs as heredoc-delimited blocks (safe for JSON).
+          {
+            echo "images<<EOF"
+            echo "${images}"
+            echo "EOF"
+            echo "matrix<<EOF"
+            echo "${matrix}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"

--- a/Docker/Dockerfile-TPLs
+++ b/Docker/Dockerfile-TPLs
@@ -41,7 +41,6 @@ RUN apt-get -q update -y && apt-get install -y tzdata && \
   openssl \
   pkg-config \
   python3 \
-  python3-distutils \
   python3-pip \
   python-is-python3 \
   rsync \

--- a/Docker/deploy-tpls-docker.sh
+++ b/Docker/deploy-tpls-docker.sh
@@ -21,7 +21,10 @@ Help()
     echo "                      (Default: /ascem/amanzi/repos/amanzi-master)"
     echo "  --amanzi_tpls_ver   Which version of the Amanzi TPLs should we build? (Default is output of get_tpl_version.sh)"
     echo "  --stop_before_tpls  Useful for debugging - stops docker image build at base stage and doesn't build TPLs"
+<<<<<<< HEAD
     echo "  --build_type        Flag to specify opt, relwithdebinfo, or debug builds (Default: opt)"
+=======
+>>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
     echo "  --output_style      Should we use the condensed or plain version of Docker output (Default: condensed)"
     echo "  --multiarch         Build for both linux/amd64 and linux/arm64 instead of only local system architecture"
     echo "                      Assumes your already have Docker configured to build multiarchitecture images"
@@ -76,6 +79,17 @@ case $i in
     ;;
     --cmake_version=*)
     cmake_version="${i#*=}"
+<<<<<<< HEAD
+=======
+    shift
+    ;;
+    --petsc_ver=*)
+    petsc_ver="${i#*=}"
+    shift
+    ;;
+    --trilinos_ver=*)
+    trilinos_ver="${i#*=}"
+>>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
     shift
     ;;
     --amanzi_branch=*)
@@ -131,8 +145,13 @@ build_mpi="${build_mpi:-True}"
 mpi_distro="${mpi_distro:-mpich}"
 mpi_version="${mpi_version:-4.0.3}"
 cmake_version="${cmake_version:-}"
+<<<<<<< HEAD
 #petsc_ver="${petsc_ver:-3.21}"
 #trilinos_ver="${trilnos_ver:-15-1-0}"
+=======
+petsc_ver="${petsc_ver:-3.21}"
+trilinos_ver="${trilnos_ver:-15-1-0}"
+>>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
 amanzi_branch="${amanzi_branch:-master}"
 amanzi_src_dir="${amanzi_src_dir:-/ascem/amanzi/repos/amanzi-master}"
 amanzi_tpls_ver="${amanzi_tpls_ver:-`get_tpl_version`}"
@@ -182,7 +201,10 @@ then
         --build-arg base_image=${base_image} \
         --build-arg ver_tag=${ver_tag} \
         --build-arg cmake_version=${cmake_version} \
+<<<<<<< HEAD
         --build-arg build_type=${build_type} \
+=======
+>>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
         ${use_proxy} \
         ${output} \
         -f ${amanzi_src_dir}/Docker/Dockerfile-TPLs \
@@ -202,7 +224,10 @@ else
         --build-arg base_image=${base_image} \
         --build-arg ver_tag=${ver_tag} \
         --build-arg cmake_version=${cmake_version} \
+<<<<<<< HEAD
         --build-arg build_type=${build_type} \
+=======
+>>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
         ${use_proxy} \
         ${output} \
         -f ${amanzi_src_dir}/Docker/Dockerfile-TPLs \

--- a/Docker/deploy-tpls-docker.sh
+++ b/Docker/deploy-tpls-docker.sh
@@ -21,10 +21,7 @@ Help()
     echo "                      (Default: /ascem/amanzi/repos/amanzi-master)"
     echo "  --amanzi_tpls_ver   Which version of the Amanzi TPLs should we build? (Default is output of get_tpl_version.sh)"
     echo "  --stop_before_tpls  Useful for debugging - stops docker image build at base stage and doesn't build TPLs"
-<<<<<<< HEAD
     echo "  --build_type        Flag to specify opt, relwithdebinfo, or debug builds (Default: opt)"
-=======
->>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
     echo "  --output_style      Should we use the condensed or plain version of Docker output (Default: condensed)"
     echo "  --multiarch         Build for both linux/amd64 and linux/arm64 instead of only local system architecture"
     echo "                      Assumes your already have Docker configured to build multiarchitecture images"
@@ -79,8 +76,6 @@ case $i in
     ;;
     --cmake_version=*)
     cmake_version="${i#*=}"
-<<<<<<< HEAD
-=======
     shift
     ;;
     --petsc_ver=*)
@@ -89,7 +84,6 @@ case $i in
     ;;
     --trilinos_ver=*)
     trilinos_ver="${i#*=}"
->>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
     shift
     ;;
     --amanzi_branch=*)
@@ -145,13 +139,8 @@ build_mpi="${build_mpi:-True}"
 mpi_distro="${mpi_distro:-mpich}"
 mpi_version="${mpi_version:-4.0.3}"
 cmake_version="${cmake_version:-}"
-<<<<<<< HEAD
-#petsc_ver="${petsc_ver:-3.21}"
-#trilinos_ver="${trilnos_ver:-15-1-0}"
-=======
 petsc_ver="${petsc_ver:-3.21}"
-trilinos_ver="${trilnos_ver:-15-1-0}"
->>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
+trilinos_ver="${trilinos_ver:-15-1-0}"
 amanzi_branch="${amanzi_branch:-master}"
 amanzi_src_dir="${amanzi_src_dir:-/ascem/amanzi/repos/amanzi-master}"
 amanzi_tpls_ver="${amanzi_tpls_ver:-`get_tpl_version`}"
@@ -201,10 +190,7 @@ then
         --build-arg base_image=${base_image} \
         --build-arg ver_tag=${ver_tag} \
         --build-arg cmake_version=${cmake_version} \
-<<<<<<< HEAD
         --build-arg build_type=${build_type} \
-=======
->>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
         ${use_proxy} \
         ${output} \
         -f ${amanzi_src_dir}/Docker/Dockerfile-TPLs \
@@ -224,10 +210,7 @@ else
         --build-arg base_image=${base_image} \
         --build-arg ver_tag=${ver_tag} \
         --build-arg cmake_version=${cmake_version} \
-<<<<<<< HEAD
         --build-arg build_type=${build_type} \
-=======
->>>>>>> 7655d9251 (Update Amanzi CI to run across multiple OS, GCC, MPI, CMake)
         ${use_proxy} \
         ${output} \
         -f ${amanzi_src_dir}/Docker/Dockerfile-TPLs \


### PR DESCRIPTION
Adds a matrix of TPL images to test across:
- gcc 11, 14, 15
- 3 versions of mpich
- 3 versions of openmpi 
- 2 versions of cmake (CMAKE_MINIMUM_VERSION in Amanzi and latest release)

Let's merge #930 first and then apply this later on as surely there will be issues across this range of build systems/compilers/MPI.