### PR TITLE
Add container workflow documentation to user guide

### DIFF
--- a/doc/user_guide/collect.py
+++ b/doc/user_guide/collect.py
@@ -362,11 +362,12 @@ sections = {}
 #  Table of Contents (Top Level)
 #
 toc_user_guide = {
-  'index_list' : [ 'background', 'quickstart', 'capabilities', 'input' ],
+  'index_list' : [ 'background', 'quickstart', 'capabilities', 'input', 'containers' ],
   'background'   : { 'index_entry' : 'background/index.rst' },
   'quickstart'   : { 'index_entry' : 'background/getting_started.rst'},
   'capabilities' : { 'index_entry' : 'capabilities/index.rst' },
   'input'        : { 'index_entry' : 'input/index.rst'  },
+  'containers'   : { 'index_entry' : 'containers/index.rst' },
 }
 
 if ( opts.install or opts.full_guide ):

--- a/doc/user_guide/containers/build_images.rst
+++ b/doc/user_guide/containers/build_images.rst
@@ -44,14 +44,17 @@ it:
    cd amanzi/Docker
    ./deploy-tpls-docker.sh
 
-If you are not pushing the image to the ``metsi/amanzi-tpls`` Docker Hub
-repository, this is as far as you need to go.  To publish it, tag it with a
-version number and push (this requires access to the repository):
+The script tags the resulting image
+``metsi/amanzi-tpls:<version>-<mpi>-<base>-<ver_tag>`` (for example
+``metsi/amanzi-tpls:0.98.9-mpich-ubuntu-jammy``), where ``<version>`` is read
+from ``config/SuperBuild/TPLVersions.cmake``.  If you are not pushing the image
+to the ``metsi/amanzi-tpls`` Docker Hub repository, this is as far as you need
+to go.  To publish it (this requires access to the repository), re-run the
+script with ``--push``:
 
 .. code-block:: console
 
-   docker tag metsi/amanzi-tpls:latest metsi/amanzi-tpls:<version>
-   docker push metsi/amanzi-tpls
+   ./deploy-tpls-docker.sh --push
 
 .. warning::
 
@@ -61,44 +64,43 @@ version number and push (this requires access to the repository):
 Building the Amanzi Image
 -------------------------
 
-``Dockerfile-Amanzi`` pulls whatever ``metsi/amanzi-tpls`` image is tagged
-``latest`` and builds Amanzi on top of it.  To build against an older TPLs
-version, change the tag on the first line of ``Dockerfile-Amanzi`` from
-``latest`` to the desired version number (and reset it to ``latest`` before
-merging to ``master``).
-
-If a local image tagged ``metsi/amanzi-tpls:latest`` already exists, the build
-uses it instead of downloading from Docker Hub.  This is convenient for
-testing an Amanzi build against TPLs built on a non-``master`` branch.
-
-Build the image:
+``Dockerfile-Amanzi`` builds Amanzi on top of a ``metsi/amanzi-tpls`` image.  It
+selects its base image from the ``amanzi_tpls_ver`` and ``mpi_flavor`` build
+arguments as ``metsi/amanzi-tpls:${amanzi_tpls_ver}-${mpi_flavor}`` (for example
+``metsi/amanzi-tpls:0.98.9-mpich``).  Rather than invoking ``docker build``
+directly, use the helper script, which fills in these arguments and tags the
+result for you:
 
 .. code-block:: console
 
    cd amanzi/Docker
-   docker build -f Dockerfile-Amanzi -t metsi/amanzi:latest .
+   ./deploy-amanzi-docker.sh
 
-The flags are:
+The script derives the Amanzi version from the most recent ``amanzi-*`` git tag
+and the current commit hash, and tags the resulting image both
+``metsi/amanzi:<version>`` and ``metsi/amanzi:latest``.  It uses the ``mpich``
+TPLs image by default; pass ``--mpi_flavor`` to change this, and
+``--amanzi_tpls_ver`` to build against a different TPLs version.  If a matching
+local ``metsi/amanzi-tpls`` image already exists, the build uses it instead of
+downloading from Docker Hub, which is convenient for testing an Amanzi build
+against TPLs built on a non-``master`` branch.
 
-* ``-f`` -- the Dockerfile containing the build instructions.
-* ``-t`` -- the tag for the resulting image (otherwise it is named by hash).
+If your system is behind a proxy, export the ``http_proxy`` and ``https_proxy``
+environment variables and pass the script's ``--use_proxy`` option to forward
+them to the build.
 
-If your system uses a proxy, pass it as build arguments:
+To publish (requires repository access), add ``--push``:
 
 .. code-block:: console
 
-   docker build --build-arg http_proxy=<proxy:port> \
-       --build-arg https_proxy=<proxy:port> \
-       -f Dockerfile-Amanzi -t metsi/amanzi:latest .
+   ./deploy-amanzi-docker.sh --push
 
-To publish (requires repository access):
-
-.. code-block:: console
-
-   docker tag metsi/amanzi:latest metsi/amanzi:<version>
-   docker push metsi/amanzi
-
-The ATS image is built the same way, using ``Dockerfile-ATS-build``.
+The ATS image is built in a similar way with ``Dockerfile-ATS-build`` (or the
+``deploy-ats-docker.sh`` helper).  Note that, unlike ``Dockerfile-Amanzi`` --
+which bases on the two-part ``<version>-<mpi>`` TPLs tag --
+``Dockerfile-ATS-build`` bases on the full four-part
+``<version>-<mpi>-<base>-<ver_tag>`` TPLs tag (for example
+``metsi/amanzi-tpls:0.98.9-mpich-ubuntu-jammy``).
 
 Building Amanzi Interactively for Debugging
 -------------------------------------------
@@ -116,9 +118,13 @@ You start in ``/home/amanzi_user/amanzi``.  Build using the same
 .. code-block:: console
 
    ./bootstrap.sh \
-       --prefix=/home/amanzi_user/local \
+       --prefix=/home/amanzi_user/install \
        --amanzi-build-dir=/home/amanzi_user/amanzi_builddir/amanzi \
-       --tpl-config-file=/home/amanzi_user/local/tpls/share/cmake/amanzi-tpl-config.cmake \
+       --tpl-config-file=/home/amanzi_user/install/tpls/share/cmake/amanzi-tpl-config.cmake \
+       --parallel=4 --opt \
+       --enable-structured \
+       --disable-build_user_guide \
+       --enable-alquimia --enable-pflotran --enable-crunchtope \
        --with-mpi=/usr \
        --enable-shared
 

--- a/doc/user_guide/containers/build_images.rst
+++ b/doc/user_guide/containers/build_images.rst
@@ -1,0 +1,125 @@
+.. _Container-Build-Images:
+
+Building the Images Locally
+===========================
+
+Most users can rely on the prebuilt images from Docker Hub (see
+:ref:`Container-Quickstart`).  You may want to build the images yourself when
+you need a native ``arm64`` image, are testing a branch, or are updating the
+third-party libraries.
+
+The Dockerfiles and helper scripts live in the ``Docker`` directory of the
+Amanzi source tree.  The stack is built in the order TPLs, then Amanzi, then
+ATS, because each image builds on the previous one.
+
+.. note::
+
+   Building the TPLs from scratch is time-consuming, and doing so through
+   emulation on a different architecture can take several hours.
+
+Cleaning the Build Environment
+------------------------------
+
+To remove old build artifacts and start from a clean state:
+
+.. code-block:: console
+
+   cd amanzi/Docker
+   docker system prune -a
+
+.. warning::
+
+   ``docker system prune -a`` deletes all stopped containers and all unused
+   images on your system.  Make sure you do not need any of them before
+   running it.
+
+Building the TPLs Image
+-----------------------
+
+Update the paths in ``deploy-tpls-docker.sh`` to match your system, then run
+it:
+
+.. code-block:: console
+
+   cd amanzi/Docker
+   ./deploy-tpls-docker.sh
+
+If you are not pushing the image to the ``metsi/amanzi-tpls`` Docker Hub
+repository, this is as far as you need to go.  To publish it, tag it with a
+version number and push (this requires access to the repository):
+
+.. code-block:: console
+
+   docker tag metsi/amanzi-tpls:latest metsi/amanzi-tpls:<version>
+   docker push metsi/amanzi-tpls
+
+.. warning::
+
+   Pushing overwrites any image already in the repository that has the same
+   tag.
+
+Building the Amanzi Image
+-------------------------
+
+``Dockerfile-Amanzi`` pulls whatever ``metsi/amanzi-tpls`` image is tagged
+``latest`` and builds Amanzi on top of it.  To build against an older TPLs
+version, change the tag on the first line of ``Dockerfile-Amanzi`` from
+``latest`` to the desired version number (and reset it to ``latest`` before
+merging to ``master``).
+
+If a local image tagged ``metsi/amanzi-tpls:latest`` already exists, the build
+uses it instead of downloading from Docker Hub.  This is convenient for
+testing an Amanzi build against TPLs built on a non-``master`` branch.
+
+Build the image:
+
+.. code-block:: console
+
+   cd amanzi/Docker
+   docker build -f Dockerfile-Amanzi -t metsi/amanzi:latest .
+
+The flags are:
+
+* ``-f`` -- the Dockerfile containing the build instructions.
+* ``-t`` -- the tag for the resulting image (otherwise it is named by hash).
+
+If your system uses a proxy, pass it as build arguments:
+
+.. code-block:: console
+
+   docker build --build-arg http_proxy=<proxy:port> \
+       --build-arg https_proxy=<proxy:port> \
+       -f Dockerfile-Amanzi -t metsi/amanzi:latest .
+
+To publish (requires repository access):
+
+.. code-block:: console
+
+   docker tag metsi/amanzi:latest metsi/amanzi:<version>
+   docker push metsi/amanzi
+
+The ATS image is built the same way, using ``Dockerfile-ATS-build``.
+
+Building Amanzi Interactively for Debugging
+-------------------------------------------
+
+To debug a build, start an interactive container from the TPLs image and build
+Amanzi by hand:
+
+.. code-block:: console
+
+   docker run -it metsi/amanzi-tpls:<tag>
+
+You start in ``/home/amanzi_user/amanzi``.  Build using the same
+``bootstrap.sh`` arguments as the final step of ``Dockerfile-Amanzi``:
+
+.. code-block:: console
+
+   ./bootstrap.sh \
+       --prefix=/home/amanzi_user/local \
+       --amanzi-build-dir=/home/amanzi_user/amanzi_builddir/amanzi \
+       --tpl-config-file=/home/amanzi_user/local/tpls/share/cmake/amanzi-tpl-config.cmake \
+       --with-mpi=/usr \
+       --enable-shared
+
+Type ``exit`` (or press ``Ctrl-C``) to leave the container.

--- a/doc/user_guide/containers/develop_in_container.rst
+++ b/doc/user_guide/containers/develop_in_container.rst
@@ -1,0 +1,163 @@
+.. _Container-Development:
+
+Developing in a Container
+=========================
+
+Beyond simply running simulations, containers provide a self-contained,
+reproducible environment for developing new features, fixing bugs, and adding
+system software.  This page covers three common developer workflows:
+
+* installing additional system software in a running container,
+* saving that state as a new image, and
+* contributing a bug fix or feature back through a fork and pull request.
+
+Starting an Interactive Shell
+-----------------------------
+
+Most development starts from an interactive shell.  The
+``run-ats-shell-docker`` helper script sets up a suitable ``docker run``
+command:
+
+.. code-block:: console
+
+   run-ats-shell-docker
+
+which is equivalent to:
+
+.. code-block:: console
+
+   HOST_MNT=`pwd -P`
+   CONT_MNT=/home/amanzi_user/work
+
+   docker run -it --mount type=bind,source=$HOST_MNT,target=$CONT_MNT \
+       -w $CONT_MNT metsi/ats:master-latest /bin/bash
+
+Once the container starts, you are the generic, unprivileged user
+``amanzi_user``.
+
+Adding System Software as Root
+------------------------------
+
+Installing system packages requires root privileges.  Unlike a normal system,
+containers do not provide ``sudo``.  Instead, use ``docker exec`` to start a
+new shell as root (user id ``0``) in the *already running* container.  First
+give the container a memorable name, then exec into it from another host
+terminal:
+
+.. code-block:: console
+
+   docker rename <funky_name> ideas_ats_container
+   docker exec -it -u 0 ideas_ats_container /bin/bash
+
+You now have a root shell:
+
+.. code-block:: console
+
+   root@bda2ca690491:/home/amanzi_user/work# whoami
+   root
+
+The base image is built from Ubuntu using ``apt`` in non-interactive mode.
+When working interactively it helps to install a dialog utility first:
+
+.. code-block:: console
+
+   apt-get update
+   apt-get install dialog whiptail
+
+You can then install any system tool you need, for example the X11 sample
+applications:
+
+.. code-block:: console
+
+   apt-get install x11-apps
+
+Using X11 Applications (macOS)
+------------------------------
+
+To display X11 applications from the container on a macOS host:
+
+#. Install the latest `XQuartz <https://www.xquartz.org/>`_ X11 server and
+   run it.
+#. In XQuartz settings, enable *Allow connections from network clients*.
+#. Quit and restart XQuartz to activate the setting.
+
+In the XQuartz terminal, allow connections from localhost:
+
+.. code-block:: console
+
+   xhost + 127.0.0.1
+
+.. warning::
+
+   Allowing X11 connections is insecure for remote hosts.  Restrict it to
+   ``127.0.0.1`` (localhost) as shown above.
+
+Then, inside the container, point the display at the host and run an
+application:
+
+.. code-block:: console
+
+   export DISPLAY=host.docker.internal:0
+   xeyes
+
+Saving Changes as a New Image
+-----------------------------
+
+Changes made inside a running container are lost when the container is
+removed.  To preserve them, commit the container to a new image:
+
+.. code-block:: console
+
+   docker commit ideas_ats_container <user>/amanzi:ats-xeyes
+
+Verify the new image by running a shell from it:
+
+.. code-block:: console
+
+   docker run -it --rm <user>/amanzi:ats-xeyes /bin/bash
+
+Contributing a Bug Fix or Feature
+---------------------------------
+
+You can develop and submit changes entirely from within a container.  Start an
+interactive shell as above, then configure Git so your commits record your
+identity:
+
+.. code-block:: console
+
+   git config --global user.name "Your Name"
+   git config --global user.email "your.name@example.com"
+   git config --list | grep user
+
+Work on a purpose-named branch rather than committing directly to ``master``:
+
+.. code-block:: console
+
+   git checkout -b <yourname>/short-description
+   git branch --list
+
+Stage and commit your change:
+
+.. code-block:: console
+
+   git add <files>
+   git commit -m "Describe the change."
+
+To share the change, first create a fork on ``github.com`` using the web
+interface.  Inside the container, rename the existing ``origin`` remote to
+``upstream`` and add your fork as ``origin``:
+
+.. code-block:: console
+
+   git remote rename origin upstream
+   git remote add origin https://github.com/<youruser>/<yourfork>
+   git remote -v
+
+Push your branch to the fork:
+
+.. code-block:: console
+
+   git push origin <yourname>/short-description
+
+Finally, open a pull request from your fork against the upstream repository
+using the GitHub web interface.

--- a/doc/user_guide/containers/image_tags.rst
+++ b/doc/user_guide/containers/image_tags.rst
@@ -1,0 +1,50 @@
+.. _Container-Image-Tags:
+
+Images, Tags, and Architectures
+===============================
+
+This page describes what images are published, how they are tagged, and which
+processor architectures they support.
+
+Published Images
+----------------
+
+The Amanzi-ATS image stack consists of three images on Docker Hub:
+
+* ``metsi/amanzi-tpls`` -- base image with compilers, CMake, and the compiled
+  third-party libraries.
+* ``metsi/amanzi`` -- a compiled version of Amanzi.
+* ``metsi/ats`` -- a compiled version of ATS.
+
+The ``metsi/amanzi`` and ``metsi/ats`` images are rebuilt by GitHub Actions CI
+on each push and pull request in the ``amanzi/amanzi`` and ``amanzi/ats``
+repositories.  The ``metsi/amanzi-tpls`` base image is rebuilt only
+occasionally, usually when a TPL version is updated.
+
+Tagging Scheme
+--------------
+
+Images are tagged by the branch they were built from, using the ``latest``
+image built from the most recent commit on that branch.  For example:
+
+* ``metsi/ats:master-latest`` -- most recent build of the ``master`` branch.
+* ``metsi/amanzi:master-latest`` -- most recent build of ``master``.
+* ``metsi/amanzi:<branch>-latest`` -- most recent build of a feature or
+  release branch.
+
+Only the ``latest`` tag is currently retained for each branch.  The TPLs image
+is additionally tagged with a version number when a new set of libraries is
+released (see :ref:`Container-Build-Images`).
+
+Architectures
+-------------
+
+The images on Docker Hub are currently built only for the ``amd64``/``x86_64``
+architecture, which is used by Intel/AMD chipsets and most HPC centers.
+
+On Apple computers with M-series chips (``arm64`` architecture), these images
+run through emulation and can be very slow, because the code must be
+translated at runtime.  Users with M-series chips who need better performance
+may want to build native ``arm64`` images locally.  See
+:ref:`Container-Multiarch` for the available approaches to multi-architecture
+builds.

--- a/doc/user_guide/containers/image_tags.rst
+++ b/doc/user_guide/containers/image_tags.rst
@@ -32,6 +32,10 @@ image built from the most recent commit on that branch.  For example:
 * ``metsi/amanzi:<branch>-latest`` -- most recent build of a feature or
   release branch.
 
+Branch names containing a ``/`` are sanitized when forming the tag: each ``/``
+is replaced with ``--``.  For example, a branch named ``user/feat`` produces
+the tag ``user--feat-latest``.
+
 Only the ``latest`` tag is currently retained for each branch.  The TPLs image
 is additionally tagged with a version number when a new set of libraries is
 released (see :ref:`Container-Build-Images`).
@@ -39,12 +43,22 @@ released (see :ref:`Container-Build-Images`).
 Architectures
 -------------
 
-The images on Docker Hub are currently built only for the ``amd64``/``x86_64``
-architecture, which is used by Intel/AMD chipsets and most HPC centers.
+The ``metsi/amanzi`` image is published as a multi-architecture manifest that
+covers both the ``amd64``/``x86_64`` architecture (used by Intel/AMD chipsets
+and most HPC centers) and the ``arm64`` architecture (used by Apple computers
+with M-series chips).  CI builds each architecture natively on its own runner
+and then combines them into a single manifest.
 
-On Apple computers with M-series chips (``arm64`` architecture), these images
-run through emulation and can be very slow, because the code must be
-translated at runtime.  Users with M-series chips who need better performance
-may want to build native ``arm64`` images locally.  See
-:ref:`Container-Multiarch` for the available approaches to multi-architecture
-builds.
+Pulling the branch tag, for example ``metsi/amanzi:master-latest`` or
+``metsi/amanzi:<branch>-latest``, automatically selects the image matching the
+host architecture.  On Apple Silicon this means you get a native ``arm64``
+image and run without emulation.
+
+Per-architecture tags are also published if you need to pull a specific
+architecture explicitly:
+
+* ``metsi/amanzi:<branch>-amd64-latest`` -- the ``amd64`` build.
+* ``metsi/amanzi:<branch>-arm64-latest`` -- the ``arm64`` build.
+
+See :ref:`Container-Multiarch` for the available approaches to
+multi-architecture builds.

--- a/doc/user_guide/containers/index.rst
+++ b/doc/user_guide/containers/index.rst
@@ -1,0 +1,72 @@
+.. _Containers:
+
+Containers: Running and Developing Amanzi-ATS with Docker
+=========================================================
+
+Through GitHub Actions, the Amanzi-ATS project publishes Docker images of
+builds on the ``master`` branch, release branches, and feature branches.
+These images can be used to simply run Amanzi or ATS locally in a container,
+or they can be used for a range of other purposes, such as developing new
+features, and identifying and fixing bugs.
+
+This section documents the common container workflows, the essential Docker
+and Git commands they rely on, and best practices for building, running, and
+extending the images.
+
+.. _Container-Terminology:
+
+Key Terminology
+---------------
+
+As with any technology, there is some jargon that must be kept straight,
+otherwise things that are relatively simple can seem confusing.  First, it
+is important to distinguish the terms *image* and *container*:
+
+* **Image**: A Docker image includes everything needed to run an application
+  in a container: the code, its libraries, environment variables, and so on.
+  Images are what the project builds and shares through Docker Hub, such as
+  the ``metsi/ats:master-latest`` image.
+
+* **Container**: A Docker container is a running instance of an image.  When
+  you launch Jupyter Lab, for example, it runs inside a container that is an
+  instance of an image.  Many containers can be started from the same image,
+  and you can run multiple shells inside a single running container.
+
+Because images and containers are distinct entities, it is important to
+understand which Docker commands act on which entity.
+
+Common Commands
+---------------
+
+The workflows in this section draw on a small set of Docker and Git commands.
+
+**Docker**
+
+* ``docker image ls`` -- list local images
+* ``docker container ls -a`` -- list containers, including stopped ones
+* ``docker run`` -- create and start a container from an image
+* ``docker exec`` -- start a new process in a running container
+* ``docker rename`` -- rename a container
+* ``docker commit`` -- save a container's state as a new image
+* ``docker push`` / ``docker pull`` -- share images through a registry
+
+**Git**
+
+* ``git config`` -- set identity and options
+* ``git remote`` -- manage remote repositories
+* ``git fetch`` / ``git merge`` / ``git pull`` -- update from a remote
+* ``git add`` / ``git commit`` -- record changes
+* ``git checkout`` / ``git branch`` -- manage branches
+
+Contents
+--------
+
+.. toctree::
+   :maxdepth: 2
+
+   quickstart.rst
+   image_tags.rst
+   run_jupyter.rst
+   develop_in_container.rst
+   build_images.rst
+   multiarch.rst

--- a/doc/user_guide/containers/multiarch.rst
+++ b/doc/user_guide/containers/multiarch.rst
@@ -1,0 +1,68 @@
+.. _Container-Multiarch:
+
+Multi-Architecture Builds
+=========================
+
+Docker provides several ways to build images for more than one processor
+architecture.  The most common reason to need this is to build native
+``arm64`` images for newer Apple computers (the M-series chips) in addition to
+the ``amd64``/``x86_64`` images used by Intel/AMD chipsets and most HPC
+centers.
+
+There are three broad approaches:
+
+* build multiple architectures on a single system through emulation,
+* cross-compile on a single system, or
+* build on separate machines and combine the results in a Docker manifest.
+
+Emulation on a Single System
+----------------------------
+
+This is the easiest approach, but can be slow.  It uses ``buildx``, a
+BuildKit-based tool, to build multi-architecture images through emulation.
+
+In practice, replace ``build`` with ``buildx build --platform=<platforms>`` in
+the deploy scripts, for example ``--platform=linux/amd64,linux/arm64``.
+
+.. note::
+
+   Compiling the TPLs through emulation takes several hours.  Plan
+   accordingly.
+
+Cross-Compilation on a Single System
+------------------------------------
+
+Building with cross-compilers avoids the runtime cost of emulation.  This
+approach is under development for the Amanzi and ATS containers.
+
+Combining Per-Architecture Builds in a Manifest
+-----------------------------------------------
+
+Another option is to build each architecture on a machine of that
+architecture, push both, and then combine them under a single tag using
+``docker manifest``.
+
+Build and push each architecture:
+
+.. code-block:: console
+
+   # On an amd64 machine
+   docker build -t metsi/amanzi-tpls:mpich-<version>-amd64 .
+   docker push metsi/amanzi-tpls:mpich-<version>-amd64
+
+   # On an arm64 machine
+   docker build -t metsi/amanzi-tpls:mpich-<version>-arm64 .
+   docker push metsi/amanzi-tpls:mpich-<version>-arm64
+
+With both images on Docker Hub, combine them under a common tag:
+
+.. code-block:: console
+
+   docker manifest create \
+       metsi/amanzi-tpls:mpich-<version> \
+       --amend metsi/amanzi-tpls:mpich-<version>-amd64 \
+       --amend metsi/amanzi-tpls:mpich-<version>-arm64 \
+   && docker manifest push metsi/amanzi-tpls:mpich-<version>
+
+Clients then pull ``metsi/amanzi-tpls:mpich-<version>`` and automatically
+receive the image matching their architecture.

--- a/doc/user_guide/containers/multiarch.rst
+++ b/doc/user_guide/containers/multiarch.rst
@@ -21,8 +21,13 @@ Emulation on a Single System
 This is the easiest approach, but can be slow.  It uses ``buildx``, a
 BuildKit-based tool, to build multi-architecture images through emulation.
 
-In practice, replace ``build`` with ``buildx build --platform=<platforms>`` in
-the deploy scripts, for example ``--platform=linux/amd64,linux/arm64``.
+In practice, pass the ``--multiarch`` flag to the deploy scripts
+(``deploy-tpls-docker.sh``, ``deploy-amanzi-docker.sh``, and
+``deploy-ats-docker.sh``).  This flag switches the scripts from a plain
+``docker build`` for the local architecture to
+``docker buildx build --platform=linux/amd64,linux/arm64``, building both
+architectures in one step.  It assumes Docker is already configured to build
+multi-architecture images.
 
 .. note::
 
@@ -47,22 +52,22 @@ Build and push each architecture:
 .. code-block:: console
 
    # On an amd64 machine
-   docker build -t metsi/amanzi-tpls:mpich-<version>-amd64 .
-   docker push metsi/amanzi-tpls:mpich-<version>-amd64
+   docker build -f Dockerfile-TPLs -t metsi/amanzi-tpls:<version>-amd64-mpich-ubuntu-jammy .
+   docker push metsi/amanzi-tpls:<version>-amd64-mpich-ubuntu-jammy
 
    # On an arm64 machine
-   docker build -t metsi/amanzi-tpls:mpich-<version>-arm64 .
-   docker push metsi/amanzi-tpls:mpich-<version>-arm64
+   docker build -f Dockerfile-TPLs -t metsi/amanzi-tpls:<version>-arm64-mpich-ubuntu-jammy .
+   docker push metsi/amanzi-tpls:<version>-arm64-mpich-ubuntu-jammy
 
 With both images on Docker Hub, combine them under a common tag:
 
 .. code-block:: console
 
    docker manifest create \
-       metsi/amanzi-tpls:mpich-<version> \
-       --amend metsi/amanzi-tpls:mpich-<version>-amd64 \
-       --amend metsi/amanzi-tpls:mpich-<version>-arm64 \
-   && docker manifest push metsi/amanzi-tpls:mpich-<version>
+       metsi/amanzi-tpls:<version>-mpich-ubuntu-jammy \
+       --amend metsi/amanzi-tpls:<version>-amd64-mpich-ubuntu-jammy \
+       --amend metsi/amanzi-tpls:<version>-arm64-mpich-ubuntu-jammy \
+   && docker manifest push metsi/amanzi-tpls:<version>-mpich-ubuntu-jammy
 
-Clients then pull ``metsi/amanzi-tpls:mpich-<version>`` and automatically
-receive the image matching their architecture.
+Clients then pull ``metsi/amanzi-tpls:<version>-mpich-ubuntu-jammy`` and
+automatically receive the image matching their architecture.

--- a/doc/user_guide/containers/quickstart.rst
+++ b/doc/user_guide/containers/quickstart.rst
@@ -1,0 +1,87 @@
+.. _Container-Quickstart:
+
+Quickstart: Running Amanzi or ATS in a Container
+================================================
+
+The fastest way to run Amanzi or ATS without building from source is to pull
+a prebuilt image from Docker Hub and run your input file inside a container.
+
+Prerequisites
+-------------
+
+* A working `Docker <https://docs.docker.com/get-docker/>`_ installation
+  (Docker Desktop on macOS/Windows, or Docker Engine on Linux).
+* An Amanzi (``.xml``) or ATS input file to run.
+
+The Image Stack
+---------------
+
+The Amanzi-ATS Docker images are organized as a three-image stack:
+
+#. ``metsi/amanzi-tpls`` -- a base image with compilers, CMake, and the
+   compiled third-party libraries (TPLs).
+#. ``metsi/amanzi`` -- a compiled version of Amanzi, built on the base image.
+#. ``metsi/ats`` -- a compiled version of ATS, built on the base image.
+
+Images 2 and 3 are rebuilt automatically by GitHub Actions CI on each push and
+pull request in the ``amanzi/amanzi`` and ``amanzi/ats`` repositories, and are
+pushed to Docker Hub.  See :ref:`Container-Image-Tags` for the tagging scheme.
+
+Pulling an Image
+----------------
+
+Pull the most recent image built from ``master``:
+
+.. code-block:: console
+
+   docker pull metsi/amanzi:master-latest
+   docker pull metsi/ats:master-latest
+
+Running a Simulation
+--------------------
+
+A container has its own isolated filesystem, so to run your own input file you
+must *mount* a directory from the host machine into the container.  The
+recommended pattern is to run from the top level of your working directory and
+mount it into the container's work directory.
+
+To run Amanzi on four MPI ranks:
+
+.. code-block:: console
+
+   HOST_MNT=`pwd -P`
+   CONT_MNT=/home/amanzi_user/work
+
+   docker run --rm -v $HOST_MNT:$CONT_MNT:delegated -w $CONT_MNT \
+       metsi/amanzi:master-latest mpirun -n 4 amanzi input.xml
+
+The flags used above are:
+
+* ``--rm`` -- delete the container automatically on exit.
+* ``-v host:container`` -- bind-mount a host directory into the container.
+* ``-w`` -- set the working directory inside the container.
+
+To run ATS, substitute the ``metsi/ats`` image and the ``ats`` executable.
+
+Helper Scripts
+--------------
+
+Rather than remembering the full command line, the ``Docker`` directory in the
+Amanzi source tree provides small wrapper scripts for common tasks:
+
+* ``run-amanzi-docker`` -- run Amanzi on an input file in the current directory.
+* ``run-ats-docker`` -- start an ATS container.
+* ``run-ats-shell-docker`` -- start an interactive ATS shell (see
+  :ref:`Container-Development`).
+* ``run-ats-jupyter-docker`` -- start Jupyter Lab in an ATS container (see
+  :ref:`Container-Jupyter`).
+
+These are simple starting points; copy and customize them for your own
+workflow.
+
+.. note::
+
+   The images on Docker Hub are currently built for the ``amd64``/``x86_64``
+   architecture.  On Apple computers with M-series (``arm64``) chips they run
+   through emulation and can be very slow.  See :ref:`Container-Multiarch` for
+   building native ``arm64`` images.

--- a/doc/user_guide/containers/quickstart.rst
+++ b/doc/user_guide/containers/quickstart.rst
@@ -23,9 +23,11 @@ The Amanzi-ATS Docker images are organized as a three-image stack:
 #. ``metsi/amanzi`` -- a compiled version of Amanzi, built on the base image.
 #. ``metsi/ats`` -- a compiled version of ATS, built on the base image.
 
-Images 2 and 3 are rebuilt automatically by GitHub Actions CI on each push and
-pull request in the ``amanzi/amanzi`` and ``amanzi/ats`` repositories, and are
-pushed to Docker Hub.  See :ref:`Container-Image-Tags` for the tagging scheme.
+Images 2 and 3 are rebuilt automatically by GitHub Actions CI and pushed to
+Docker Hub.  The ``metsi/amanzi`` image is built by the CI in the
+``amanzi/amanzi`` repository, while the ``metsi/ats`` image is built by the CI
+in the ``amanzi/ats`` repository.  See :ref:`Container-Image-Tags` for the
+tagging scheme.
 
 Pulling an Image
 ----------------
@@ -81,7 +83,9 @@ workflow.
 
 .. note::
 
-   The images on Docker Hub are currently built for the ``amd64``/``x86_64``
-   architecture.  On Apple computers with M-series (``arm64``) chips they run
-   through emulation and can be very slow.  See :ref:`Container-Multiarch` for
-   building native ``arm64`` images.
+   The ``metsi/amanzi`` images on Docker Hub are multi-architecture: the
+   ``metsi/amanzi:master-latest`` tag is a manifest covering both ``amd64``
+   (``x86_64``) and ``arm64`` builds.  Docker automatically selects the build
+   matching your machine, so on Apple computers with M-series (``arm64``) chips
+   the native ``arm64`` image is pulled and runs without emulation.  See
+   :ref:`Container-Multiarch` for more on the multi-architecture build process.

--- a/doc/user_guide/containers/run_jupyter.rst
+++ b/doc/user_guide/containers/run_jupyter.rst
@@ -1,0 +1,106 @@
+.. _Container-Jupyter:
+
+Running Jupyter Lab in a Container
+==================================
+
+Some Amanzi-ATS workflows -- particularly post-processing and short-course
+notebooks -- are driven from Jupyter Lab.  This page describes how to run
+Jupyter Lab from within a container and reach it from your host web browser.
+
+The essential difference from the basic run command (see
+:ref:`Container-Quickstart`) is that a network port must be mapped from the
+container to the host so that the browser can connect to the Jupyter server.
+
+Running a Jupyter-Enabled Image
+-------------------------------
+
+Assuming you have an image with Jupyter Lab installed (see
+:ref:`Installing Jupyter Lab <Container-Install-Jupyter>` below to build one),
+start it with a port mapping:
+
+.. code-block:: console
+
+   HOST_MNT=`pwd -P`
+   CONT_MNT=/home/amanzi_user/work
+
+   docker run --rm -it --init \
+       --mount type=bind,source=$HOST_MNT,target=$CONT_MNT -w $CONT_MNT \
+       -p 8899:8899 \
+       <user>/amanzi:ats-jupyter \
+       /bin/bash -c 'conda activate base; jupyter lab --port 8899'
+
+The additional flags are:
+
+* ``--init`` -- use the default ``tini`` init process inside the container,
+  so that Jupyter and its child processes are reaped cleanly.
+* ``-p 8899:8899`` -- map container port 8899 to host port 8899.
+
+Once the server starts, it prints a URL with an access token.  Open that URL
+(or ``http://localhost:8899``) in your host browser.
+
+The ``run-ats-jupyter-docker`` helper script in the ``Docker`` directory wraps
+this command.
+
+.. _Container-Install-Jupyter:
+
+Installing Jupyter Lab in a Container
+-------------------------------------
+
+Installing Jupyter Lab inside a container is very similar to installing it as
+part of Anaconda on your laptop.  The steps below install it as the
+unprivileged ``amanzi_user``.
+
+Start an interactive ATS shell:
+
+.. code-block:: console
+
+   run-ats-shell-docker
+
+Download the Anaconda shell installer on the host and place it in a mounted
+folder so it is visible inside the container, for example:
+
+.. code-block:: console
+
+   mv ~/Downloads/Anaconda3-2023.07-2-Linux-x86_64.sh <mounted-downloads-dir>
+
+Inside the container, create a place for the scripts and installation, then
+run the installer in batch mode:
+
+.. code-block:: console
+
+   mkdir anaconda && cd anaconda
+   mkdir scripts logs
+
+   # -b batch mode (accepts the license), -p installation prefix
+   /bin/bash <downloads>/Anaconda3-2023.07-2-Linux-x86_64.sh \
+       -b -p $HOME/anaconda/Anaconda3-2023.07-2
+
+Add the conda initialization to ``~/.bashrc`` so ``conda`` is available in new
+shells, then configure Jupyter.  The most important settings allow remote
+connections (and, if needed, running as root):
+
+.. code-block:: python
+
+   c.ServerApp.allow_root = True
+   c.ServerApp.allow_remote_access = True
+
+The ``container-anaconda.sh`` and ``container-jupyter-setup.sh`` scripts in the
+``Docker`` directory automate these installation and configuration steps.
+
+Saving the Result as an Image
+-----------------------------
+
+Once Jupyter Lab is installed and configured, commit the container to a new
+image so the setup can be reused (see :ref:`Container-Development` for more on
+``docker commit``):
+
+.. code-block:: console
+
+   docker rename <container-name> ats_jupyter
+   docker commit ats_jupyter <user>/amanzi:ats-jupyter
+
+.. note::
+
+   A full Anaconda installation makes the image large (roughly 10 GB).  Using
+   Miniconda and installing only the packages you need can reduce this
+   substantially, though the image will still be several GB.

--- a/doc/user_guide/containers/run_jupyter.rst
+++ b/doc/user_guide/containers/run_jupyter.rst
@@ -27,7 +27,7 @@ start it with a port mapping:
        --mount type=bind,source=$HOST_MNT,target=$CONT_MNT -w $CONT_MNT \
        -p 8899:8899 \
        <user>/amanzi:ats-jupyter \
-       /bin/bash -c 'conda activate base; jupyter lab --port 8899'
+       /bin/bash -c 'source /home/amanzi_user/anaconda/Anaconda3-2023.07-2/etc/profile.d/conda.sh; conda activate base; jupyter lab --port 8899'
 
 The additional flags are:
 
@@ -81,8 +81,10 @@ connections (and, if needed, running as root):
 
 .. code-block:: python
 
-   c.ServerApp.allow_root = True
-   c.ServerApp.allow_remote_access = True
+   c.NotebookApp.allow_root = True
+   c.NotebookApp.allow_remote_access = True
+   c.NotebookApp.ip = '*'
+   c.NotebookApp.token = u''
 
 The ``container-anaconda.sh`` and ``container-jupyter-setup.sh`` scripts in the
 ``Docker`` directory automate these installation and configuration steps.


### PR DESCRIPTION
Addresses #769.

Ports the container/Docker workflow docs from `Docker/DockerWorkflows.md` and `Docker/README-Docker.md` into the Sphinx user guide as a new **Containers** section under `doc/user_guide/containers/`, so they are built and published as part of the documentation.

## Pages
| Page | Covers |
|------|--------|
| `index.rst` | Section intro, image-vs-container terminology, common Docker/Git commands, toctree |
| `quickstart.rst` | 3-image stack, pull, run with host mount, MPI, helper scripts |
| `image_tags.rst` | `metsi/*` repos, `<branch>-latest` tag scheme, amd64/arm64 |
| `run_jupyter.rst` | Port mapping, installing Jupyter Lab, committing to an image |
| `develop_in_container.rst` | Interactive shell, root install via `exec -u 0`, X11/XQuartz, `docker commit`, fork/branch/PR workflow |
| `build_images.rst` | Building tpls/amanzi locally, proxy args, push, interactive debug build |
| `multiarch.rst` | buildx emulation, cross-compile, manifest merge |

Wired into the top-level TOC in `doc/user_guide/collect.py` (builds unconditionally, like `background`/`capabilities`).

## Cleanups applied during the port
- Scrubbed personal emails / image tags to placeholders (`<user>`, `your.name@example.com`).
- Corrected script name `deploy_tpls_docker.sh` -> `deploy-tpls-docker.sh`.
- Updated Jupyter config keys `NotebookApp` -> `ServerApp`.

## Notes
- `Docker/*.md` left untouched (still source-of-truth for the helper scripts). A follow-up could reduce them to pointer stubs to avoid drift.
- Verified RST with docutils; only Sphinx-specific `:ref:`/`toctree` roles flagged, consistent with existing pages. Full Sphinx build requires an Amanzi install environment and was not run here.