### PR TITLE
Update Alquimia_PK.cc to convert temperatures from K to C

### DIFF
--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -762,7 +762,7 @@ Alquimia_PK::copyToAlquimia(int cell, AlquimiaBeaker& beaker)
   beaker.state.porosity = (*substate_.porosity)[0][cell];
 
   if (substate_.temperature) {
-    beaker.state.temperature = (*substate_.temperature)[0][cell];
+    beaker.state.temperature = (*substate_.temperature)[0][cell] - 273.15;
   }
 
   for (unsigned int i = 0; i != number_aqueous_components_; ++i) {

--- a/src/pks/chemistry/Alquimia_PK.cc
+++ b/src/pks/chemistry/Alquimia_PK.cc
@@ -34,6 +34,7 @@
 #include "exceptions.hh"
 #include "Mesh.hh"
 #include "PK_Helpers.hh"
+#include "Units.hh"
 
 // Chemistry
 #include "Alquimia_PK.hh"
@@ -762,7 +763,9 @@ Alquimia_PK::copyToAlquimia(int cell, AlquimiaBeaker& beaker)
   beaker.state.porosity = (*substate_.porosity)[0][cell];
 
   if (substate_.temperature) {
-    beaker.state.temperature = (*substate_.temperature)[0][cell] - 273.15;
+    static Utils::Units units;
+    bool flag;
+    beaker.state.temperature = units.ConvertTemperature((*substate_.temperature)[0][cell], "K", "C", flag);
   }
 
   for (unsigned int i = 0; i != number_aqueous_components_; ++i) {

--- a/src/utils/Units.cc
+++ b/src/utils/Units.cc
@@ -170,6 +170,35 @@ Units::ConvertConcentration(double val,
 
 
 /* ******************************************************************
+* Convert any input temperature to any output temperature.
+****************************************************************** */
+double
+Units::ConvertTemperature(double val,
+                          const std::string& in_unit,
+                          const std::string& out_unit,
+                          bool& flag)
+{
+  flag = true;
+  if (temperature_.find(in_unit) == temperature_.end() || temperature_.find(out_unit) == temperature_.end()) {
+    flag = false;
+    return val;
+  }
+
+  double tmp(val);
+
+  // Convert to Kelvin first
+  if (in_unit == "C") tmp += 273.15;
+  else if (in_unit == "F") tmp = (tmp + 459.67) * 5.0 / 9.0;
+
+  // Convert from Kelvin to the output unit
+  if (out_unit == "C") tmp -= 273.15;
+  else if (out_unit == "F") tmp = tmp * 1.8 - 459.67;
+
+  return tmp;
+}
+
+
+/* ******************************************************************
 * Convert any derived input unit to compatible output unit.
 * Special case, out_unit="SI", leads to conversion to SI units.
 ****************************************************************** */


### PR DESCRIPTION
Alquimia operates with temperature in units of C whereas Amanzi-ATS uses K, this conversion was not in the code causing incorrect temperatures to be used if temperature-sensitive reactions were turned on. Added this conversion in with a -273.15 in one line and tested with a regression test to ensure it ran ok.